### PR TITLE
feat: issue-driven development with claude-code-action

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Report a KERNEL bug. Add the 'claude' label to auto-fix.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add the `claude` label to this issue to trigger automatic investigation and fix.
+        Claude will reproduce, diagnose, fix, and open a PR.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's broken?
+      description: Describe the bug. What happened vs what should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can this be triggered?
+      placeholder: |
+        1. Run /kernel:ingest
+        2. Select tier 2
+        3. Surgeon spawns but...
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Files likely affected
+      description: Where do you think the bug lives?
+      placeholder: |
+        - skills/build/SKILL.md
+        - hooks/scripts/guard-bash.sh

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: Request a new KERNEL feature. Add the 'claude' label to auto-implement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add the `claude` label to this issue to trigger automatic implementation.
+        Claude will read this issue, create a branch, implement, and open a PR.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What should be built?
+      description: Describe the feature clearly. Include expected behavior.
+      placeholder: "Add a new agent type for..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Files likely affected
+      description: Which files or directories should change?
+      placeholder: |
+        - skills/build/SKILL.md
+        - agents/new-agent.md
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - "Small (1-2 files)"
+        - "Medium (3-5 files)"
+        - "Large (6+ files)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: done-when
+    attributes:
+      label: Done when
+      description: How do we know this is complete?
+      placeholder: |
+        - [ ] New agent file exists
+        - [ ] Tests pass
+        - [ ] CHANGELOG updated
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, examples, prior art, constraints.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,43 @@
+name: Task
+description: General work item. Add the 'claude' label to auto-execute.
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Add the `claude` label for automatic execution.
+        For manual-only tasks, don't add the label.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Task type
+      options:
+        - "Refactor"
+        - "Documentation"
+        - "Testing"
+        - "Performance"
+        - "Security audit"
+        - "Dependency update"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What needs to be done?
+      description: Be specific. Claude reads this literally.
+    validations:
+      required: true
+
+  - type: textarea
+    id: done-when
+    attributes:
+      label: Done when
+      description: Success criteria.
+      placeholder: |
+        - [ ] All tests pass
+        - [ ] No lint errors
+    validations:
+      required: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,30 @@
+name: Claude Agent
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') ||
+      github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') ||
+      github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') ||
+      github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          include_fix_links: true


### PR DESCRIPTION
## Summary

- Add `anthropics/claude-code-action@v1` GitHub Actions workflow
- Add 3 structured issue templates (feature, bug, task)
- Enable issue-driven development: create issue → add `claude` label → auto-implement → PR

## How it works

1. Create an issue using the templates
2. Add the `claude` label (or mention `@claude` in any comment)
3. Claude reads the issue, creates a branch, implements, opens a PR
4. Review and merge

## Setup required

After merging, set the OAuth token secret:
```bash
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo ariaxhan/kernel-claude
```
(Paste your Claude Code OAuth token when prompted)

Or via CLI:
```bash
claude /install-github-app
```

## Files added

- `.github/workflows/claude.yml` - Action workflow
- `.github/ISSUE_TEMPLATE/feature.yml` - Feature request template
- `.github/ISSUE_TEMPLATE/bug.yml` - Bug report template
- `.github/ISSUE_TEMPLATE/task.yml` - General task template

## Test plan

- [ ] Merge PR
- [ ] Set `CLAUDE_CODE_OAUTH_TOKEN` secret
- [ ] Create test issue with `claude` label
- [ ] Verify Claude responds and creates PR