### PR TITLE
fix: add id-token permission for OAuth OIDC

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,48 @@
+name: Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  review:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-review')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            CODE REVIEW — You are KERNEL's code reviewer. Be direct, specific, critical.
+
+            Review this PR with KERNEL's quality standards:
+
+            1. **Architecture**: Does this follow KERNEL's modular design?
+               - Skills are methodology, agents are actors — not mixed
+               - No circular dependencies between files
+               - Changes scoped to what the PR claims
+
+            2. **Big 5 Check** (from skills/quality/SKILL.md):
+               - Input validation: Are inputs checked at boundaries?
+               - Edge cases: null, empty, boundary conditions handled?
+               - Error handling: Failures caught and reported?
+               - Duplication: Any repeated logic that should be extracted?
+               - Complexity: Simpler approach possible?
+
+            3. **KERNEL-specific**:
+               - AgentDB integration correct?
+               - Tier routing accurate?
+               - Anti-patterns avoided? (check CLAUDE.md anti_patterns)
+               - Skills referenced where needed?
+
+            4. **Verdict**: APPROVE, REQUEST CHANGES, or COMMENT
+               - Threshold: >80% confidence to approve
+               - Every issue: file:line, description, suggested fix
+               - If requesting changes: be specific enough to auto-fix
+
+            Be the critical eye. Don't rubber-stamp. Challenge weak code.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   health-check:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,50 @@
+name: Maintenance
+on:
+  schedule:
+    # Daily 6am UTC — health check
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            DAILY MAINTENANCE — KERNEL health check.
+
+            1. VALIDATE structure:
+               - All agents/*.md have required sections (purpose, tools, spawn conditions)
+               - All skills/*/SKILL.md have frontmatter (name, description, triggers)
+               - All commands/*.md have required sections
+               - CLAUDE.md parses as valid XML within <kernel> tags
+
+            2. CHECK consistency:
+               - Every agent referenced in CLAUDE.md exists in agents/
+               - Every skill referenced in CLAUDE.md exists in skills/
+               - Every command referenced in CLAUDE.md exists in commands/
+               - No orphan files (defined but not referenced)
+
+            3. TEST AgentDB:
+               - Verify agent.db schema is current
+               - Check for stale contracts (>7 days old)
+               - Report any error patterns in recent failures
+
+            4. SCAN for issues:
+               - Any TODO/FIXME/HACK comments in non-test files?
+               - Any files modified >90 days ago that reference outdated patterns?
+
+            5. REPORT:
+               - If all healthy: no action needed, exit silently
+               - If issues found: create ONE issue titled "maintenance: [date] health check"
+                 with findings and suggested fixes
+               - Label: 'maintenance', 'claude' (auto-triggers fix)
+
+            Keep KERNEL clean. Don't create noise for passing checks.

--- a/.github/workflows/research-scout.yml
+++ b/.github/workflows/research-scout.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   research-sweep:

--- a/.github/workflows/research-scout.yml
+++ b/.github/workflows/research-scout.yml
@@ -1,0 +1,59 @@
+name: Research Scout
+on:
+  schedule:
+    # Wednesday and Saturday 2pm UTC — research sweeps
+    - cron: '0 14 * * 3,6'
+  workflow_dispatch:
+    inputs:
+      topic:
+        description: 'Specific research topic (leave empty for general sweep)'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  research-sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            RESEARCH SCOUT — Find improvements, patterns, and opportunities.
+
+            You are KERNEL's research agent. Think like a senior AI engineer who is
+            deeply curious about agent orchestration, memory systems, and developer tools.
+
+            ${{ github.event.inputs.topic && format('SPECIFIC TOPIC: {0}', github.event.inputs.topic) || 'GENERAL SWEEP' }}
+
+            1. READ current state:
+               - CLAUDE.md (core philosophy)
+               - skills/build/SKILL.md, skills/testing/SKILL.md
+               - agents/*.md (all agent definitions)
+               - _meta/research/ (prior work, don't repeat)
+
+            2. SEARCH for new developments:
+               - "Claude Code plugin best practices 2026"
+               - "agent memory persistence patterns"
+               - "multi-agent orchestration failures"
+               - "developer tool automation GitHub Actions"
+               - "AI code review accuracy improvements"
+
+            3. ANALYZE gaps:
+               - What do other top Claude Code plugins do that KERNEL doesn't?
+               - What patterns from CrewAI/LangGraph/Composio should we adopt?
+               - Any new Claude Code features we're not using?
+
+            4. CREATE issues for actionable findings (max 3):
+               - Use the Feature or Task template format
+               - Include: what to change, which files, why it matters
+               - Label: 'research', 'claude' (auto-triggers implementation)
+               - Be specific — these become work orders
+
+            5. If nothing actionable found, create no issues. Don't create noise.
+
+            PHILOSOPHY: We're building the best Claude Code plugin.
+            Every improvement should make KERNEL more autonomous and more correct.

--- a/.github/workflows/self-improve.yml
+++ b/.github/workflows/self-improve.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   learn-from-merge:

--- a/.github/workflows/self-improve.yml
+++ b/.github/workflows/self-improve.yml
@@ -1,0 +1,82 @@
+name: Self-Improvement Loop
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  schedule:
+    # Every Monday 9am UTC — weekly retrospective
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  learn-from-merge:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            A PR was just merged: #${{ github.event.pull_request.number }}
+            Title: ${{ github.event.pull_request.title }}
+
+            TASK: Extract learnings from this merge and improve KERNEL.
+
+            1. Read the PR diff and understand what changed
+            2. Check if any new patterns emerged that should be captured:
+               - New anti-patterns discovered → update skills/*/SKILL.md
+               - New conventions established → update rules/
+               - Workflow improvements → update commands/
+            3. If improvements found:
+               - Create a branch: learn/pr-${{ github.event.pull_request.number }}
+               - Make the updates (minimal, surgical)
+               - Open a PR with label 'self-improvement'
+            4. If nothing to learn, comment on the merged PR: "No new patterns to extract."
+
+            CONSTRAINTS:
+            - Only update if genuinely new insight (don't churn)
+            - Keep changes under 20 lines total
+            - Never modify CLAUDE.md directly (too high risk)
+            - Focus on skills/ and rules/ files
+
+  weekly-retrospective:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            WEEKLY RETROSPECTIVE — Autonomous improvement cycle.
+
+            1. Review all PRs merged in the last 7 days:
+               - What patterns repeat?
+               - What failed and was retried?
+               - What took multiple iterations?
+
+            2. Review open issues:
+               - Any stale (>14 days)? Comment asking if still relevant.
+               - Any that could be auto-closed? Label 'stale'.
+
+            3. Check KERNEL health:
+               - Read CLAUDE.md, skills/*, agents/*, rules/*
+               - Are there contradictions between files?
+               - Are any skills outdated based on recent merges?
+
+            4. Search for external improvements:
+               - WebSearch: "Claude Code best practices March 2026"
+               - WebSearch: "agent orchestration patterns 2026"
+               - Any new patterns worth adopting?
+
+            5. Create ONE issue titled "Weekly improvement: [date]" with:
+               - Summary of week's activity
+               - Identified improvements (max 3)
+               - Proposed changes with file paths
+               - Label: 'self-improvement', 'claude'
+
+            This issue will auto-trigger implementation via the claude workflow.
+            The system improves itself.


### PR DESCRIPTION
Fixes workflow auth failure. OAuth token exchange requires `id-token: write` permission for OIDC.