### PR TITLE
feat(v7.5.1): skill-first session hook + profile-gated git workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "7.5.0",
-  "description": "Persistent memory + multi-agent orchestration for Claude Code. AgentDB tracks failures and patterns. Tiered orchestration (surgeon, adversary, reviewer). 16 skills: TDD, security, E2E, API design, backend patterns. Pre-commit validation with secret detection.",
+  "version": "7.5.1",
+  "description": "Persistent memory, multi-agent orchestration, and project-aware context for Claude Code. AgentDB tracks failures, patterns, and telemetry across sessions. Profile detection auto-adapts to local, private, OSS, and production projects. 17 skills (TDD, security, debugging, API design, backend patterns). Tiered routing: surgeon, adversary, reviewer, dreamer agents. Circuit breakers, compaction recovery, secret detection.",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [7.5.1] - 2026-03-24
+
+### Changed
+- **Session-start rewrite** — Replaced 105-line static methodology block with skill-referencing decision tree. Session hook now points to skills instead of duplicating their content. Skills ARE the methodology; the hook is the routing protocol. (#59)
+- **Profile-gated git workflow** — Git skill and all 3 workflow files (feature, bugfix, refactor) now enforce PR requirements by profile: local (direct OK), github (PRs optional), github-oss (PRs required), github-production (PRs + review required). (#55)
+- **XML decision tree protocol** — Session-start outputs a structured `<decision_tree>` with 8 steps (READ → CLASSIFY → RESEARCH → SCOPE → DEFINE SUCCESS → EXECUTE → SHIP → LEARN), each referencing the specific skill to load.
+- **Skills index in session output** — Categorized as always/by_task/by_domain/commands/advanced so Claude aggressively loads relevant skills.
+
+---
+
 ## [7.5.0] - 2026-03-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<kernel version="7.5.0">
+<kernel version="7.5.1">
 
 <!-- ============================================ -->
 <!-- CONTEXT DELIVERY: READ THIS FIRST            -->

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -85,110 +85,70 @@ if [ -n "$HEALTH_WARNINGS" ]; then
 fi
 
 cat << 'KERNEL_CONTEXT'
-## AgentDB (MANDATORY)
+<protocol>
+  <agentdb>
+    on_start: agentdb read-start
+    on_end:   agentdb write-end '{"did":"X","learned":["Y"]}'
+    on_learn: agentdb learn failure|pattern|gotcha "what" "evidence"
+  </agentdb>
 
-```yaml
-on_start: agentdb read-start  # MUST do first
-on_end: agentdb write-end '{"did":"X","learned":["Y"]}'  # MUST do before stopping
-on_learn:
-  failure: agentdb learn failure "what" "evidence"
-  pattern: agentdb learn pattern "what" "evidence"
-  gotcha: agentdb learn gotcha "what" "context"
-```
+  <decision_tree>
+    1. READ context
+       → agentdb read-start
+       → ls _meta/research/ (check prior work)
 
-**AgentDB: read at start, write at end. Every session.**
+    2. CLASSIFY request
+       → bug?      load: /kernel:debug → /kernel:diagnose
+       → feature?  load: /kernel:build
+       → refactor? load: /kernel:refactor
+       → review?   load: /kernel:review
+       → unsure?   load: /kernel:build (default)
 
----
+    3. RESEARCH (before coding)
+       → check _meta/research/ for cached results
+       → anti-patterns FIRST: "{tech} gotchas", "{tech} not working"
+       → then solutions: official docs → github issues
+       → load: /kernel:security if auth/validation/secrets involved
 
-## Workflow
+    4. SCOPE
+       → count files that change
+       → tier 1 (1-2 files): execute directly
+       → tier 2 (3-5 files): contract + surgeon agent
+       → tier 3 (6+ files):  contract + surgeon + adversary
 
-```yaml
-flow: READ → CLASSIFY → RESEARCH → SCOPE → TESTS → EXECUTE → LEARN
+    5. DEFINE SUCCESS (before coding)
+       → load: /kernel:testing — tests BEFORE code
+       → load: /kernel:tdd if red-green-refactor appropriate
+       → edge cases first: null, empty, boundary, concurrent, timeout
 
-steps:
-  1_read:
-    do: agentdb read-start
-    then: ls _meta/research/  # check prior work
+    6. EXECUTE
+       → load: /kernel:quality — Big 5 checks on all code
+       → tier 1: implement directly
+       → tier 2+: spawn surgeon, orchestrate via /kernel:orchestration
 
-  2_classify:
-    task: what user wants
-    type: bug|feature|refactor|question
-    familiar: yes|no
+    7. SHIP
+       → load: /kernel:git — atomic commits, profile-gated workflow
+       → local: commit to main
+       → github-oss/production: feature branch → PR → review
 
-  3_research:
-    order:
-      - anti_patterns: "{tech} not working", "{tech} gotchas"
-      - solutions: official docs → github issues → stack overflow
-    output: _meta/research/{topic}.md
-    rule: search what BREAKS before what works
+    8. LEARN
+       → agentdb learn pattern|failure "what" "evidence"
+       → agentdb write-end
+       → update _meta/research/ if new findings
+  </decision_tree>
 
-  4_scope:
-    list: every file that changes
-    count: N
-    tier:
-      1: 1-2 files → execute directly
-      2: 3-5 files → contract + surgeon
-      3: 6+ files → contract + surgeon + adversary
+  <skills index="true">
+    always: /kernel:quality, /kernel:testing, /kernel:git
+    by_task: /kernel:build, /kernel:debug, /kernel:refactor, /kernel:security
+    by_domain: /kernel:api, /kernel:backend, /kernel:e2e, /kernel:tdd
+    commands: /kernel:dream, /kernel:diagnose, /kernel:tearitapart, /kernel:review
+    advanced: /kernel:orchestration, /kernel:architecture, /kernel:performance
+  </skills>
 
-  5_tests:
-    rule: tests BEFORE code
-    cycle: red (fail) → green (pass) → refactor
-    output: failing tests that define success
-
-  6_execute:
-    tier_1: implement using research + tests
-    tier_2+: create contract, spawn surgeon, orchestrate
-
-  7_learn:
-    do: agentdb learn pattern "what worked"
-    then: agentdb write-end
-    update: _meta/research/ if new anti-patterns found
-```
-
----
-
-## Testing (Non-Negotiable)
-
-```yaml
-rule: tests before code
-cycle:
-  1: write failing test (red)
-  2: write minimal code to pass (green)
-  3: refactor while green
-  4: repeat
-
-principles:
-  tests_first: code-then-tests validates bugs not requirements
-  mock_boundaries_only: external APIs, DBs — NOT internal functions
-  real_deps_preferred: test containers > mocks (mocks lie)
-  edge_cases_first: null, empty, boundary, concurrent, timeout
-  strong_assertions: specific values, not truthy/exists
-  graceful_fallbacks: test degraded mode, not just success/fail
-
-anti_patterns:  # AI generates these — avoid
-  - happy_path_only → test failure modes first
-  - weak_assertions → toBeTruthy catches nothing
-  - mock_everything → mock at boundaries only
-  - test_implementation → test behavior at public API
-```
-
----
-
-## Mindset
-
-```yaml
-core:
-  - every AI line is liability
-  - most SWE is solved problems
-  - research anti-patterns BEFORE solutions
-  - tests BEFORE code
-  - built-in > library > custom
-  - mock boundaries only, real deps when possible
-  - capture learnings AFTER every task
-
-mantra: find proven solution, test it works, don't reinvent
-```
-
+  <rule>Load the relevant skill BEFORE acting. Skills ARE the methodology.</rule>
+  <rule>Research anti-patterns BEFORE solutions. Tests BEFORE code.</rule>
+  <rule>Built-in beats library. Library beats custom. Prove you need complexity.</rule>
+</protocol>
 KERNEL_CONTEXT
 
 # =============================================================================

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -34,7 +34,11 @@ Skill-specific: skills/git/reference/git-research.md
 - fix/{name}: Bug fixes
 - refactor/{name}: Code restructuring
 
-Merge via PR when possible. Fast-forward for clean history.
+Profile-gated workflow:
+  local:            direct to main OK, branches optional
+  github:           feature branches for tier 2+, PRs optional
+  github-oss:       feature branches always, PRs REQUIRED before merge
+  github-production: feature branches always, PRs REQUIRED, review REQUIRED
 </branch_strategy>
 
 <commit_messages>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -488,9 +488,9 @@ test_session_start_workflow_present() {
 test_session_start_testing_philosophy() {
   local output
   output=$("$PLUGIN_ROOT/hooks/scripts/session-start.sh" 2>&1)
-  # Should contain testing philosophy
-  assert_contains "$output" "tests"
-  assert_contains "$output" "mock"
+  # Should reference testing skill in decision tree
+  assert_contains "$output" "/kernel:testing"
+  assert_contains "$output" "decision_tree"
 }
 
 test_pre_compact_writes_checkpoint() {

--- a/workflows/bugfix.md
+++ b/workflows/bugfix.md
@@ -39,9 +39,11 @@ tier: auto  # determined at classify step
    - checks: failing test now passes, all existing tests still green
    - on_reject: return to step 4 with feedback
 
-6. **Ship** -- Commit, push, PR
+6. **Ship** -- Commit, push, PR (profile-gated)
    - agent: orchestrator
-   - output: pushed branch, optional PR
+   - local/github: push to main or fix branch
+   - github-oss: push fix branch, create PR (required)
+   - github-production: push fix branch, create PR, request review (required)
 
 ## On Failure
 

--- a/workflows/feature.md
+++ b/workflows/feature.md
@@ -36,9 +36,11 @@ tier: auto  # determined at classify step
    - output: verdict to AgentDB
    - on_reject: return to step 4 with feedback
 
-6. **Ship** -- Commit, push, PR
+6. **Ship** -- Commit, push, PR (profile-gated)
    - agent: orchestrator
-   - output: pushed branch, optional PR
+   - local/github: push to main or feature branch
+   - github-oss: push feature branch, create PR (required)
+   - github-production: push feature branch, create PR, request review (required)
 
 ## On Failure
 

--- a/workflows/refactor.md
+++ b/workflows/refactor.md
@@ -39,9 +39,11 @@ tier: auto  # determined at classify step
    - check: test results identical to step 2 (same pass/fail, same count)
    - on_reject: return to step 4 with diff of what changed
 
-6. **Ship** -- Commit, push, PR
+6. **Ship** -- Commit, push, PR (profile-gated)
    - agent: orchestrator
-   - output: pushed branch, optional PR
+   - local/github: push to main or refactor branch
+   - github-oss: push refactor branch, create PR (required)
+   - github-production: push refactor branch, create PR, request review (required)
 
 ## On Failure
 


### PR DESCRIPTION
## Summary
- Session-start hook rewritten: 105-line static methodology block → XML decision tree that aggressively references skills
- Git workflow now profile-gated across skill + all 3 workflow files
- Plugin description updated to reflect v7.5.x feature set

## Changes

### Session-start hook (the big one)
Before: duplicated testing philosophy, workflow steps, and mindset inline (105 lines of static content that duplicated skills)
After: `<decision_tree>` with 8 steps, each pointing to the specific skill to load. `<skills>` index categorized by always/by_task/by_domain/commands/advanced.

**Why:** Plugin system does NOT load CLAUDE.md for plugin users. Session-start is the only ambient context injection. But skills ARE auto-discovered and loadable. So the hook should route TO skills, not copy FROM them.

### Profile-gated git workflow (#55)
- `skills/git/SKILL.md`: branch_strategy now shows per-profile rules
- `workflows/*.md`: Step 6 (Ship) enforces PRs for github-oss/production
- Session-start already outputs git workflow section for OSS/production profiles (from v7.5.0)

### Plugin description
Updated to mention: profile detection, 17 skills, dreamer agent, circuit breakers, compaction recovery, telemetry.

## Test plan
- [x] 127/127 tests passing
- [x] `session-start has workflow` test updated to check for decision_tree
- [x] `session-start has testing philosophy` test updated to check for /kernel:testing reference
- [ ] Manual: verify session-start output is readable and actionable

## Closes
- #55 (profile-gated git workflow)
- #59 (dead files — session-start now references skills instead of duplicating)