### PR TITLE
fix(hooks): update_current_symlink crashes with pipefail in plugin cache

### DIFF
--- a/hooks/scripts/common.sh
+++ b/hooks/scripts/common.sh
@@ -15,18 +15,22 @@ update_current_symlink() {
   [[ "$CACHE_DIR" == *"plugins/cache"* ]] || return 0
 
   # Find highest semver directory
+  # CACHE_DIR is 2 levels up from hooks/scripts/ — lands at the VERSION dir (e.g. 7.5.2/)
+  # We need the PARENT (e.g. kernel/) to find other versions
+  CACHE_DIR="$(dirname "$CACHE_DIR")"
+
   local LATEST
   LATEST=$(ls -d "$CACHE_DIR"/[0-9]*/ 2>/dev/null \
     | xargs -n1 basename 2>/dev/null \
     | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
     | sort -t. -k1,1n -k2,2n -k3,3n \
-    | tail -1)
+    | tail -1 || true)
 
   [ -z "$LATEST" ] && return 0
 
   # Check if current symlink needs updating
   local CURRENT_TARGET
-  CURRENT_TARGET=$(readlink "$CACHE_DIR/current" 2>/dev/null | xargs basename 2>/dev/null)
+  CURRENT_TARGET=$(readlink "$CACHE_DIR/current" 2>/dev/null | xargs basename 2>/dev/null || true)
 
   if [ "$CURRENT_TARGET" != "$LATEST" ]; then
     ln -sfn "$CACHE_DIR/$LATEST" "$CACHE_DIR/current" 2>/dev/null && \


### PR DESCRIPTION
## Summary
Session-start hook crashes silently when run from plugin cache with `set -eo pipefail`.

## Root Cause (two bugs)

**Bug 1:** `CACHE_DIR` resolves to the version directory (e.g. `kernel/7.5.2/`), not the parent (`kernel/`). When `ls -d "$CACHE_DIR"/[0-9]*/` runs inside `7.5.2/`, there are no version subdirectories — the pipeline fails, `pipefail` propagates the error, script exits.

**Bug 2:** `readlink "$CACHE_DIR/current"` exits 1 when the `current` symlink doesn't exist. With `pipefail`, this kills the script even though `2>/dev/null` suppresses stderr.

## Fix
1. `dirname` the CACHE_DIR to get the parent (kernel/) before scanning versions
2. `|| true` on the readlink pipeline to survive missing symlink

## Test plan
- [x] 127/127 tests passing
- [x] Manual: session-start runs cleanly from plugin cache (`~/.claude/plugins/cache/`)
- [x] Manual: auto-updates current symlink when missing
- [x] Manual: works in dev mode (non-cache path, early return)