### PR TITLE
fix(tests): update AgentDB assertion to match XML protocol

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -305,7 +305,7 @@ test_session_start_outputs_kernel() {
   local output
   output=$("$PLUGIN_ROOT/hooks/scripts/session-start.sh" 2>&1)
   assert_contains "$output" "# KERNEL"
-  assert_contains "$output" "AgentDB"
+  assert_contains "$output" "agentdb"
 }
 
 test_session_start_creates_agent_file() {


### PR DESCRIPTION
Test checked for 'AgentDB' but session-start now uses XML '<agentdb>' tag. Updated assertion to match.