### PR TITLE
fix: bump plugin.json to 7.5.4 — marketplace stuck on 7.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "7.5.1",
+  "version": "7.5.4",
   "description": "Persistent memory, multi-agent orchestration, and project-aware context for Claude Code. AgentDB tracks failures, patterns, and telemetry across sessions. Profile detection auto-adapts to local, private, OSS, and production projects. 17 skills (TDD, security, debugging, API design, backend patterns). Tiered routing: surgeon, adversary, reviewer, dreamer agents. Circuit breakers, compaction recovery, secret detection.",
   "author": {
     "name": "Aria Han",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<kernel version="7.5.1">
+<kernel version="7.5.4">
 
 <!-- ============================================ -->
 <!-- CONTEXT DELIVERY: READ THIS FIRST            -->


### PR DESCRIPTION
Hotfixes 7.5.2-7.5.4 changed code but never bumped plugin.json. Marketplace saw 7.5.1 as latest. Users couldn't get the fixes.