### PR TITLE
fix(plugin): register hooks in plugin.json — hooks never loaded on fresh sessions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -31,5 +31,6 @@
     "./commands/help.md",
     "./commands/dream.md",
     "./commands/diagnose.md"
-  ]
+  ],
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Problem
Plugin hooks (SessionStart, PreToolUse, etc.) never fired on fresh sessions. Commands and skills worked fine.

## Root Cause
`plugin.json` had `commands` array but no `hooks` field. `hooks/hooks.json` existed but was never referenced in the manifest.

AgentDB learning: "hooks.json vs hook scripts confusion" — we've hit hook discovery issues before (v7.0.1-v7.0.4).

## Fix
Added `"hooks": "./hooks/hooks.json"` to plugin.json.

## Test
Start fresh Claude Code session → verify "# KERNEL" + decision tree appear.