### PR TITLE
fix: remove duplicate hooks declaration from plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Persistent memory, multi-agent orchestration, and project-aware context for Claude Code. AgentDB tracks failures, patterns, and telemetry across sessions. Profile detection auto-adapts to local, private, OSS, and production projects. 17 skills (TDD, security, debugging, API design, backend patterns). Tiered routing: surgeon, adversary, reviewer, dreamer agents. Circuit breakers, compaction recovery, secret detection.",
-      "version": "7.5.5"
+      "version": "7.5.6"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "description": "Persistent memory, multi-agent orchestration, and project-aware context for Claude Code. AgentDB tracks failures, patterns, and telemetry across sessions. Profile detection auto-adapts to local, private, OSS, and production projects. 17 skills (TDD, security, debugging, API design, backend patterns). Tiered routing: surgeon, adversary, reviewer, dreamer agents. Circuit breakers, compaction recovery, secret detection.",
   "author": {
     "name": "Aria Han",
@@ -31,6 +31,5 @@
     "./commands/help.md",
     "./commands/dream.md",
     "./commands/diagnose.md"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<kernel version="7.5.5">
+<kernel version="7.5.6">
 
 <!-- ============================================ -->
 <!-- CONTEXT DELIVERY: READ THIS FIRST            -->


### PR DESCRIPTION
hooks/hooks.json is auto-discovered by Claude Code. Adding it to plugin.json caused a duplicate load error. Reverted.