### PR TITLE
feat(v7.7.0): GitHub as unified agent-human interface — Issues + Discussions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,15 @@ Use Grep only when: LSP unavailable, searching string literals, or pattern match
 Setup: _meta/reference/lsp-setup.md
 </lsp>
 
-<!-- ERROR RECOVERY: See rules/kernel.md -->
+<github_layer>
+GitHub is a supplementary visibility layer. AgentDB is ALWAYS the source of truth for ALL profiles.
+Non-local profiles (github, github-oss, github-production) get additive GitHub features:
+- Issues: tier 2+ contracts surface as GitHub Issues with agent/tier labels
+- Discussions: session summaries → Agent Logs, learnings → Learnings, decisions → Decisions
+- Agents post checkpoints and verdicts as issue comments
+Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-and-forget.
+<rule>AgentDB first. GitHub after. Never block on GitHub API failures.</rule>
+</github_layer>
 
 <!-- ============================================ -->
 <!-- GIT                                          -->

--- a/agents/adversary.md
+++ b/agents/adversary.md
@@ -73,6 +73,7 @@ Partial = FAIL.
 
 <verdict>
 agentdb verdict pass|fail '{"tested":[...],"evidence":"<actual_output>","big5":"pass|fail"}'
+Surface to GitHub: if github-oss/production profile and issue exists, post verdict as issue comment with PASS/FAIL badge.
 </verdict>
 
 <anti_patterns>

--- a/agents/surgeon.md
+++ b/agents/surgeon.md
@@ -61,6 +61,7 @@ In worktree: commit to worktree branch. Orchestrator handles merge to main.
 
 <phase id="checkpoint">
 Write to AgentDB: files, commit hash, evidence, big5 status.
+Surface to GitHub: if github-oss/production profile, post checkpoint as issue comment via _gh_comment_issue.
 </phase>
 </protocol>
 
@@ -82,6 +83,7 @@ Write to AgentDB: files, commit hash, evidence, big5 status.
 
 <on_end>
 agentdb write-end '{"agent":"surgeon","contract":"ID","files":[...],"commits":[...],"big5":"pass"}'
+Surface to GitHub: if github-oss/production profile and issue exists, post completion summary as issue comment and close issue.
 </on_end>
 
 <checklist>

--- a/commands/forge.md
+++ b/commands/forge.md
@@ -61,6 +61,7 @@ Load ALL always-skills immediately. Load task/domain skills after classify.
 
     ```bash
     agentdb emit command "forge-heat" "" '{"approaches":N,"tier":N}'
+    # If non-local profile: create tracking issue via _gh_create_issue
     ```
   </phase>
 
@@ -144,6 +145,7 @@ Load ALL always-skills immediately. Load task/domain skills after classify.
     agentdb learn pattern "what worked" "approach X, integrity Y"
     agentdb emit command "forge-ship" "" '{"iterations":N,"integrity":0.X,"approach":"X"}'
     agentdb write-end '{"command":"forge","iterations":N,"tests":N,"integrity":0.X,"shipped":true}'
+    # If non-local profile: close tracking issue with completion summary
     # Suggest /kernel:retrospective if learnings accumulated across forge cycles
     ```
   </phase>

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -118,6 +118,7 @@ Generated: {timestamp}
 <on_complete>
 ```bash
 agentdb write-end '{"command":"handoff","saved_to":"path","branch":"X","tier":N}'
+# If non-local profile: post handoff to GitHub Discussions (Agent Logs category)
 # Suggest /kernel:retrospective if learnings accumulated across sessions
 ```
 </on_complete>

--- a/commands/ingest.md
+++ b/commands/ingest.md
@@ -142,6 +142,7 @@ If none match, execute below.
 rule: you do NOT write code
 1. /kernel:tearitapart — review plan before implementation
 2. agentdb contract '{"goal":"X","files":["Y"],"tier":N}'
+2b. If non-local profile: _gh_create_issue with contract goal + tier label
 3. git checkout -b {type}/{name}
 4. Spawn surgeon
 5. Wait for checkpoint

--- a/commands/retrospective.md
+++ b/commands/retrospective.md
@@ -34,6 +34,7 @@ resolves contradictions, merges duplicates, archives stale entries, promotes hig
    - Merge duplicates: `agentdb learn {type} "{merged}" "{combined evidence}"`
    - Archive stale: `agentdb query "DELETE FROM learnings WHERE id = {id}"`
    - Promote patterns: Recommend additions to CLAUDE.md or skill reference docs
+   - If non-local profile: surface promoted patterns to GitHub Discussions (Learnings category)
 
 5. Write synthesis to AgentDB:
    ```bash

--- a/hooks/scripts/github-integration.sh
+++ b/hooks/scripts/github-integration.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+set -eo pipefail
+# KERNEL: GitHub integration library (sourced, not executed directly)
+# Provides functions for Issues, Discussions, and labels.
+# Profile-gated: local profiles get NO GitHub operations.
+# AgentDB always runs; GitHub is additive visibility.
+
+# Load shared functions
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+# === Cached state (populated on first use) ===
+_GH_REPO=""
+_GH_REPO_ID=""
+_GH_LABELS_ENSURED=""
+
+# Discussion category IDs (resolved dynamically, cached after first lookup)
+_GH_CAT_AGENT_LOGS=""
+_GH_CAT_DECISIONS=""
+_GH_CAT_LEARNINGS=""
+_GH_CATS_RESOLVED=""
+
+# === Internal helpers ===
+
+# Derive owner/repo from git remote (cached after first call)
+_gh_repo() {
+  if [[ -n "$_GH_REPO" ]]; then
+    echo "$_GH_REPO"
+    return
+  fi
+  local remote
+  remote=$(git remote get-url origin 2>/dev/null) || return 1
+  local repo
+  repo=$(parse_github_remote "$remote")
+  [[ -z "${repo:-}" ]] && return 1
+  _GH_REPO="$repo"
+  echo "$_GH_REPO"
+}
+
+# Get repo node ID (cached, needed for GraphQL mutations)
+_gh_repo_id() {
+  if [[ -n "$_GH_REPO_ID" ]]; then
+    echo "$_GH_REPO_ID"
+    return
+  fi
+  local repo
+  repo=$(_gh_repo) || return 1
+  _GH_REPO_ID=$(gh api "repos/${repo}" --jq '.node_id' --cache 3600s 2>/dev/null) || return 1
+  echo "$_GH_REPO_ID"
+}
+
+# === Core gate ===
+
+# Returns 0 if gh CLI installed, authenticated, and profile is NOT local.
+# All public functions call this first; return silently (0) if false.
+_gh_available() {
+  command -v gh >/dev/null 2>&1 || return 1
+  gh auth status >/dev/null 2>&1 || return 1
+  local profile
+  profile=$(_gh_get_profile)
+  [[ "$profile" == "local" ]] && return 1
+  return 0
+}
+
+# Read cached profile. Does NOT call detect_profile (expensive).
+# Falls back to "local" if no cache found.
+_gh_get_profile() {
+  local cache_dir="$HOME/.cache/kernel"
+  if [[ -d "$cache_dir" ]]; then
+    local latest
+    latest=$(ls -t "$cache_dir"/profile-* 2>/dev/null | head -1)
+    if [[ -n "${latest:-}" ]] && [[ -f "$latest" ]]; then
+      cat "$latest"
+      return
+    fi
+  fi
+  echo "local"
+}
+
+# === Label management ===
+
+# Creates agent/tier labels if they don't exist. Idempotent. Once per session.
+_gh_ensure_labels() {
+  _gh_available || return 0
+  [[ -n "$_GH_LABELS_ENSURED" ]] && return 0
+
+  local repo
+  repo=$(_gh_repo) || return 0
+
+  local labels=(
+    "agent-contract:#1d76db"
+    "tier-1:#0e8a16"
+    "tier-2:#fbca04"
+    "tier-3:#d93f0b"
+    "agent:surgeon:#6f42c1"
+    "agent:adversary:#b60205"
+    "agent:researcher:#0075ca"
+    "agent:dreamer:#e4e669"
+  )
+
+  # Fetch existing labels once
+  local existing
+  existing=$(gh api "repos/${repo}/labels" --paginate --jq '.[].name' --cache 300s 2>/dev/null) || existing=""
+
+  for entry in "${labels[@]}"; do
+    local name="${entry%%:*}"
+    local color="${entry#*:}"
+    color="${color#\#}"  # strip leading #
+
+    if ! echo "$existing" | grep -qxF "$name"; then
+      gh api "repos/${repo}/labels" \
+        -f name="$name" \
+        -f color="$color" \
+        -f description="KERNEL auto-managed" \
+        2>/dev/null || true
+    fi
+  done
+
+  _GH_LABELS_ENSURED="1"
+  return 0
+}
+
+# === Issues ===
+
+# Create a GitHub Issue. Returns issue number on stdout.
+# Args: title body labels(comma-separated)
+_gh_create_issue() {
+  _gh_available || return 0
+  local title="${1:-}" body="${2:-}" labels="${3:-}"
+  [[ -z "$title" ]] && return 0
+
+  local repo
+  repo=$(_gh_repo) || return 0
+
+  local args=("issue" "create" "-R" "$repo" "--title" "$title" "--body" "${body:-}")
+  [[ -n "$labels" ]] && args+=("--label" "$labels")
+
+  local url
+  url=$(gh "${args[@]}" 2>/dev/null) || return 0
+  # Extract issue number from URL
+  echo "$url" | grep -oE '[0-9]+$'
+  return 0
+}
+
+# Add comment to existing issue.
+# Args: issue_number body
+_gh_comment_issue() {
+  _gh_available || return 0
+  local issue="${1:-}" body="${2:-}"
+  [[ -z "$issue" || -z "$body" ]] && return 0
+
+  local repo
+  repo=$(_gh_repo) || return 0
+
+  gh issue comment "$issue" -R "$repo" --body "$body" 2>/dev/null || true
+  return 0
+}
+
+# Close issue with final comment.
+# Args: issue_number comment
+_gh_close_issue() {
+  _gh_available || return 0
+  local issue="${1:-}" comment="${2:-}"
+  [[ -z "$issue" ]] && return 0
+
+  local repo
+  repo=$(_gh_repo) || return 0
+
+  [[ -n "$comment" ]] && gh issue comment "$issue" -R "$repo" --body "$comment" 2>/dev/null || true
+  gh issue close "$issue" -R "$repo" 2>/dev/null || true
+  return 0
+}
+
+# === Discussion category resolution ===
+
+# Resolve discussion category IDs from repo (cached after first call)
+_gh_resolve_categories() {
+  [[ -n "$_GH_CATS_RESOLVED" ]] && return 0
+  local repo
+  repo=$(_gh_repo) || return 1
+  local owner="${repo%%/*}" name="${repo##*/}"
+
+  local cats_json
+  cats_json=$(gh api graphql -f query='
+    query($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        discussionCategories(first: 20) { nodes { id name } }
+      }
+    }' -f owner="$owner" -f name="$name" \
+    --jq '.data.repository.discussionCategories.nodes' \
+    --cache 3600s 2>/dev/null) || return 1
+
+  _GH_CAT_AGENT_LOGS=$(echo "$cats_json" | jq -r '.[] | select(.name == "Agent Logs") | .id' 2>/dev/null)
+  _GH_CAT_DECISIONS=$(echo "$cats_json" | jq -r '.[] | select(.name == "Decisions") | .id' 2>/dev/null)
+  _GH_CAT_LEARNINGS=$(echo "$cats_json" | jq -r '.[] | select(.name == "Learnings") | .id' 2>/dev/null)
+  _GH_CATS_RESOLVED="1"
+  return 0
+}
+
+# === Discussions (GraphQL) ===
+
+# Create a Discussion via GraphQL. Returns discussion URL.
+# Args: category_id title body
+_gh_post_discussion() {
+  _gh_available || return 0
+  _gh_resolve_categories || return 0
+  local category_id="${1:-}" title="${2:-}" body="${3:-}"
+  [[ -z "$category_id" || -z "$title" ]] && return 0
+
+  local repo_id
+  repo_id=$(_gh_repo_id) || return 0
+
+  local result
+  result=$(gh api graphql -f query='
+    mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
+      createDiscussion(input: {
+        repositoryId: $repoId,
+        categoryId: $catId,
+        title: $title,
+        body: $body
+      }) {
+        discussion { url }
+      }
+    }' \
+    -f repoId="$repo_id" \
+    -f catId="$category_id" \
+    -f title="$title" \
+    -f body="${body:-}" \
+    --jq '.data.createDiscussion.discussion.url' \
+    2>/dev/null) || return 0
+
+  echo "$result"
+  return 0
+}
+
+# === High-level posting functions ===
+
+# Agent personality voice hints for session summaries
+_gh_agent_voice() {
+  case "${1:-}" in
+    surgeon)    echo "Minimal diff. In and out." ;;
+    adversary)  echo "Assumed broken until proven otherwise." ;;
+    researcher) echo "Searched before building." ;;
+    dreamer)    echo "Explored the edges." ;;
+    *)          echo "Session complete." ;;
+  esac
+}
+
+# Post formatted session summary to Agent Logs.
+# Args: agent_name branch did learned next
+_gh_post_session_summary() {
+  _gh_available || return 0
+  local agent="${1:-unknown}" branch="${2:-main}"
+  local did="${3:-}" learned="${4:-}" next="${5:-}"
+
+  local voice
+  voice=$(_gh_agent_voice "$agent")
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local body
+  body=$(cat <<EOF
+## Session Summary: \`${agent}\`
+
+> _${voice}_
+
+**Branch:** \`${branch}\`
+**Timestamp:** ${timestamp}
+
+### What was done
+${did:-Nothing recorded.}
+
+### What was learned
+${learned:-Nothing new.}
+
+### What's next
+${next:-No follow-up identified.}
+EOF
+)
+
+  _gh_post_discussion "$_GH_CAT_AGENT_LOGS" "Session: ${agent} @ ${branch} ($(date +%Y-%m-%d))" "$body" &
+  return 0
+}
+
+# Post high-hit learning to Learnings discussion category.
+# Args: insight evidence hit_count
+_gh_post_learning() {
+  _gh_available || return 0
+  local insight="${1:-}" evidence="${2:-}" hit_count="${3:-1}"
+  [[ -z "$insight" ]] && return 0
+
+  local body
+  body=$(cat <<EOF
+## Learning
+
+**Insight:** ${insight}
+**Hit count:** ${hit_count}
+
+### Evidence
+${evidence:-No evidence provided.}
+
+---
+_Auto-posted by KERNEL when hit_count >= threshold._
+EOF
+)
+
+  _gh_post_discussion "$_GH_CAT_LEARNINGS" "Learning: ${insight%%. *}" "$body" &
+  return 0
+}
+
+# Post to Decisions discussion category.
+# Args: title body
+_gh_post_decision() {
+  _gh_available || return 0
+  local title="${1:-}" body="${2:-}"
+  [[ -z "$title" ]] && return 0
+
+  _gh_post_discussion "$_GH_CAT_DECISIONS" "$title" "$body" &
+  return 0
+}
+
+# Post handoff to Agent Logs discussion category.
+# Args: title body
+_gh_post_handoff() {
+  _gh_available || return 0
+  local title="${1:-}" body="${2:-}"
+  [[ -z "$title" ]] && return 0
+
+  local body_with_meta
+  body_with_meta=$(cat <<EOF
+## Handoff
+
+${body:-No details provided.}
+
+---
+_Posted: $(date -u +"%Y-%m-%dT%H:%M:%SZ")_
+EOF
+)
+
+  _gh_post_discussion "$_GH_CAT_AGENT_LOGS" "Handoff: ${title}" "$body_with_meta" &
+  return 0
+}

--- a/hooks/scripts/session-end.sh
+++ b/hooks/scripts/session-end.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 # Load shared functions
 source "$(dirname "$0")/common.sh"
+source "$(dirname "$0")/github-integration.sh" 2>/dev/null || true
 _kernel_hook_start
 
 # Detect paths
@@ -42,6 +43,15 @@ if [ -f "$AGENT_JSON" ]; then
   fi
 fi
 "$AGENTDB" emit session "session:end" "${SESSION_DURATION_S:+$(( SESSION_DURATION_S * 1000 ))}" "{\"branch\":\"$BRANCH\",\"files_changed\":$FILES_CHANGED,\"agent\":\"$AGENT\"}" "" "" 2>/dev/null &
+
+# === GITHUB LAYER: Post session summary for non-local profiles ===
+if type _gh_available &>/dev/null && _gh_available; then
+    DURATION_DISPLAY=""
+    [ -n "$SESSION_DURATION_S" ] && DURATION_DISPLAY=" (${SESSION_DURATION_S}s)"
+    _gh_post_session_summary "$AGENT" "$BRANCH" \
+        "${FILES_CHANGED} files changed${DURATION_DISPLAY}" "" "" &
+fi
+
 _kernel_hook_end "session-end" 0
 
 # === STEP 1: DEREGISTER THIS AGENT ===

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1370,6 +1370,66 @@ test_retrospective_has_clusters() {
   grep -q "Clusters\|cluster" "$PLUGIN_ROOT/commands/retrospective.md"
 }
 
+# === GitHub Integration Tests ===
+
+test_github_integration_exists() {
+  [ -f "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" ] || return 1
+  head -1 "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" | grep -q "^#!/bin/bash"
+}
+
+test_github_integration_has_availability_check() {
+  grep -q "_gh_available" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh"
+}
+
+test_github_integration_has_profile_gate() {
+  # Must check profile — local profiles get no GitHub operations
+  grep -q "local\|profile" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh"
+}
+
+test_github_integration_has_issue_functions() {
+  grep -q "_gh_create_issue" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" &&
+  grep -q "_gh_comment_issue" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" &&
+  grep -q "_gh_close_issue" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh"
+}
+
+test_github_integration_has_discussion_functions() {
+  grep -q "_gh_post_discussion" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" &&
+  grep -q "_gh_post_session_summary" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" &&
+  grep -q "_gh_post_learning" "$PLUGIN_ROOT/hooks/scripts/github-integration.sh"
+}
+
+test_github_integration_fire_and_forget() {
+  # All gh calls should have error suppression — never block hooks
+  # Check that functions return 0 on failure paths
+  grep -q '2>/dev/null' "$PLUGIN_ROOT/hooks/scripts/github-integration.sh"
+}
+
+test_session_end_sources_github() {
+  grep -q "github-integration.sh" "$PLUGIN_ROOT/hooks/scripts/session-end.sh"
+}
+
+test_session_end_posts_summary() {
+  grep -q "_gh_post_session_summary" "$PLUGIN_ROOT/hooks/scripts/session-end.sh"
+}
+
+test_github_integration_not_hardcoded_repo() {
+  # Repo should be derived from git remote, not hardcoded
+  ! grep -q '"ariaxhan/kernel-claude"' "$PLUGIN_ROOT/hooks/scripts/github-integration.sh" || \
+  grep -q 'git remote' "$PLUGIN_ROOT/hooks/scripts/github-integration.sh"
+}
+
+test_agents_have_github_layer() {
+  grep -q "github\|_gh_\|issue" "$PLUGIN_ROOT/agents/surgeon.md" &&
+  grep -q "github\|_gh_\|issue" "$PLUGIN_ROOT/agents/adversary.md"
+}
+
+test_commands_have_github_layer() {
+  grep -q "non-local\|_gh_\|GitHub\|github" "$PLUGIN_ROOT/commands/ingest.md" &&
+  grep -q "non-local\|_gh_\|GitHub\|github" "$PLUGIN_ROOT/commands/forge.md" &&
+  grep -q "non-local\|_gh_\|GitHub\|github" "$PLUGIN_ROOT/commands/handoff.md" &&
+  grep -q "non-local\|_gh_\|GitHub\|github" "$PLUGIN_ROOT/commands/retrospective.md"
+}
+
 # === Profile Detection Tests ===
 
 test_parse_github_remote_https() {
@@ -1617,6 +1677,19 @@ run_test_suite() {
       run_test "retrospective has output format" test_retrospective_has_output_format
       run_test "retrospective has cluster analysis" test_retrospective_has_clusters
       ;;
+    github_integration)
+      run_test "github-integration.sh exists" test_github_integration_exists
+      run_test "has availability check" test_github_integration_has_availability_check
+      run_test "has profile gate" test_github_integration_has_profile_gate
+      run_test "has issue functions" test_github_integration_has_issue_functions
+      run_test "has discussion functions" test_github_integration_has_discussion_functions
+      run_test "fire-and-forget safety" test_github_integration_fire_and_forget
+      run_test "session-end sources github" test_session_end_sources_github
+      run_test "session-end posts summary" test_session_end_posts_summary
+      run_test "repo not hardcoded" test_github_integration_not_hardcoded_repo
+      run_test "agents have github layer" test_agents_have_github_layer
+      run_test "commands have github layer" test_commands_have_github_layer
+      ;;
     profile)
       run_test "parse_github_remote HTTPS" test_parse_github_remote_https
       run_test "parse_github_remote SSH" test_parse_github_remote_ssh
@@ -1666,6 +1739,7 @@ main() {
     run_test_suite "circuit_breaker"
     run_test_suite "diagnose"
     run_test_suite "retrospective"
+    run_test_suite "github_integration"
     run_test_suite "profile"
   else
     run_test_suite "$target"


### PR DESCRIPTION
## Summary
Implements epic #49: GitHub becomes a supplementary visibility layer on top of AgentDB.

**Architecture:** AgentDB is ALWAYS the source of truth for ALL profiles. GitHub is additive for non-local profiles (github, github-oss, github-production). Local profiles are completely unaffected.

### What's new

**`hooks/scripts/github-integration.sh`** — Core library (330 lines)
- `_gh_available()` — profile gate (local = no-op)
- `_gh_ensure_labels()` — idempotent label creation
- `_gh_create_issue/comment/close()` — GitHub Issues
- `_gh_post_discussion()` — GraphQL Discussion creation
- `_gh_post_session_summary()` — formatted with agent personality voice
- `_gh_post_learning()` — surfaces high-hit patterns
- `_gh_post_decision/handoff()` — category-routed posts
- Discussion category IDs resolved dynamically (no hardcoded IDs)

**Hooks**
- `session-end.sh` auto-posts session summary to Agent Logs discussion

**Agents** (supplementary, AgentDB first)
- `surgeon.md` — posts checkpoint + completion to Issues
- `adversary.md` — posts PASS/FAIL verdict to Issues

**Commands** (profile-gated additions)
- `ingest.md` — tier 2+ creates GitHub Issue with contract
- `forge.md` — creates/closes tracking issue
- `handoff.md` — posts to Agent Logs discussion
- `retrospective.md` — surfaces promoted patterns to Learnings discussion

**Labels created on repo:**
`agent-contract`, `tier-1`, `tier-2`, `tier-3`, `agent:surgeon`, `agent:adversary`, `agent:researcher`, `agent:dreamer`

## Closes
- Closes #50 — GitHub Issues as work tracking
- Closes #51 — GitHub Discussions as agent communication
- Partial #49 — epic (Wiki #52 deferred to GitHub Actions)

## Test plan
- [x] `bash tests/run-tests.sh` — 146/146 pass
- [x] All command files under 200-line token budget
- [x] `bash -n` syntax check on all shell scripts
- [x] Profile gate: 9/9 public functions check `_gh_available`
- [x] Fire-and-forget: 37 `return 0` paths, never blocks on API failure
- [x] No hardcoded repo/category IDs — all derived from git remote + GraphQL
- [ ] Manual: verify session-end posts to Discussions on github-oss profile
- [ ] Manual: verify local profile gets zero GitHub API calls