### PR TITLE
kernel .md: blob→flow skill rewrite + consistency bookends

### DIFF
--- a/agents/dreamer.md
+++ b/agents/dreamer.md
@@ -1,5 +1,5 @@
 ---
-name: kernel:dreamer
+name: dreamer
 description: "Multi-perspective debate agent. Generates minimalist, maximalist, and pragmatist approaches grounded in actual codebase context."
 allowed-tools: Read, Grep, Glob, Bash, Write
 ---

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -14,7 +14,7 @@ APPROVE, REQUEST CHANGES, or COMMENT.
 </role>
 
 <on_start>
-agentdb inject-context adversary
+agentdb inject-context reviewer
 </on_start>
 
 <skill_load>

--- a/commands/diagnose.md
+++ b/commands/diagnose.md
@@ -11,6 +11,10 @@ Mixing diagnosis with implementation means the surgeon starts cutting before the
 /kernel:diagnose is the X-ray.
 </purpose>
 
+<on_start>
+agentdb read-start   # surface prior failures/gotchas first — a known bug class shortcuts the diagnosis
+</on_start>
+
 <skill_load>
 Load: skills/debug/SKILL.md, skills/testing/SKILL.md, skills/architecture/SKILL.md
 </skill_load>

--- a/commands/dream.md
+++ b/commands/dream.md
@@ -18,6 +18,10 @@ The winning approach is the one that SURVIVES attack, not the one that sounds be
 Use before any non-trivial decision. Use when the obvious answer feels too easy.
 </purpose>
 
+<on_start>
+agentdb read-start   # prior dreams + learnings seed the perspectives; don't re-explore killed approaches
+</on_start>
+
 <skill_load>
 always: skills/quality/SKILL.md, skills/architecture/SKILL.md
 on_domain:

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -12,7 +12,7 @@ Save session state for seamless continuation.
 Context = decisions + artifacts + warnings + next steps.
 A good handoff lets the next session start working immediately.
 
-Reference: skills/context/SKILL.md
+Reference: skills/context-mgmt/SKILL.md
 </purpose>
 
 <on_start>

--- a/commands/help.md
+++ b/commands/help.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Bash, Grep, Glob
 <command id="help">
 
 <purpose>
-Quick reference for KERNEL v7.6.1.
+Quick reference for KERNEL v7.13.0.
 Commands, agents, workflows, philosophy — and current plugin status.
 </purpose>
 

--- a/skills/api/SKILL.md
+++ b/skills/api/SKILL.md
@@ -21,212 +21,81 @@ Identify API versioning strategy in use (URL path, header, none).
 Skill-specific: skills/api/reference/api-research.md
 </reference>
 
-<core_principles>
-1. RESOURCES ARE NOUNS: /users, /orders, /products. Not /getUsers, /createOrder.
-2. HTTP METHODS MATTER: GET reads, POST creates, PUT replaces, PATCH updates, DELETE removes.
-3. STATUS CODES ARE SEMANTIC: 200 OK, 201 Created, 400 Bad Request, 401 Unauthorized, 404 Not Found, 500 Internal Error.
-4. PAGINATION BY DEFAULT: Lists return paginated results. Cursor > offset for scale.
-5. VALIDATE BEFORE PROCESS: Schema validation (Zod, Pydantic) on all inputs.
-</core_principles>
+<methodology>
 
-<url_structure>
-```
-# Resource-based URLs
-GET    /api/v1/users              # List
-GET    /api/v1/users/:id          # Get one
-POST   /api/v1/users              # Create
-PUT    /api/v1/users/:id          # Replace
-PATCH  /api/v1/users/:id          # Update
-DELETE /api/v1/users/:id          # Delete
+1. **RESOURCE NAMING**
+   - URLs are nouns, plural, kebab-case: `/api/v1/users`, `/api/v1/team-members`
+   - HTTP methods are the verbs: GET/POST/PUT/PATCH/DELETE
+   - Sub-resources for relationships: `/api/v1/users/:id/orders`
+   - Actions (sparingly): `POST /api/v1/orders/:id/cancel`
+   - (gate: no verb in URL path, no singular resource names, no snake_case in URL)
 
-# Sub-resources for relationships
-GET    /api/v1/users/:id/orders   # User's orders
-POST   /api/v1/users/:id/orders   # Create order for user
+2. **STATUS CODES** — use semantically, never 200 for errors
+   ```
+   200 OK · 201 Created (+ Location header) · 204 No Content
+   400 Bad Request · 401 Unauthorized · 403 Forbidden · 404 Not Found
+   409 Conflict · 422 Unprocessable Entity · 429 Too Many Requests
+   500 Internal Server Error · 502 Bad Gateway · 503 Service Unavailable (+ Retry-After)
+   ```
+   (gate: POST returns 201, DELETE returns 204, errors never return 200)
 
-# Actions (use sparingly)
-POST   /api/v1/orders/:id/cancel  # Verb for non-CRUD action
-POST   /api/v1/auth/login         # Auth endpoints
-```
+3. **VALIDATE ALL INPUT** before any processing
+   - Schema validation with Zod (TS) or Pydantic (Python) on every endpoint
+   - Return 422 with structured field errors on validation failure
+   - (gate: no endpoint processes input without schema.safeParse / model.validate)
 
-```
-# GOOD: kebab-case, plural, no verbs
-/api/v1/team-members
-/api/v1/orders?status=active
+4. **RESPONSE SHAPE** — consistent envelope
+   - Single resource: `{ "data": { ... } }`
+   - Collection: `{ "data": [...], "meta": { total, page, per_page }, "links": { self, next, last } }`
+   - Error: `{ "error": { "code": "snake_case_code", "message": "...", "details": [...] } }`
+   - (gate: all responses use envelope; no bare objects; error.code is machine-readable)
 
-# BAD: verbs, singular, snake_case in URL
-/api/v1/getUser
-/api/v1/user
-/api/v1/team_members
-```
-</url_structure>
+5. **PAGINATION** — mandatory for all list endpoints
+   - Cursor (`?cursor=...&limit=20`): use for feeds, infinite scroll, >10K rows
+   - Offset (`?page=N&per_page=20`): use for admin dashboards, search with page jumps
+   - Return `next_cursor` as opaque string — agents must not compute it from math
+   - (gate: no list endpoint returns unbounded results)
 
-<status_codes>
-```
-# Success
-200 OK                    - GET, PUT, PATCH with response body
-201 Created               - POST (include Location header)
-204 No Content            - DELETE, PUT without response body
+6. **VERSIONING**
+   - URL path versioning: `/api/v1/`, `/api/v2/` (recommended)
+   - Max 2 active versions; add `Sunset` header before removal
+   - Non-breaking (no new version): add fields, add optional params, add endpoints
+   - Breaking (new version required): remove/rename fields, change types, change URL structure
+   - (gate: breaking change without version bump = blocked)
 
-# Client Errors
-400 Bad Request           - Malformed JSON, validation failure
-401 Unauthorized          - Missing or invalid auth token
-403 Forbidden             - Authenticated but not authorized
-404 Not Found             - Resource doesn't exist
-409 Conflict              - Duplicate entry, state conflict
-422 Unprocessable Entity  - Valid JSON but semantically invalid
-429 Too Many Requests     - Rate limit exceeded
+7. **RATE LIMITING** — expose via headers on every response
+   ```
+   X-RateLimit-Limit: 100
+   X-RateLimit-Remaining: 95
+   X-RateLimit-Reset: <unix-timestamp>
+   Retry-After: 60   # on 429 only
+   ```
+   (gate: 429 response always includes Retry-After)
 
-# Server Errors
-500 Internal Server Error - Unexpected failure (never expose details)
-502 Bad Gateway           - Upstream service failed
-503 Service Unavailable   - Overloaded, include Retry-After
-```
-</status_codes>
+8. **IDEMPOTENCY** — mandatory for state-changing ops in distributed/agentic contexts
+   - Accept `Idempotency-Key` header on POST/PATCH
+   - Cache result keyed by `idem:<key>` with 24h TTL; return cached on repeat
+   - Required for: payments, orders, bulk imports, any agent-called endpoint
+   - (gate: agent-facing POST endpoints either are idempotent by design OR support Idempotency-Key)
 
-<response_format>
-<!-- Success -->
-```json
-{
-  "data": {
-    "id": "abc-123",
-    "email": "user@example.com",
-    "name": "Alice"
-  }
-}
-```
+9. **HEALTH ENDPOINTS**
+   ```
+   GET /health          # Liveness: 200 if process alive
+   GET /health/ready    # Readiness: 200 if all dependencies up
+   GET /health/startup  # Startup: 200 once init complete
+   ```
+   - Response: `{ "status": "ok|degraded", "version": "...", "dependencies": { "db": "ok" } }`
+   - 503 if critical dependency down; 200 + "degraded" if non-critical
+   - (gate: every new service exposes /health and /health/ready)
 
-<!-- Collection with pagination -->
-```json
-{
-  "data": [
-    { "id": "abc-123", "name": "Alice" },
-    { "id": "def-456", "name": "Bob" }
-  ],
-  "meta": {
-    "total": 142,
-    "page": 1,
-    "per_page": 20,
-    "total_pages": 8
-  },
-  "links": {
-    "self": "/api/v1/users?page=1",
-    "next": "/api/v1/users?page=2",
-    "last": "/api/v1/users?page=8"
-  }
-}
-```
+10. **AGENTIC CLIENT DESIGN** — when API is called by AI agents
+    - Every state-changing endpoint: idempotent OR requires `Idempotency-Key` (document which)
+    - Distinct error codes per failure mode — agents parse codes to decide retry vs abort vs escalate
+    - Batch endpoints for high-frequency reads: `GET /api/v1/users/batch?ids=a,b,c`
+    - Return `next_cursor` as direct string, never derivable by offset math
+    - (gate: agent-facing APIs documented with retry-safety posture per endpoint)
 
-<!-- Error -->
-```json
-{
-  "error": {
-    "code": "validation_error",
-    "message": "Request validation failed",
-    "details": [
-      { "field": "email", "message": "Must be valid email", "code": "invalid_format" }
-    ]
-  }
-}
-```
-</response_format>
-
-<pagination>
-<!-- Offset-based (simple, small datasets) -->
-```
-GET /api/v1/users?page=2&per_page=20
-
-SELECT * FROM users ORDER BY created_at DESC LIMIT 20 OFFSET 20;
-```
-
-<!-- Cursor-based (scalable, large datasets) -->
-```
-GET /api/v1/users?cursor=eyJpZCI6MTIzfQ&limit=20
-
-SELECT * FROM users WHERE id > :cursor_id ORDER BY id LIMIT 21;
-```
-
-Use cursor for: infinite scroll, feeds, >10K rows.
-Use offset for: admin dashboards, search results with page numbers.
-</pagination>
-
-<implementation>
-```typescript
-import { z } from "zod"
-import { NextRequest, NextResponse } from "next/server"
-
-const createUserSchema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1).max(100),
-})
-
-export async function POST(req: NextRequest) {
-  const body = await req.json()
-  const parsed = createUserSchema.safeParse(body)
-
-  if (!parsed.success) {
-    return NextResponse.json({
-      error: {
-        code: "validation_error",
-        message: "Request validation failed",
-        details: parsed.error.issues.map(i => ({
-          field: i.path.join("."),
-          message: i.message,
-          code: i.code,
-        })),
-      },
-    }, { status: 422 })
-  }
-
-  const user = await createUser(parsed.data)
-
-  return NextResponse.json(
-    { data: user },
-    {
-      status: 201,
-      headers: { Location: `/api/v1/users/${user.id}` },
-    },
-  )
-}
-```
-</implementation>
-
-<versioning>
-```
-# URL path versioning (recommended)
-/api/v1/users
-/api/v2/users
-
-# Rules
-1. Start with /api/v1/ - don't version until needed
-2. Max 2 active versions (current + previous)
-3. Non-breaking changes don't need new version:
-   - Adding new response fields
-   - Adding optional query params
-   - Adding new endpoints
-4. Breaking changes require new version:
-   - Removing/renaming fields
-   - Changing field types
-   - Changing URL structure
-```
-</versioning>
-
-<rate_limiting>
-```
-HTTP/1.1 200 OK
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1640000000
-
-HTTP/1.1 429 Too Many Requests
-Retry-After: 60
-{
-  "error": {
-    "code": "rate_limit_exceeded",
-    "message": "Rate limit exceeded. Try again in 60 seconds."
-  }
-}
-```
-</rate_limiting>
+</methodology>
 
 <anti_patterns>
 <block id="verbs_in_urls">/getUsers, /createOrder. Use HTTP methods for actions.</block>
@@ -235,86 +104,6 @@ Retry-After: 60
 <block id="leaking_details">Stack traces in error responses. Generic messages for users.</block>
 <block id="no_pagination">Returning all records. Pagination is mandatory for lists.</block>
 </anti_patterns>
-
-<!-- Updated 2026-03-30: Claude Code best practices, REST API 2026 patterns -->
-<idempotency>
-Idempotency is mandatory for state-changing operations in distributed and agentic contexts:
-
-```typescript
-// POST with idempotency key prevents duplicate operations
-export async function POST(req: NextRequest) {
-  const idempotencyKey = req.headers.get('Idempotency-Key')
-
-  if (idempotencyKey) {
-    const existing = await cache.get(`idem:${idempotencyKey}`)
-    if (existing) return NextResponse.json(existing, { status: 200 })
-  }
-
-  const result = await processRequest(req)
-
-  if (idempotencyKey) {
-    await cache.set(`idem:${idempotencyKey}`, result, { ttl: 86400 })
-  }
-
-  return NextResponse.json(result, { status: 201 })
-}
-```
-
-Idempotency keys are especially important for:
-- Payment and order endpoints (AI agent retries on timeout)
-- Bulk import operations
-- Any endpoint an agent might call in a retry loop
-</idempotency>
-
-<health_and_observability>
-Every API should expose health and observability endpoints:
-
-```
-GET /health          # Liveness: returns 200 if process is alive
-GET /health/ready    # Readiness: returns 200 if all dependencies are up
-GET /health/startup  # Startup probe: returns 200 once initialization complete
-```
-
-Health response format:
-```json
-{
-  "status": "ok",
-  "version": "1.2.3",
-  "dependencies": {
-    "database": "ok",
-    "cache": "ok",
-    "queue": "degraded"
-  }
-}
-```
-
-503 if any critical dependency is down. 200 with "degraded" if non-critical.
-</health_and_observability>
-
-<!-- Updated 2026-04-27: https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents, https://code.claude.com/docs/en/best-practices -->
-<agentic_client_design>
-When your API will be called by AI agents (not just browsers/mobile), additional design rules apply:
-
-**Retry-safe by default**: Agents retry on timeout and network error. Every state-changing endpoint
-must be idempotent OR require an Idempotency-Key header. Document which one. Agents that can't
-safely retry will corrupt state or lose operations.
-
-**Explicit error taxonomy**: Agents parse error responses to decide retry vs. abort. Use distinct
-error codes for distinct failure modes. "error: something went wrong" forces agents to guess.
-
-```json
-{ "error": { "code": "rate_limit_exceeded", "retry_after": 60 } }  // agent knows: wait 60s, retry
-{ "error": { "code": "validation_error", "field": "email" } }       // agent knows: fix input, don't retry
-{ "error": { "code": "insufficient_credits" } }                     // agent knows: abort, escalate to human
-```
-
-**Batch endpoints**: Agents calling N endpoints in a loop amplify latency. Offer bulk variants
-for high-frequency reads (GET /api/v1/users/batch?ids=a,b,c) for lists an agent might traverse.
-
-**Machine-readable pagination**: Always return `next_cursor` as a direct string, never compute
-it from `page + per_page`. Agents parsing offset arithmetic introduce off-by-one bugs.
-Cursor approach: return cursor string, agent passes it back verbatim — no math required.
-</agentic_client_design>
 
 <on_complete>
 agentdb write-end '{"skill":"api","endpoints_created":<N>,"validation":"zod|pydantic|none","pagination":"cursor|offset|none","versioning":"v1|none"}'

--- a/skills/api/reference/api-research.md
+++ b/skills/api/reference/api-research.md
@@ -349,3 +349,132 @@ X-API-Key: sk_live_abc123
 - Microsoft REST API Guidelines
 - JSON:API specification
 - RFC 7807 (Problem Details)
+
+---
+<!-- Migrated from SKILL.md 2026-05-28 -->
+
+## URL Structure Reference
+
+```
+# Resource CRUD
+GET    /api/v1/users              # List
+GET    /api/v1/users/:id          # Get one
+POST   /api/v1/users              # Create
+PUT    /api/v1/users/:id          # Replace
+PATCH  /api/v1/users/:id          # Update
+DELETE /api/v1/users/:id          # Delete
+
+# Sub-resources for relationships
+GET    /api/v1/users/:id/orders   # User's orders
+POST   /api/v1/users/:id/orders   # Create order for user
+
+# Actions (use sparingly)
+POST   /api/v1/orders/:id/cancel  # Verb for non-CRUD action
+POST   /api/v1/auth/login         # Auth endpoints
+```
+
+Good vs bad:
+```
+# GOOD: kebab-case, plural, no verbs
+/api/v1/team-members
+/api/v1/orders?status=active
+
+# BAD: verbs, singular, snake_case in URL
+/api/v1/getUser
+/api/v1/user
+/api/v1/team_members
+```
+
+## TypeScript Implementation Example (Next.js + Zod)
+
+```typescript
+import { z } from "zod"
+import { NextRequest, NextResponse } from "next/server"
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1).max(100),
+})
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const parsed = createUserSchema.safeParse(body)
+
+  if (!parsed.success) {
+    return NextResponse.json({
+      error: {
+        code: "validation_error",
+        message: "Request validation failed",
+        details: parsed.error.issues.map(i => ({
+          field: i.path.join("."),
+          message: i.message,
+          code: i.code,
+        })),
+      },
+    }, { status: 422 })
+  }
+
+  const user = await createUser(parsed.data)
+
+  return NextResponse.json(
+    { data: user },
+    {
+      status: 201,
+      headers: { Location: `/api/v1/users/${user.id}` },
+    },
+  )
+}
+```
+
+## Idempotency Implementation
+
+```typescript
+// POST with idempotency key prevents duplicate operations
+export async function POST(req: NextRequest) {
+  const idempotencyKey = req.headers.get('Idempotency-Key')
+
+  if (idempotencyKey) {
+    const existing = await cache.get(`idem:${idempotencyKey}`)
+    if (existing) return NextResponse.json(existing, { status: 200 })
+  }
+
+  const result = await processRequest(req)
+
+  if (idempotencyKey) {
+    await cache.set(`idem:${idempotencyKey}`, result, { ttl: 86400 })
+  }
+
+  return NextResponse.json(result, { status: 201 })
+}
+```
+
+Idempotency keys are especially important for:
+- Payment and order endpoints (AI agent retries on timeout)
+- Bulk import operations
+- Any endpoint an agent might call in a retry loop
+
+## Agentic Client Design — Deep Reference
+
+When your API will be called by AI agents (not just browsers/mobile), additional design rules apply.
+
+**Retry-safe by default**: Agents retry on timeout and network error. Every state-changing endpoint
+must be idempotent OR require an Idempotency-Key header. Document which one. Agents that can't
+safely retry will corrupt state or lose operations.
+
+**Explicit error taxonomy**: Agents parse error responses to decide retry vs. abort. Use distinct
+error codes for distinct failure modes.
+
+```json
+{ "error": { "code": "rate_limit_exceeded", "retry_after": 60 } }  // agent knows: wait 60s, retry
+{ "error": { "code": "validation_error", "field": "email" } }       // agent knows: fix input, don't retry
+{ "error": { "code": "insufficient_credits" } }                     // agent knows: abort, escalate to human
+```
+
+**Batch endpoints**: Agents calling N endpoints in a loop amplify latency. Offer bulk variants
+for high-frequency reads (GET /api/v1/users/batch?ids=a,b,c) for lists an agent might traverse.
+
+**Machine-readable pagination**: Always return `next_cursor` as a direct string, never compute
+it from `page + per_page`. Agents parsing offset arithmetic introduce off-by-one bugs.
+Cursor approach: return cursor string, agent passes it back verbatim — no math required.
+
+Sources: https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents (2026-04-27)

--- a/skills/app-dev/SKILL.md
+++ b/skills/app-dev/SKILL.md
@@ -4,124 +4,36 @@ description: "Mobile/web app build pipeline, EAS, store submission, pre-submissi
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 
-# PURPOSE
+# FLOW
 
-Ship apps to stores with confidence. Build pipeline patterns, EAS/Expo workflows,
-and pre-submission checklists that prevent rejection and downtime.
+1. **Load source files** — Read `eas.json`/`app.config.js`/`build.gradle`/CI config. If none exist, scaffold from EAS defaults. (gate: build tooling identified)
+2. **Identify environment** — dev / staging / production. Confirm API endpoints, signing creds, and feature flags are environment-specific. (gate: no hardcoded keys or shared signing certs)
+3. **Select build profile** — development (simulator), preview (internal dist), or production (auto-increment). Run `eas build --profile <profile>`. (gate: build completes without error)
+4. **OTA vs. store build decision** — JS-only change → `eas update`. Any native change → full store build. (gate: OTA never used for native changes)
+5. **Run pre-submission checklist** (gate: all items pass before submitting):
+   - [ ] Privacy manifests (iOS): all required API reasons declared
+   - [ ] Permissions: only what you use, with clear usage descriptions
+   - [ ] Metadata: screenshots current, descriptions accurate
+   - [ ] Version/build numbers: incremented correctly
+   - [ ] Physical device testing: tested on real device (not simulator)
+   - [ ] Deep links: universal links / app links verified
+   - [ ] Push notifications: working in production config
+   - [ ] Crash-free rate: > 99% on staging before promoting
+   - [ ] Bundle size: within limits, no large accidental assets
+   - [ ] Offline behavior: handles no-network gracefully
+6. **iOS submission** — TestFlight (internal → external) → App Store review. (gate: all metadata complete; privacy manifests present)
+7. **Android submission** — Internal testing → closed/open beta → staged production rollout starting at 5-10%. (gate: data safety form complete; crash rate stable)
+8. **Monitor rollout** — watch crash rates before expanding staged rollout. OTA rollback: `eas update:rollback`. Store rollback: halt rollout in console. (gate: crash-free rate holds > 99%)
 
-**Prerequisite**: AgentDB read-start has already run. Project build tooling identified.
+# ANTI-PATTERNS (block on detection)
 
----
+- Hardcoded API keys in builds → use EAS secrets
+- OTA update for native changes → must be a store build
+- Skipping physical device testing → simulators miss real-world issues
+- 0-to-100% rollout on Android → start at 5-10%
+- Shared signing certs across environments → separate keystores
 
-# BUILD PIPELINE
+# REFERENCE
 
-```
-LOCAL DEV -> STAGING -> PRODUCTION
-   |            |           |
-   v            v           v
- hot reload   OTA test    store build
- simulators   TestFlight   full review
- dev API       staging API  prod API
-```
-
-## Environment Separation
-
-Each environment gets its own:
-- API endpoints (never hardcode — use env configs)
-- Signing credentials (dev, staging, prod keystores)
-- Feature flags (staging can enable experimental features)
-- Analytics keys (separate dev/prod to avoid polluting data)
-
----
-
-# EAS / EXPO PATTERNS
-
-## Build Profiles
-
-```json
-{
-  "build": {
-    "development": { "distribution": "internal", "ios": { "simulator": true } },
-    "preview": { "distribution": "internal" },
-    "production": { "autoIncrement": true }
-  }
-}
-```
-
-## OTA Updates (EAS Update)
-
-- Use `eas update` for JS-only changes (no native code changes).
-- Runtime version pinning: tie OTA updates to compatible native builds.
-- Never push OTA updates that require native changes — this crashes apps.
-- Channel strategy: `production`, `staging`, `preview` channels.
-- Rollback: `eas update:rollback` to revert bad OTA pushes.
-
-## Environment Configs
-
-- Use `app.config.js` (dynamic) over `app.json` (static) for environment switching.
-- Expo Constants for runtime env detection.
-- EAS secrets for build-time environment variables.
-- Never commit `.env` files — use EAS secrets or CI/CD env vars.
-
----
-
-# STORE SUBMISSION
-
-## iOS (App Store Connect)
-
-1. **TestFlight**: internal testing first, then external beta.
-2. **App Store Review**: 24-48 hours typical. Plan for rejection cycles.
-3. **Required metadata**: screenshots (6.7", 6.5", 5.5"), description, keywords, privacy URL.
-4. **Privacy manifests** (required since Spring 2024): declare all API usage reasons.
-5. **Signing**: use automatic signing in EAS. Manual = pain.
-
-## Android (Play Console)
-
-1. **Internal testing**: fastest approval, limited testers.
-2. **Closed/open testing**: broader beta before production.
-3. **Production rollout**: staged rollout (start 5-10%, watch crash rates).
-4. **Required metadata**: feature graphic, screenshots, descriptions, content rating.
-5. **Data safety form**: declare all data collection and sharing.
-
----
-
-# PRE-SUBMISSION CHECKLIST
-
-Run before EVERY store submission:
-
-- [ ] **Privacy manifests** (iOS): all required API reasons declared
-- [ ] **Permissions**: only request what you use, with clear usage descriptions
-- [ ] **Metadata**: all screenshots current, descriptions accurate
-- [ ] **Version/build numbers**: incremented correctly
-- [ ] **Physical device testing**: tested on real device (not just simulator)
-- [ ] **Deep links**: universal links / app links verified
-- [ ] **Push notifications**: registered and working in production config
-- [ ] **Crash-free rate**: > 99% on staging before promoting
-- [ ] **Bundle size**: within acceptable limits, no accidental large assets
-- [ ] **Offline behavior**: app handles no-network gracefully
-
----
-
-# ANTI-PATTERNS
-
-- **Hardcoded API keys in builds**: use EAS secrets or env configs. Keys in source = revoked keys.
-- **Skip store review guidelines**: read the guidelines. Rejection wastes days.
-- **Deploy without physical device testing**: simulators miss real-world issues (memory, GPS, camera).
-- **OTA for native changes**: OTA is JS-only. Native changes need a new store build.
-- **Ignore staged rollout**: going 0 to 100% is reckless. Start at 5-10%.
-- **Same signing certs for dev and prod**: separate keystores per environment.
-- **Skip TestFlight/internal testing**: internal testers catch what automated tests miss.
-
----
-
-# SOURCE LOADING
-
-Project-specific build configs vary. Load these at start:
-- `eas.json` or `eas.config.js` — EAS build profiles
-- `app.config.js` or `app.json` — Expo configuration
-- `fastlane/Fastfile` — if using Fastlane for native builds
-- `android/app/build.gradle` — Android build config
-- `ios/*.xcodeproj` or `ios/*.xcworkspace` — iOS project
-- CI/CD config (`.github/workflows/`, `bitrise.yml`, etc.)
-
-If none exist, this is likely a new project — scaffold from EAS defaults.
+Deep rationale, eas.json examples, environment config patterns, iOS/Android submission detail:
+`skills/app-dev/reference/app-dev-research.md`

--- a/skills/app-dev/SKILL.md
+++ b/skills/app-dev/SKILL.md
@@ -37,3 +37,7 @@ allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 
 Deep rationale, eas.json examples, environment config patterns, iOS/Android submission detail:
 `skills/app-dev/reference/app-dev-research.md`
+
+# ON COMPLETE
+
+agentdb write-end '{"skill":"app-dev","platform":"ios|android|both","gate":"submitted|built|blocked","store_ready":true}'

--- a/skills/app-dev/reference/app-dev-research.md
+++ b/skills/app-dev/reference/app-dev-research.md
@@ -1,0 +1,108 @@
+---
+date: 2026-05-28
+topic: app-dev deep reference
+scope: EAS/Expo build pipeline, store submission, environment patterns, anti-patterns
+---
+
+# App Dev — Deep Reference
+
+Consult this file when you need rationale, examples, or tooling surveys.
+The executable flow lives in `../SKILL.md`.
+
+---
+
+## Build Pipeline Architecture
+
+```
+LOCAL DEV -> STAGING -> PRODUCTION
+   |            |           |
+   v            v           v
+ hot reload   OTA test    store build
+ simulators   TestFlight   full review
+ dev API       staging API  prod API
+```
+
+Each environment gets its own:
+- API endpoints (never hardcode — use env configs)
+- Signing credentials (dev, staging, prod keystores)
+- Feature flags (staging can enable experimental features)
+- Analytics keys (separate dev/prod to avoid polluting data)
+
+---
+
+## EAS Build Profiles — Example eas.json
+
+```json
+{
+  "build": {
+    "development": { "distribution": "internal", "ios": { "simulator": true } },
+    "preview": { "distribution": "internal" },
+    "production": { "autoIncrement": true }
+  }
+}
+```
+
+---
+
+## OTA Updates (EAS Update) — Patterns and Pitfalls
+
+- Use `eas update` for JS-only changes (no native code changes).
+- Runtime version pinning: tie OTA updates to compatible native builds.
+- **Never push OTA updates that require native changes — this crashes apps.**
+- Channel strategy: `production`, `staging`, `preview` channels.
+- Rollback: `eas update:rollback` to revert bad OTA pushes.
+
+---
+
+## Environment Config Patterns
+
+- Use `app.config.js` (dynamic) over `app.json` (static) for environment switching.
+- Expo Constants for runtime env detection.
+- EAS secrets for build-time environment variables.
+- Never commit `.env` files — use EAS secrets or CI/CD env vars.
+
+---
+
+## Source Files to Load at Start
+
+Project-specific build configs vary. Check these locations:
+- `eas.json` or `eas.config.js` — EAS build profiles
+- `app.config.js` or `app.json` — Expo configuration
+- `fastlane/Fastfile` — if using Fastlane for native builds
+- `android/app/build.gradle` — Android build config
+- `ios/*.xcodeproj` or `ios/*.xcworkspace` — iOS project
+- CI/CD config (`.github/workflows/`, `bitrise.yml`, etc.)
+
+If none exist, this is likely a new project — scaffold from EAS defaults.
+
+---
+
+## iOS Store Submission — Detail
+
+1. **TestFlight**: internal testing first, then external beta.
+2. **App Store Review**: 24-48 hours typical. Plan for rejection cycles.
+3. **Required metadata**: screenshots (6.7", 6.5", 5.5"), description, keywords, privacy URL.
+4. **Privacy manifests** (required since Spring 2024): declare all API usage reasons.
+5. **Signing**: use automatic signing in EAS. Manual = pain.
+
+## Android Play Console Submission — Detail
+
+1. **Internal testing**: fastest approval, limited testers.
+2. **Closed/open testing**: broader beta before production.
+3. **Production rollout**: staged rollout (start 5-10%, watch crash rates).
+4. **Required metadata**: feature graphic, screenshots, descriptions, content rating.
+5. **Data safety form**: declare all data collection and sharing.
+
+---
+
+## Anti-Pattern Rationale
+
+| Anti-pattern | Why it hurts |
+|---|---|
+| Hardcoded API keys in builds | Keys in source = revoked keys. Use EAS secrets or env configs. |
+| Skip store review guidelines | Rejection wastes days. Read the guidelines before submitting. |
+| Deploy without physical device testing | Simulators miss real-world issues (memory, GPS, camera). |
+| OTA for native changes | OTA is JS-only. Native changes need a new store build. |
+| Ignore staged rollout | Going 0 to 100% is reckless. Start at 5-10%. |
+| Same signing certs for dev and prod | Separate keystores per environment. |
+| Skip TestFlight/internal testing | Internal testers catch what automated tests miss. |

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -55,4 +55,8 @@ Before adding AI to a codebase:
 - Feature envy (methods that use another class more than their own)
 </anti_patterns>
 
+<on_complete>
+agentdb write-end '{"skill":"architecture","decision":"X","coupling_reduced":true,"adr":"path|none"}'
+</on_complete>
+
 </skill>

--- a/skills/backend/SKILL.md
+++ b/skills/backend/SKILL.md
@@ -21,263 +21,58 @@ Identify ORM (Prisma, Drizzle, TypeORM) and cache (Redis, in-memory).
 Skill-specific: skills/backend/reference/backend-research.md
 </reference>
 
-<core_principles>
-1. REPOSITORY PATTERN: Abstract data access. Swap implementations without changing logic.
-2. SERVICE LAYER: Business logic separate from data access and HTTP handling.
-3. N+1 PREVENTION: Never query in a loop. Batch fetch with IN clauses.
-4. CACHE-ASIDE: Check cache, miss -> fetch from DB -> populate cache.
-5. TRANSACTIONS: Atomic operations. All succeed or all fail.
-</core_principles>
+<steps>
 
-<repository_pattern>
-```typescript
-interface UserRepository {
-  findAll(filters?: UserFilters): Promise<User[]>
-  findById(id: string): Promise<User | null>
-  create(data: CreateUserDto): Promise<User>
-  update(id: string, data: UpdateUserDto): Promise<User>
-  delete(id: string): Promise<void>
-}
+1. **Identify layer** — determine which layer the change touches: handler / service / repository / DB.
+   (gate: layer is named; no logic crosses two layers in a single function)
 
-class SupabaseUserRepository implements UserRepository {
-  async findAll(filters?: UserFilters): Promise<User[]> {
-    let query = supabase.from('users').select('id, name, email')
+2. **Repository pattern** — abstract all data access behind an interface.
+   - Interface defines: findById, findAll, create, update, delete.
+   - Implementation depends on ORM/DB; swap without touching service.
+   - (gate: no raw DB calls outside repository files)
+   - Reference: backend-research.md §Repository Pattern Deep Dive
 
-    if (filters?.role) {
-      query = query.eq('role', filters.role)
-    }
+3. **Service layer** — business logic only; no HTTP, no DB calls.
+   - Constructor-inject repositories and external services.
+   - Validate, transform, orchestrate; throw typed errors on failure.
+   - (gate: no `req`/`res` objects; no supabase/prisma/drizzle imports)
+   - Reference: backend-research.md §Service Layer Patterns
 
-    const { data, error } = await query
-    if (error) throw new Error(error.message)
-    return data
-  }
-}
-```
-</repository_pattern>
+4. **N+1 prevention** — before any loop over a result set, check for nested queries.
+   - Collect IDs → single batch fetch → build Map → attach in-memory.
+   - Alternative: JOIN in query or DataLoader for GraphQL.
+   - (gate: zero `await repo.findById` calls inside a `for`/`forEach`/`.map`)
+   - Reference: backend-research.md §N+1 Query Solutions
 
-<service_layer>
-```typescript
-class UserService {
-  constructor(
-    private userRepo: UserRepository,
-    private emailService: EmailService
-  ) {}
+5. **Cache-aside** — for read-heavy data: check cache → miss → fetch DB → populate cache.
+   - Invalidate on every mutation (`redis.del(key)` after update/delete).
+   - TTL: 5 min default; shorter for volatile data.
+   - (gate: no cache writes on mutation paths; only invalidation)
+   - Reference: backend-research.md §Caching Strategies
 
-  async createUser(data: CreateUserDto): Promise<User> {
-    // Business logic: validate, transform, orchestrate
-    const existing = await this.userRepo.findByEmail(data.email)
-    if (existing) throw new ConflictError('Email already registered')
+6. **Transactions** — multi-step mutations must be atomic.
+   - Use DB transaction block or Supabase RPC for cross-table ops.
+   - Rollback must be automatic on any error.
+   - (gate: no two-step mutations without wrapping transaction)
+   - Reference: backend-research.md §Transactions
 
-    const user = await this.userRepo.create(data)
-    await this.emailService.sendWelcome(user.email)
+7. **Error handling** — typed error hierarchy; never expose stack traces.
+   - AppError → NotFoundError / ValidationError / UnauthorizedError.
+   - Global handler: map known errors to HTTP status; log + return generic 500 for unknown.
+   - (gate: no raw `Error` thrown from service; no stack trace in response body)
+   - Reference: backend-research.md §Error Handling
 
-    return user
-  }
-}
-```
-</service_layer>
+8. **Retry with backoff** — transient failures (network, lock contention) get exponential backoff.
+   - Max 3 retries; delays: 1 s, 2 s, 4 s.
+   - (gate: idempotent operations only; never retry mutations without idempotency key)
+   - Reference: backend-research.md §Retry Pattern
 
-<n_plus_one_prevention>
-```typescript
-// BAD: N+1 queries
-const orders = await getOrders()
-for (const order of orders) {
-  order.customer = await getCustomer(order.customer_id)  // N queries!
-}
+9. **Queue pattern** — fire-and-forget or deferred work uses a job queue.
+   - Failed jobs: retry up to maxAttempts, then dead-letter queue.
+   - (gate: queue is not blocking the HTTP response)
+   - Reference: backend-research.md §Queue Patterns
 
-// GOOD: Batch fetch
-const orders = await getOrders()
-const customerIds = [...new Set(orders.map(o => o.customer_id))]
-const customers = await getCustomersByIds(customerIds)  // 1 query
-const customerMap = new Map(customers.map(c => [c.id, c]))
-
-orders.forEach(order => {
-  order.customer = customerMap.get(order.customer_id)
-})
-```
-
-```typescript
-// GOOD: Select only needed columns
-const { data } = await supabase
-  .from('orders')
-  .select('id, total, status, customer:customers(id, name)')
-  .eq('status', 'active')
-  .limit(10)
-```
-</n_plus_one_prevention>
-
-<caching>
-```typescript
-// Cache-aside pattern
-class CachedUserRepository implements UserRepository {
-  constructor(
-    private baseRepo: UserRepository,
-    private redis: RedisClient
-  ) {}
-
-  async findById(id: string): Promise<User | null> {
-    const cacheKey = `user:${id}`
-
-    // Check cache
-    const cached = await this.redis.get(cacheKey)
-    if (cached) return JSON.parse(cached)
-
-    // Cache miss - fetch from DB
-    const user = await this.baseRepo.findById(id)
-
-    if (user) {
-      // Cache for 5 minutes
-      await this.redis.setex(cacheKey, 300, JSON.stringify(user))
-    }
-
-    return user
-  }
-
-  async update(id: string, data: UpdateUserDto): Promise<User> {
-    const user = await this.baseRepo.update(id, data)
-    // Invalidate cache on mutation
-    await this.redis.del(`user:${id}`)
-    return user
-  }
-}
-```
-</caching>
-
-<transactions>
-```typescript
-// Supabase RPC for atomic operations
-async function transferFunds(fromId: string, toId: string, amount: number) {
-  const { data, error } = await supabase.rpc('transfer_funds', {
-    from_id: fromId,
-    to_id: toId,
-    amount: amount
-  })
-
-  if (error) throw new Error('Transfer failed')
-  return data
-}
-
-// SQL function
-CREATE OR REPLACE FUNCTION transfer_funds(
-  from_id uuid,
-  to_id uuid,
-  amount decimal
-)
-RETURNS jsonb
-LANGUAGE plpgsql
-AS $$
-BEGIN
-  -- Deduct from sender
-  UPDATE accounts SET balance = balance - amount WHERE id = from_id;
-  -- Add to receiver
-  UPDATE accounts SET balance = balance + amount WHERE id = to_id;
-  RETURN jsonb_build_object('success', true);
-EXCEPTION
-  WHEN OTHERS THEN
-    -- Automatic rollback
-    RETURN jsonb_build_object('success', false, 'error', SQLERRM);
-END;
-$$;
-```
-</transactions>
-
-<error_handling>
-```typescript
-class ApiError extends Error {
-  constructor(
-    public statusCode: number,
-    public message: string,
-    public code: string
-  ) {
-    super(message)
-  }
-}
-
-export function errorHandler(error: unknown): Response {
-  if (error instanceof ApiError) {
-    return NextResponse.json({
-      error: { code: error.code, message: error.message }
-    }, { status: error.statusCode })
-  }
-
-  if (error instanceof z.ZodError) {
-    return NextResponse.json({
-      error: {
-        code: 'validation_error',
-        message: 'Validation failed',
-        details: error.errors
-      }
-    }, { status: 400 })
-  }
-
-  // Log unexpected errors, don't expose details
-  console.error('Unexpected error:', error)
-  return NextResponse.json({
-    error: { code: 'internal_error', message: 'Internal server error' }
-  }, { status: 500 })
-}
-```
-</error_handling>
-
-<retry_pattern>
-```typescript
-async function fetchWithRetry<T>(
-  fn: () => Promise<T>,
-  maxRetries = 3
-): Promise<T> {
-  let lastError: Error
-
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      return await fn()
-    } catch (error) {
-      lastError = error as Error
-      if (i < maxRetries - 1) {
-        // Exponential backoff: 1s, 2s, 4s
-        const delay = Math.pow(2, i) * 1000
-        await new Promise(r => setTimeout(r, delay))
-      }
-    }
-  }
-
-  throw lastError!
-}
-```
-</retry_pattern>
-
-<queue_pattern>
-```typescript
-class JobQueue<T> {
-  private queue: T[] = []
-  private processing = false
-
-  async add(job: T): Promise<void> {
-    this.queue.push(job)
-    if (!this.processing) this.process()
-  }
-
-  private async process(): Promise<void> {
-    this.processing = true
-
-    while (this.queue.length > 0) {
-      const job = this.queue.shift()!
-      try {
-        await this.execute(job)
-      } catch (error) {
-        console.error('Job failed:', error)
-        // Optionally: retry, dead-letter queue
-      }
-    }
-
-    this.processing = false
-  }
-
-  private async execute(job: T): Promise<void> {
-    // Implement job execution
-  }
-}
-```
-</queue_pattern>
+</steps>
 
 <anti_patterns>
 <block id="n_plus_one">Querying in loops. Batch fetch with IN clauses or joins.</block>

--- a/skills/backend/reference/backend-research.md
+++ b/skills/backend/reference/backend-research.md
@@ -419,3 +419,251 @@ function errorHandler(error: unknown, req: Request, res: Response) {
 - Martin Fowler, "Patterns of Enterprise Application Architecture"
 - Redis docs on caching patterns
 - AWS Well-Architected Framework
+
+---
+
+## Inline Examples Moved from SKILL.md (2026-05-28)
+
+### Repository Pattern — Supabase Implementation
+```typescript
+interface UserRepository {
+  findAll(filters?: UserFilters): Promise<User[]>
+  findById(id: string): Promise<User | null>
+  create(data: CreateUserDto): Promise<User>
+  update(id: string, data: UpdateUserDto): Promise<User>
+  delete(id: string): Promise<void>
+}
+
+class SupabaseUserRepository implements UserRepository {
+  async findAll(filters?: UserFilters): Promise<User[]> {
+    let query = supabase.from('users').select('id, name, email')
+
+    if (filters?.role) {
+      query = query.eq('role', filters.role)
+    }
+
+    const { data, error } = await query
+    if (error) throw new Error(error.message)
+    return data
+  }
+}
+```
+
+### Service Layer — Constructor Injection
+```typescript
+class UserService {
+  constructor(
+    private userRepo: UserRepository,
+    private emailService: EmailService
+  ) {}
+
+  async createUser(data: CreateUserDto): Promise<User> {
+    // Business logic: validate, transform, orchestrate
+    const existing = await this.userRepo.findByEmail(data.email)
+    if (existing) throw new ConflictError('Email already registered')
+
+    const user = await this.userRepo.create(data)
+    await this.emailService.sendWelcome(user.email)
+
+    return user
+  }
+}
+```
+
+### N+1 Prevention — Batch Fetch Pattern
+```typescript
+// BAD: N+1 queries
+const orders = await getOrders()
+for (const order of orders) {
+  order.customer = await getCustomer(order.customer_id)  // N queries!
+}
+
+// GOOD: Batch fetch
+const orders = await getOrders()
+const customerIds = [...new Set(orders.map(o => o.customer_id))]
+const customers = await getCustomersByIds(customerIds)  // 1 query
+const customerMap = new Map(customers.map(c => [c.id, c]))
+
+orders.forEach(order => {
+  order.customer = customerMap.get(order.customer_id)
+})
+```
+
+```typescript
+// GOOD: Select only needed columns
+const { data } = await supabase
+  .from('orders')
+  .select('id, total, status, customer:customers(id, name)')
+  .eq('status', 'active')
+  .limit(10)
+```
+
+### Caching — Cache-Aside with Invalidation
+```typescript
+// Cache-aside pattern
+class CachedUserRepository implements UserRepository {
+  constructor(
+    private baseRepo: UserRepository,
+    private redis: RedisClient
+  ) {}
+
+  async findById(id: string): Promise<User | null> {
+    const cacheKey = `user:${id}`
+
+    // Check cache
+    const cached = await this.redis.get(cacheKey)
+    if (cached) return JSON.parse(cached)
+
+    // Cache miss - fetch from DB
+    const user = await this.baseRepo.findById(id)
+
+    if (user) {
+      // Cache for 5 minutes
+      await this.redis.setex(cacheKey, 300, JSON.stringify(user))
+    }
+
+    return user
+  }
+
+  async update(id: string, data: UpdateUserDto): Promise<User> {
+    const user = await this.baseRepo.update(id, data)
+    // Invalidate cache on mutation
+    await this.redis.del(`user:${id}`)
+    return user
+  }
+}
+```
+
+### Transactions — Supabase RPC
+```typescript
+// Supabase RPC for atomic operations
+async function transferFunds(fromId: string, toId: string, amount: number) {
+  const { data, error } = await supabase.rpc('transfer_funds', {
+    from_id: fromId,
+    to_id: toId,
+    amount: amount
+  })
+
+  if (error) throw new Error('Transfer failed')
+  return data
+}
+```
+
+```sql
+-- SQL function with automatic rollback
+CREATE OR REPLACE FUNCTION transfer_funds(
+  from_id uuid,
+  to_id uuid,
+  amount decimal
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Deduct from sender
+  UPDATE accounts SET balance = balance - amount WHERE id = from_id;
+  -- Add to receiver
+  UPDATE accounts SET balance = balance + amount WHERE id = to_id;
+  RETURN jsonb_build_object('success', true);
+EXCEPTION
+  WHEN OTHERS THEN
+    -- Automatic rollback
+    RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+```
+
+### Error Handling — ApiError + Global Handler
+```typescript
+class ApiError extends Error {
+  constructor(
+    public statusCode: number,
+    public message: string,
+    public code: string
+  ) {
+    super(message)
+  }
+}
+
+export function errorHandler(error: unknown): Response {
+  if (error instanceof ApiError) {
+    return NextResponse.json({
+      error: { code: error.code, message: error.message }
+    }, { status: error.statusCode })
+  }
+
+  if (error instanceof z.ZodError) {
+    return NextResponse.json({
+      error: {
+        code: 'validation_error',
+        message: 'Validation failed',
+        details: error.errors
+      }
+    }, { status: 400 })
+  }
+
+  // Log unexpected errors, don't expose details
+  console.error('Unexpected error:', error)
+  return NextResponse.json({
+    error: { code: 'internal_error', message: 'Internal server error' }
+  }, { status: 500 })
+}
+```
+
+### Retry Pattern — Exponential Backoff
+```typescript
+async function fetchWithRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3
+): Promise<T> {
+  let lastError: Error
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error as Error
+      if (i < maxRetries - 1) {
+        // Exponential backoff: 1s, 2s, 4s
+        const delay = Math.pow(2, i) * 1000
+        await new Promise(r => setTimeout(r, delay))
+      }
+    }
+  }
+
+  throw lastError!
+}
+```
+
+### Queue Pattern — Basic Job Queue
+```typescript
+class JobQueue<T> {
+  private queue: T[] = []
+  private processing = false
+
+  async add(job: T): Promise<void> {
+    this.queue.push(job)
+    if (!this.processing) this.process()
+  }
+
+  private async process(): Promise<void> {
+    this.processing = true
+
+    while (this.queue.length > 0) {
+      const job = this.queue.shift()!
+      try {
+        await this.execute(job)
+      } catch (error) {
+        console.error('Job failed:', error)
+        // Optionally: retry, dead-letter queue
+      }
+    }
+
+    this.processing = false
+  }
+
+  private async execute(job: T): Promise<void> {
+    // Implement job execution
+  }
+}
+```

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -4,10 +4,7 @@ description: "Solution exploration and implementation. Generate 2-3 approaches, 
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 ---
 
-# PURPOSE
-
-Minimal code through maximum research. The best code is code you don't write.
-Your first solution is never right. Explore, compare, choose simplest.
+# BUILD SKILL
 
 **Prerequisite**: AgentDB read-start has already run. Tier classification done via /kernel:ingest.
 
@@ -15,7 +12,9 @@ Your first solution is never right. Explore, compare, choose simplest.
 
 ---
 
-# GOAL EXTRACTION
+## STEPS
+
+### 1. GOAL EXTRACTION
 
 ```
 GOAL: [What are we building?]
@@ -25,19 +24,52 @@ OUTPUTS: [What should exist when done?]
 DONE-WHEN: [How do we know it's complete?]
 ```
 
-<!-- Updated 2026-04-10: https://code.claude.com/docs/en/best-practices -->
-**Interview pattern for large features**: For ambiguous or complex features, instead of
-filling in the template manually, prompt Claude to interview you:
-> "I want to build [brief description]. Interview me using the AskUserQuestion tool.
-> Ask about technical implementation, UI/UX, edge cases, and tradeoffs. Don't ask
-> obvious questions — dig into the hard parts. Then write a complete spec to _meta/plans/."
+(gate: all 5 fields filled before continuing)
 
-Start a fresh session after the spec is written. The implementation session gets clean context
-focused entirely on execution, with a written spec to reference throughout.
+For ambiguous features, use interview pattern: `"I want to build [X]. Interview me using AskUserQuestion. Ask about implementation, UI/UX, edge cases, tradeoffs. Write spec to _meta/plans/."`
+Start fresh session after spec is written — implementation gets clean context.
 
 ---
 
-# SOLUTION EXPLORATION (NEVER SKIP)
+### 2. RESEARCH CACHE CHECK
+
+1. `ls _meta/research/` for topic matches
+2. Read frontmatter date + ttl
+3. If `today - date < ttl`: use cached result, skip web search
+4. If stale or missing: search, write result with frontmatter
+
+```yaml
+---
+query: "{original search query}"
+date: "YYYY-MM-DD"
+ttl: 7  # days — anti-patterns/gotchas=7, framework docs=30, package versions=3, architecture=30
+domain: "{tech domain}"
+---
+```
+
+(gate: cache checked — either hit confirmed or new entry written)
+
+**Rule**: Research without verification is theory fiction. (LRN-F11)
+Cache finding → build 10-line proof before committing to it across the codebase.
+Always check agentdb for learnings after cache check — learnings are never cached.
+
+---
+
+### 3. ASSUMPTION VERIFICATION
+
+Confirm (not guess) max 6 per category:
+- Tech stack (languages, frameworks, versions)
+- File locations (where code lives, where to create)
+- Naming conventions (casing, patterns in existing code)
+- Error handling approach (existing patterns)
+- Test expectations (framework, coverage requirements)
+- Dependencies (approved, version constraints)
+
+(gate: assumptions documented before implementation)
+
+---
+
+### 4. SOLUTION EXPLORATION
 
 **Rule: Generate 2-3 approaches minimum. Never implement first idea.**
 
@@ -54,64 +86,15 @@ Evaluation criteria (ordered):
 4. **Maintenance**: active, clear docs
 5. **Performance**: only if bottleneck exists
 
-**Rules:**
-- Write chosen solution + rejected alternatives to `_meta/plans/{feature}.md`
-- Plans under 50 lines. Longer = overthinking.
-- **Planning heuristic**: If you can describe the complete diff in one sentence, skip the plan and implement directly. Planning overhead is only justified for multi-file changes or uncertain approaches.
-<!-- Updated 2026-03-28: https://code.claude.com/docs/en/best-practices -->
+Write chosen solution + rejected alternatives to `_meta/plans/{feature}.md`.
+Plans under 50 lines. Longer = overthinking.
+**Skip plan if diff can be described in one sentence** — planning overhead only justified for multi-file or uncertain approaches.
+
+(gate: ≥2 approaches compared, one chosen with rationale)
 
 ---
 
-# RESEARCH CACHE
-
-**RULE: Research without verification is theory fiction.** (LRN-F11)
-Every research finding must be verified with a minimal test before it drives implementation.
-Cached research is a starting point, not a conclusion. If the cache says "use approach X",
-build a 10-line proof before committing to X across your codebase.
-
-Before web search, check for cached research in `_meta/research/`.
-
-**Cache format** — research files use frontmatter:
-```yaml
----
-query: "{original search query}"
-date: "YYYY-MM-DD"
-ttl: 7  # days
-domain: "{tech domain}"
----
-```
-
-**TTL rules:**
-- Anti-patterns/gotchas: 7 days (change slowly)
-- Framework docs/APIs: 30 days (stable references)
-- Package versions/compatibility: 3 days (changes fast)
-- Architecture patterns: 30 days (stable)
-
-**Cache check protocol:**
-1. `ls _meta/research/` for topic matches
-2. Read frontmatter date + ttl
-3. If `today - date < ttl`: use cached result, skip web search
-4. If stale or missing: search, then write result with frontmatter
-
-**Cold start**: No behavior change when cache empty — search normally, create cache entry.
-
-**Note**: Cache hits still check agentdb for learnings. Learnings are never cached — always fresh.
-
----
-
-# ASSUMPTION VERIFICATION
-
-Confirm (not guess) max 6 per category:
-- Tech stack (languages, frameworks, versions)
-- File locations (where code lives, where to create)
-- Naming conventions (casing, patterns in existing code)
-- Error handling approach (existing patterns)
-- Test expectations (framework, coverage requirements)
-- Dependencies (approved, version constraints)
-
----
-
-# EXECUTION
+### 5. EXECUTION
 
 **BEFORE** each step: review research doc, check if fewer lines possible.
 **DURING**: use researched package, minimal changes, follow existing patterns, one commit per logical unit.
@@ -119,9 +102,17 @@ Confirm (not guess) max 6 per category:
 
 **If tier 2+**: You are the surgeon. Follow contract scope exactly.
 
+Context discipline:
+- State DONE-WHEN criteria at session START, not end
+- Compact at ~70% context usage — signal: shorter responses, earlier instructions ignored
+- Scope sessions by task, not time — one session = one feature or one bug
+- Two-failure reset: same mistake twice → `/clear` and restart with refined prompt
+
+(gate: each logical unit committed before moving to next)
+
 ---
 
-# VALIDATION
+### 6. VALIDATION
 
 Automated (run what exists):
 - Tests: `npm test` / `pytest` / `cargo test` / `go test`
@@ -129,12 +120,13 @@ Automated (run what exists):
 - Types: `tsc --noEmit` / `mypy`
 
 Manual: walk through done-when criteria. Document how verified.
-
 Edge cases (at least 3): empty/null, boundary, error/failure path.
+
+(gate: all automated checks green, ≥3 edge cases covered)
 
 ---
 
-# FAILURE HANDLING
+### 7. FAILURE HANDLING
 
 1. STOP immediately
 2. Check research doc for this error
@@ -146,7 +138,7 @@ Edge cases (at least 3): empty/null, boundary, error/failure path.
 
 ---
 
-# COMPLETION
+### 8. COMPLETION
 
 Report: feature name, branch, files changed, validation results, next steps.
 
@@ -156,183 +148,7 @@ agentdb write-end '{"skill":"build","feature":"X","files":["Y"],"approach":"Z"}'
 
 ---
 
-# CONTEXT ENGINEERING
-
-<!-- Updated 2026-04-25: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview, https://smartscope.blog/en/generative-ai/claude/claude-code-best-practices-advanced-2026/ -->
-The field has shifted from "prompt engineering" to **context engineering**: optimizing *everything* the model sees, not just the instruction.
-
-The context payload = system prompt + tools + examples + conversation history + available files.
-Each element is a lever. Optimize all of them, not just the user message.
-
-**Long context query position (20k+ tokens)**: When the context payload exceeds ~20K tokens
-(multi-document inputs, large codebases), place your query and instructions at the END, after all
-document content. Anthropic data: this improves response quality by up to 30%. Structure:
-```xml
-<documents>
-  <document index="1"><document_content>{{CONTENT}}</document_content></document>
-  ...
-</documents>
-[Your query and instructions HERE — after all documents, not before]
-```
-<!-- Updated 2026-05-04: https://platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/overview -->
-
-**Explore-Plan-Act loop** (three permission-escalating phases):
-1. **Explore** (read-only): Find relevant files, understand architecture, map dependencies. No writes.
-2. **Plan**: Propose strategy. Human reviews and adjusts before implementation begins.
-3. **Act** (full tools): Implement plan, run tests, iterate on failures.
-
-Anthropic internal data: unguided attempts (Act only, skip Explore+Plan) succeed ~33% of the time.
-Structured Explore-Plan-Act: ~80%+. The phases aren't ceremony — they're the multiplier.
-
-**CLAUDE.md hygiene**: Reference separate files for large domain docs. Inlining >1KB into CLAUDE.md
-consumes token budget before work starts. Use `_meta/reference/` and load on demand.
-
-<!-- Updated 2026-05-10: https://smart-webtech.com/blog/claude-code-workflows-and-best-practices/, https://discuss.huggingface.co/t/10-essential-claude-code-best-practices-you-need-to-know/174731 -->
-**Context7 for versioned library docs**: Use the Context7 MCP plugin instead of asking Claude to web-search documentation. Context7 indexes library docs at a precise version and serves exactly the page Claude needs — no hallucinated APIs, no stale docs from wrong versions. Install once, reference with `use context7` in prompts when working with specific library versions.
-
----
-
-# AGENTIC BUILD PATTERNS
-
-<!-- Updated 2026-04-27: https://marmelab.com/blog/2026/04/24/claude-code-tips-i-wish-id-had-from-day-one.html, https://code.claude.com/docs/en/best-practices -->
-**Writer/Reviewer session split**: Implementation session and review session use separate contexts
-to avoid confirmation bias. Session A implements. Session B opens a fresh context, reads only the
-diff and the spec, and reviews without any memory of the implementation choices.
-
-Without this split, the implementing agent unconsciously validates its own code. Fresh context
-has no investment in prior decisions — it catches what the implementing session rationalized past.
-
-<!-- Updated 2026-04-29: https://code.claude.com/docs/en/best-practices, https://www.builder.io/blog/claude-code-tips-best-practices -->
-**Worktree isolation for parallel features**: Use `claude --worktree <branch-name>` to create
-an isolated branch + context per feature. Multiple worktrees run in parallel without file conflicts.
-Preferred over spawning agents on the same working tree when features touch overlapping files.
-
-<!-- Updated 2026-05-06: https://code.claude.com/docs/en/best-practices -->
-**Subagent definition files**: Define reusable subagents in `.claude/agents/<name>.md` with their own model, tools, and system prompt. Each agent gets isolated context. Use for: security review, test generation, research tasks that would pollute main session.
-
-```markdown
-# .claude/agents/security-reviewer.md
----
-name: security-reviewer
-description: Reviews code for security vulnerabilities
-tools: Read, Grep, Glob, Bash
-model: opus
----
-Review for SQL injection, XSS, auth flaws, secrets, insecure data handling.
-Provide line references and remediation steps.
-```
-
-**Subagent scoping**: When spawning agents for implementation, scope each agent to a
-single file or function boundary. Cross-file agents produce merge conflicts and silent overrides.
-
-**Fan-out batch pattern**: For large-scale migrations (2,000+ files), distribute work across parallel non-interactive invocations. Test on 2-3 files first, then scale.
-
-```bash
-for file in $(cat files.txt); do
-  claude -p "Migrate $file from React to Vue. Return OK or FAIL." \
-    --allowedTools "Edit,Bash(git commit *)"
-done
-```
-
-**Prefer Read before Write**: Always read the target file before editing it, even when
-the task is purely additive. Prevents format drift and ensures you match existing style.
-
-**Minimal footprint**: Request only the permissions and file access actually needed.
-Touch the minimum viable set of files. Unanticipated side effects compound across agents.
-
-<!-- Updated 2026-05-12: https://hamy.xyz/blog/2026-02_code-reviews-claude-subagents, https://code.claude.com/docs/en/best-practices -->
-**Parallel multi-aspect review**: Spin up 5–9 parallel subagents, each scoped to a single concern (security, performance, edge cases, concurrency, business logic, API contracts, etc.). Each agent gets a tight prompt describing exactly what it looks for. Aggregated feedback outperforms a single model reviewing everything — scope focus beats breadth.
-
-**Outcomes rubric + grader pattern**: Before implementation, write a rubric of success criteria (expected behaviors, acceptance criteria). After implementation, spawn a *separate* grader agent that evaluates the output against the rubric in its own context — no memory of how the code was written. Grader failure returns specific issues; agent retakes a pass. Solves "looks good but doesn't actually work."
-
-**Three-part prompt structure for agents**: Identity (who the agent is + its specialty) → Rules (constraints + behaviors, XML-tagged) → Output Format (structured expectations). XML tags create semantic boundaries Claude honors better than markdown headings. More precise than free-text system prompts for multi-agent chains.
-
-<!-- Updated 2026-05-12: https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents -->
-**Init script session validation**: For long-running agentic builds, write `init.sh` that runs at every session start: confirms prior work didn't break the application, verifies key invariants, resets to clean state. Each new feature starts from a verified baseline. Prevents accumulated technical debt from silently compounding across sessions.
-
-**Interrupt-safe commits**: Commit every working state, not just at milestone boundaries.
-If an agent is interrupted mid-task, the last commit must be valid and buildable.
-
-**Clarify before long tasks**: For tasks estimated >5 min, surface ambiguities before
-starting. Mid-task clarification requests cause partial-state problems.
-
----
-
-<!-- Updated 2026-04-02: https://code.claude.com/docs/en/best-practices, https://www.morphllm.com/claude-code-best-practices -->
-# CONTEXT WINDOW HYGIENE
-
-Long build sessions degrade model performance as context fills. Mitigate:
-
-- **Compact at ~70% context usage**: Use `/compact` before context degrades. Signal: responses
-  getting shorter, earlier instructions being ignored, more mistakes per edit.
-  Use `/compact <instructions>` to control what survives: e.g. `/compact Focus on API changes only`.
-  For partial compaction, use `Esc+Esc` → `/rewind`, select a checkpoint, choose "Summarize from here".
-- **Scope sessions by task, not by time**: One session = one feature or one bug. Don't let a
-  session sprawl across multiple concerns. Use `/clear` between unrelated tasks.
-- **Delegate research to subagents**: Research subtasks consume context without adding code.
-  Spawn a researcher agent for deep exploration, synthesize the result into a brief, then
-  start the implementation session with that brief injected as context — not the full research.
-- **Verification criteria before coding**: State done-when criteria at session START, not end.
-  Claude performs dramatically better when it can run tests to verify its own output throughout
-  the session, not just at the end.
-- **Side questions with `/btw`**: Quick questions that don't need to stay in context go in `/btw`.
-  The answer appears as a dismissible overlay and never enters conversation history.
-  Use it for "what does this function do?" or "what's the flag for X?" without growing context.
-- **Cross-context state persistence**: For tasks that span multiple context windows, write state to
-  `_meta/context/progress.json` before context fills. Include: completed steps, current position,
-  next action, key decisions made. New context reads this file first and resumes where the previous left off.
-  Models now understand their own token budget in real-time — use this to trigger state saves proactively.
-- **Two-failure reset rule**: If Claude makes the same mistake twice in a session (same instruction
-  ignored twice, same wrong approach tried twice), run `/clear` and restart with a refined prompt
-  that encodes the lessons as constraints. A clean session with a better prompt outperforms a long
-  session polluted with corrections and failed attempts. Two corrections = stop, reflect, rewrite.
-<!-- Updated 2026-05-04: https://code.claude.com/docs/en/best-practices, https://smartscope.blog/en/generative-ai/claude/claude-code-best-practices-advanced-2026/ -->
-<!-- Updated 2026-04-19: Anthropic April 2026 prompting guide -->
-<!-- Updated 2026-04-10: https://code.claude.com/docs/en/best-practices -->
-
----
-
-# VELOCITY CALIBRATION
-<!-- Updated 2026-04-04: METR 2025 research, https://code.claude.com/docs/en/best-practices -->
-
-**The Velocity Paradox (METR 2025)**: Developers with AI assistance feel ~20% faster but measure ~19% slower.
-Root cause: shifting to ~10% planning / ~90% implementation — AI makes coding cheap, so people skip planning.
-Fix: **50-70% planning / 30-50% implementation** → 50% fewer refactors, 3x overall velocity.
-
-Invest in:
-- Goal extraction and done-when criteria BEFORE any code
-- Generating 2-3 approaches and rejecting the first one
-- Writing or specifying test cases before implementation
-
-**Verification-first multiplier**: Providing tests, screenshots, or expected outputs BEFORE asking Claude to
-implement changes quality dramatically. Claude can run verification against its own output throughout the
-session — not just at the end. State verification criteria at session START.
-
-**Adaptive thinking (Claude 4.6)**: Claude Opus/Sonnet 4.6 uses adaptive thinking, not `budget_tokens`.
-When spawning agents for deep reasoning, guide effort via instruction:
-- Complex architecture/multi-file: `"After reviewing tool results, reflect carefully before proceeding"`
-- Standard implementation: no special instruction needed
-- Simple edits/validation: explicitly say `"This is straightforward, implement directly"`
-
-<!-- Updated 2026-04-19: Anthropic Opus 4.7 migration guide -->
-**Effort parameter (Opus 4.7)**: Opus 4.7 uses an explicit `effort` parameter, not instruction-based guidance.
-- `xhigh`: production code, architecture decisions, deep multi-file reasoning
-- `high`: test generation, code review, moderate complexity tasks
-- `medium`: standard implementation (default if unspecified)
-- `low`: validation, linting, trivial edits — model does only what's asked, no elaboration
-Use `effort: xhigh` when spawning surgeon agents for tier 2+ work. At `low`, the model won't generalize — be explicit about scope.
-
-**Explicit scope instructions (Opus 4.7 literal following)**: Opus 4.7 interprets instructions precisely — it won't auto-generalize.
-- Wrong: "Apply this validation pattern" (applies to first occurrence only)
-- Right: "Apply this validation pattern to EVERY endpoint in /src/api/"
-State the full scope explicitly in every agent prompt. Assume nothing is inferred.
-
-<!-- Updated 2026-05-17: web research — https://claudify.tech/blog/claude-code-best-practices, https://code.claude.com/docs/en/best-practices -->
-**CLAUDE.md signal-to-noise filter**: Keep root CLAUDE.md to 50–100 lines. For each line, ask: "Would removing this cause Claude to make mistakes?" If not, cut it. Use `@import` references to `_meta/reference/` for detailed sections — inlining more than ~1KB consumes token budget before work starts and is a harder failure to detect than a missing rule.
-
----
-
-# FLAGS
+## FLAGS
 
 - `--quick`: skip confirmations, minimal prompts
 - `--plan-only`: stop after planning

--- a/skills/build/reference/build-research.md
+++ b/skills/build/reference/build-research.md
@@ -352,3 +352,137 @@ feature work. Key integration points:
 - tearitapart: for tier 2+, the plan is reviewed via tearitapart
   BEFORE the surgeon starts. Build methodology feeds plan creation;
   tearitapart validates it.
+
+---
+
+## Context Engineering
+
+Updated 2026-04-25 / 2026-05-04.
+
+Context payload = system prompt + tools + examples + conversation history + available files. Each element is a lever. Optimize all of them.
+
+**Long context query position (20k+ tokens)**: Place query/instructions at END, after all document content. Anthropic data: improves response quality up to 30%.
+
+```xml
+<documents>
+  <document index="1"><document_content>{{CONTENT}}</document_content></document>
+  ...
+</documents>
+[Your query and instructions HERE — after all documents, not before]
+```
+
+**Explore-Plan-Act loop** (three permission-escalating phases):
+1. **Explore** (read-only): Find relevant files, understand architecture, map dependencies. No writes.
+2. **Plan**: Propose strategy. Human reviews and adjusts before implementation begins.
+3. **Act** (full tools): Implement plan, run tests, iterate on failures.
+
+Unguided attempts (Act only, skip Explore+Plan) succeed ~33% of the time.
+Structured Explore-Plan-Act: ~80%+. The phases aren't ceremony — they're the multiplier.
+
+**CLAUDE.md hygiene**: Reference separate files for large domain docs. Inlining >1KB into CLAUDE.md consumes token budget before work starts.
+
+**Context7 for versioned library docs**: Use the Context7 MCP plugin instead of web-searching documentation. Context7 indexes library docs at a precise version — no hallucinated APIs, no stale docs from wrong versions.
+
+---
+
+## Agentic Build Patterns
+
+Updated 2026-04-27 / 2026-05-12.
+
+**Writer/Reviewer session split**: Implementation session and review session use separate contexts to avoid confirmation bias. Session A implements. Session B opens a fresh context, reads only the diff and spec, reviews without memory of implementation choices.
+
+**Worktree isolation for parallel features**: Use `claude --worktree <branch-name>` to create an isolated branch + context per feature. Multiple worktrees run in parallel without file conflicts. Preferred over spawning agents on the same working tree when features touch overlapping files.
+
+**Subagent definition files**: Define reusable subagents in `.claude/agents/<name>.md` with their own model, tools, and system prompt. Each agent gets isolated context. Use for: security review, test generation, research tasks that would pollute main session.
+
+```markdown
+# .claude/agents/security-reviewer.md
+---
+name: security-reviewer
+description: Reviews code for security vulnerabilities
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+Review for SQL injection, XSS, auth flaws, secrets, insecure data handling.
+Provide line references and remediation steps.
+```
+
+**Subagent scoping**: When spawning agents for implementation, scope each agent to a single file or function boundary. Cross-file agents produce merge conflicts and silent overrides.
+
+**Fan-out batch pattern**: For large-scale migrations (2,000+ files), distribute work across parallel non-interactive invocations. Test on 2-3 files first, then scale.
+
+```bash
+for file in $(cat files.txt); do
+  claude -p "Migrate $file from React to Vue. Return OK or FAIL." \
+    --allowedTools "Edit,Bash(git commit *)"
+done
+```
+
+**Prefer Read before Write**: Always read the target file before editing it, even when the task is purely additive. Prevents format drift.
+
+**Minimal footprint**: Request only the permissions and file access actually needed. Touch minimum viable file set. Unanticipated side effects compound across agents.
+
+**Parallel multi-aspect review**: Spin up 5–9 parallel subagents, each scoped to a single concern (security, performance, edge cases, concurrency, business logic, API contracts). Aggregated feedback outperforms a single model reviewing everything.
+
+**Outcomes rubric + grader pattern**: Before implementation, write a rubric of success criteria. After implementation, spawn a separate grader agent that evaluates output against the rubric in its own context — no memory of how the code was written. Grader failure returns specific issues; agent retakes a pass.
+
+**Three-part prompt structure for agents**: Identity (who the agent is + specialty) → Rules (constraints + behaviors, XML-tagged) → Output Format (structured expectations). XML tags create semantic boundaries Claude honors better than markdown headings.
+
+**Init script session validation**: For long-running agentic builds, write `init.sh` that runs at every session start: confirms prior work didn't break the application, verifies key invariants, resets to clean state. Prevents accumulated technical debt from silently compounding.
+
+**Interrupt-safe commits**: Commit every working state, not just at milestone boundaries. If an agent is interrupted mid-task, the last commit must be valid and buildable.
+
+**Clarify before long tasks**: For tasks estimated >5 min, surface ambiguities before starting. Mid-task clarification requests cause partial-state problems.
+
+---
+
+## Context Window Hygiene
+
+Updated 2026-04-02 / 2026-05-04.
+
+Long build sessions degrade model performance as context fills. Mitigate:
+
+- **Compact at ~70% context usage**: Use `/compact` before context degrades. Signal: responses getting shorter, earlier instructions being ignored, more mistakes per edit.
+  Use `/compact <instructions>` to control what survives. For partial compaction: `Esc+Esc` → `/rewind`, select checkpoint, choose "Summarize from here".
+- **Scope sessions by task, not by time**: One session = one feature or one bug. Use `/clear` between unrelated tasks.
+- **Delegate research to subagents**: Research subtasks consume context without adding code. Spawn a researcher agent, synthesize to a brief, start implementation session with that brief as context — not the full research.
+- **Verification criteria before coding**: State done-when criteria at session START. Claude performs dramatically better when it can run tests to verify output throughout the session.
+- **Side questions with `/btw`**: Quick questions that don't need context history. The answer appears as a dismissible overlay and never enters conversation history.
+- **Cross-context state persistence**: Write state to `_meta/context/progress.json` before context fills. Include: completed steps, current position, next action, key decisions. New context reads this first and resumes where previous left off.
+- **Two-failure reset rule**: Same mistake twice → `/clear` and restart with refined prompt that encodes lessons as constraints. A clean session with a better prompt outperforms a long session polluted with corrections.
+
+---
+
+## Velocity Calibration
+
+Updated 2026-04-04 (METR 2025 research).
+
+**The Velocity Paradox (METR 2025)**: Developers with AI assistance feel ~20% faster but measure ~19% slower.
+Root cause: shifting to ~10% planning / ~90% implementation — AI makes coding cheap, so people skip planning.
+Fix: **50-70% planning / 30-50% implementation** → 50% fewer refactors, 3x overall velocity.
+
+Invest in:
+- Goal extraction and done-when criteria BEFORE any code
+- Generating 2-3 approaches and rejecting the first one
+- Writing or specifying test cases before implementation
+
+**Verification-first multiplier**: Providing tests, screenshots, or expected outputs BEFORE asking Claude to implement changes quality dramatically. State verification criteria at session START.
+
+**Adaptive thinking (Claude 4.6)**: Claude Opus/Sonnet 4.6 uses adaptive thinking, not `budget_tokens`. When spawning agents for deep reasoning:
+- Complex architecture/multi-file: `"After reviewing tool results, reflect carefully before proceeding"`
+- Standard implementation: no special instruction needed
+- Simple edits/validation: explicitly say `"This is straightforward, implement directly"`
+
+**Effort parameter (Opus 4.7)**: Opus 4.7 uses explicit `effort` parameter, not instruction-based guidance.
+- `xhigh`: production code, architecture decisions, deep multi-file reasoning
+- `high`: test generation, code review, moderate complexity tasks
+- `medium`: standard implementation (default if unspecified)
+- `low`: validation, linting, trivial edits — model does only what's asked, no elaboration
+
+Use `effort: xhigh` when spawning surgeon agents for tier 2+ work.
+
+**Explicit scope instructions (Opus 4.7 literal following)**: Opus 4.7 interprets instructions precisely — it won't auto-generalize.
+- Wrong: "Apply this validation pattern" (applies to first occurrence only)
+- Right: "Apply this validation pattern to EVERY endpoint in /src/api/"
+
+**CLAUDE.md signal-to-noise filter**: Keep root CLAUDE.md to 50–100 lines. For each line, ask: "Would removing this cause Claude to make mistakes?" If not, cut it. Use `@import` references to `_meta/reference/` for detailed sections.

--- a/skills/context-mgmt/SKILL.md
+++ b/skills/context-mgmt/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: kernel:context
+name: context-mgmt
 description: "Context engineering and token management. Compaction strategies, progressive disclosure, structured note-taking via AgentDB. Triggers: tokens, compaction, memory, handoff, summarize, context window."
 allowed-tools: Read, Bash, Task
 ---

--- a/skills/context-mgmt/SKILL.md
+++ b/skills/context-mgmt/SKILL.md
@@ -11,22 +11,16 @@ Context is finite. Every token competes for attention.
 Longer context makes things WORSE (30%+ accuracy drop for middle info).
 Progressive disclosure: load what's needed when it's needed.
 
-**Reasoning fidelity is the real metric, not token count.** Quality degrades at ~60-70% fill, not at the limit. The agent appears to work normally during degradation; only the output gets shallower.
+**Reasoning fidelity is the real metric, not token count.** Quality degrades at ~60-70% fill, not at the limit.
 </purpose>
 
 <prerequisite>
-Monitor context usage. **Compact or hand off proactively at ~60% capacity** — not 80%, not at limit.
+Monitor context usage. Compact or hand off proactively at ~60% capacity — not 80%, not at limit.
 Use native /context command to check usage. This skill is for methodology.
-
-Why 60%, not 70-80%:
-- HF Daily Papers research: solve rate drops 65%→21% when architectural mental model gets evicted from context.
-- Fidelity shallowing starts at ~60% fill — the agent still produces output, but stops backtracking, exploring alternatives, or maintaining hypothesis depth.
-- By the time native compaction fires (typically near limit), the degraded reasoning has already shipped to code.
-- Token count is the lagging indicator. Hypothesis depth and step count are leading indicators.
 </prerequisite>
 
 <reference>
-Skill-specific: skills/context-mgmt/reference/context-research.md
+Skill-specific: skills/context-mgmt/reference/context-mgmt-research.md
 Architecture: _meta/research/context-graph-architecture.md
 Graph tracking: orchestration/agentdb/migrations/002_graph_tracking.sql
 </reference>
@@ -48,88 +42,53 @@ Graph tracking: orchestration/agentdb/migrations/002_graph_tracking.sql
 </token_budget>
 
 <compaction_protocol>
-Trigger compaction at ~60% fill, BEFORE reasoning quality degrades. Do not wait for native auto-compact (too late).
-
-Before compaction:
-1. Write critical state to AgentDB
-2. Commit any uncommitted changes
-3. Generate handoff if complex work in progress
-
-After compaction:
-1. Read active.md for project context
-2. Run agentdb read-start for failures, patterns, contracts
-3. Check for pending checkpoints to review
+1. CHECK fill level via /context. (gate: <60% → continue; ≥60% → proceed to step 2)
+2. Write critical state: `agentdb write-end '{"did":"X","next":"Y","blocked":"Z"}'`
+3. Commit any uncommitted changes. (gate: clean working tree)
+4. Generate handoff if complex work in progress: `/kernel:handoff`
+5. Trigger compaction.
+6. POST-COMPACT RESTORE:
+   a. Read active.md for project context.
+   b. Run `agentdb read-start` for failures, patterns, contracts.
+   c. Check for pending checkpoints to review.
 </compaction_protocol>
 
-<fidelity_health_check>
-Don't trust token count alone. Watch for these reasoning-fidelity signals before compaction is even visible as a token problem:
+<fidelity_signals>
+Watch for reasoning degradation BEFORE the token meter shows a problem:
+- Hypothesis depth dropping: agent defaults to first idea, stops exploring alternatives
+- Backtracking absent: errors patched in place instead of root-caused
+- Step count contracting: multi-step plans collapse to one-shot attempts
+- Cross-file awareness fading: agent forgets earlier files in the same session
+- Inline checks disappearing: agent stops verifying assumptions before acting
 
-- **Hypothesis depth dropping**: agent stops exploring alternatives, defaults to first idea
-- **Backtracking absent**: errors get patched in place rather than root-caused
-- **Step count contracting**: multi-step plans collapse to one-shot attempts
-- **Cross-file awareness fading**: agent forgets earlier files in the same session
-- **Inline checks disappearing**: agent stops verifying assumptions before acting
+Any one of these → compact or hand off NOW, even if /context shows <60% fill.
+</fidelity_signals>
 
-Any one of these = compact or hand off NOW, even if /context shows <60% fill.
-The token meter measures bytes, not thinking.
-</fidelity_health_check>
-
-<compaction_strategies>
-
-## Progressive Disclosure
-- Start with summary, expand on demand
-- Use AgentDB for full context, conversation for highlights
-- Pattern: "Details in AgentDB:contracts:{id}" or "See AgentDB:findings:{id}"
-
-## What to Preserve (Never Compact Away)
+<what_to_preserve>
+Never compact away:
 - Current task context and goal
 - Active decisions and their rationale
 - Blocking issues and error states
-- Recent errors and their resolutions
 - File paths currently being worked on
 - Uncommitted changes description
 - Contract IDs and branch names
+</what_to_preserve>
 
-## What to Aggressively Compact
+<what_to_compact>
+Aggressively compress:
 - Exploratory searches → "searched X, found Y at path:line"
 - File reads → "read file, key insight: Z"
 - Successful operations → "completed: X"
 - Debugging traces → "root cause: X, fix: Y"
 - Tool call history → "N tool calls, outcome: X"
 - Research context → offload to AgentDB, keep one-line summary
-
-## Compaction Format
-Before: [full exploration, multiple tool calls, iterations, dead ends]
-After: "Explored X → Found Y at path/to/file:line → Key insight: Z"
-
-Before: [read 5 files, searched patterns, traced imports]
-After: "Traced dependency: A→B→C. Issue in B:42. Fix: add null check."
-
-## AgentDB Offloading Pattern
-When context grows heavy:
-1. Write detailed findings to AgentDB: `agentdb learn pattern "finding" "evidence"`
-2. Keep one-line summary in conversation
-3. Reference: "See AgentDB:patterns for full trace"
-
-## Phase Transition Compaction
-
-| Transition | Compact? | Why |
-|------------|----------|-----|
-| Research → Planning | Yes | Research bulk served its purpose; plan is distilled output |
-| Planning → Implementation | Yes | Plan is in contract/file; free context for code |
-| Implementation → Testing | Maybe | Keep if tests reference recent code |
-| Debugging → Next feature | Yes | Debug traces pollute unrelated work |
-| Mid-implementation | No | Losing file paths, variable names, partial state is costly |
-| After failed approach | Yes | Clear dead-end reasoning before new approach |
-
-</compaction_strategies>
+</what_to_compact>
 
 <failure_modes>
 1. Agent tries too much at once → context exhausted mid-work
-   Fix: Incremental progress with commits at each step
-
+   Fix: Incremental progress with commits at each step.
 2. Later agent assumes done prematurely → work incomplete
-   Fix: Explicit done-when criteria with evidence required
+   Fix: Explicit done-when criteria with evidence required.
 </failure_modes>
 
 </skill>

--- a/skills/context-mgmt/reference/context-mgmt-research.md
+++ b/skills/context-mgmt/reference/context-mgmt-research.md
@@ -1,0 +1,121 @@
+---
+date: 2026-05-28
+source: skills/context-mgmt/SKILL.md (extracted) + context-research.md
+---
+
+# Context Management: Deep Reference
+
+Consult on demand. Not auto-loaded. See SKILL.md for the executable flow.
+
+---
+
+## Why 60%, Not 70–80%: The Fidelity Cliff
+
+- HF Daily Papers research: solve rate drops 65%→21% when architectural mental model gets evicted from context.
+- Fidelity shallowing starts at ~60% fill — the agent still produces output, but stops backtracking, exploring alternatives, or maintaining hypothesis depth.
+- By the time native compaction fires (typically near limit), the degraded reasoning has already shipped to code.
+- Token count is the lagging indicator. Hypothesis depth and step count are leading indicators.
+
+---
+
+## Compaction Strategies
+
+### Progressive Disclosure
+- Start with summary, expand on demand
+- Use AgentDB for full context, conversation for highlights
+- Pattern: "Details in AgentDB:contracts:{id}" or "See AgentDB:findings:{id}"
+
+### AgentDB Offloading Pattern
+When context grows heavy:
+1. Write detailed findings: `agentdb learn pattern "finding" "evidence"`
+2. Keep one-line summary in conversation
+3. Reference: "See AgentDB:patterns for full trace"
+
+### Compaction Format Examples
+```
+Before: [full exploration, multiple tool calls, iterations, dead ends]
+After:  "Explored X → Found Y at path/to/file:line → Key insight: Z"
+
+Before: [read 5 files, searched patterns, traced imports]
+After:  "Traced dependency: A→B→C. Issue in B:42. Fix: add null check."
+```
+
+### Phase Transition Compaction
+
+| Transition | Compact? | Why |
+|------------|----------|-----|
+| Research → Planning | Yes | Research bulk served its purpose; plan is distilled output |
+| Planning → Implementation | Yes | Plan is in contract/file; free context for code |
+| Implementation → Testing | Maybe | Keep if tests reference recent code |
+| Debugging → Next feature | Yes | Debug traces pollute unrelated work |
+| Mid-implementation | No | Losing file paths, variable names, partial state is costly |
+| After failed approach | Yes | Clear dead-end reasoning before new approach |
+
+---
+
+## Research & Quantitative Backing
+
+### Sources
+Anthropic "Effective Context Engineering for AI Agents" (Sep 2025),
+Anthropic "Effective Harnesses for Long-Running Agents" (2026),
+Anthropic AWS re:Invent 2025 talks, Claude Opus 4.6 with 1M context (Feb 5, 2026),
+Claude Context Windows Documentation (2026), Chroma Research "Context Rot" (Jul 2025),
+MECW Paper (Jan 19, 2026, arXiv 2509.21361), GAM Dual-Agent Architecture (2025),
+Mastra Observational Memory (Feb 4, 2026), ACP Protocol (Feb 2026).
+
+### The Core Problem: Context Rot (Quantified Jan 2026)
+
+Anthropic's research: "As the number of tokens in the context window increases, the model's ability to accurately recall information from that context decreases."
+
+Chroma Research (Jul 2025): Tested 18 models including GPT-4.1, Claude 4, Gemini 2.5. Key finding: **30%+ accuracy drops** for middle-positioned information. Models achieve highest accuracy at sequence start/end ("U-shaped curve").
+
+MECW Paper (Jan 2026, arXiv 2509.21361): Maximum Effective Context Window is drastically different from advertised MCW. Some models failed with as little as 100 tokens in context. All tested models fell short of MCW by **>99%** in some conditions.
+
+The agent doesn't forget because it ran out of space. It forgets because signal got drowned by accumulation.
+
+### The Three Strategies (Anthropic)
+
+**1. Compaction**
+Summarize conversation history and reinitialize context. Claude Code does this: compresses while preserving architectural decisions, unresolved bugs, and implementation details. Lowest-hanging fruit: tool result clearing. Once a tool has been called deep in history, raw output rarely needs to be seen again.
+
+**2. Structured Note-Taking**
+External memory files (NOTES.md, active.md, AgentDB). Enable persistence across context resets. Claude playing Pokemon maintained precise tallies across thousands of game steps using structured notes. In KERNEL: AgentDB is the structured note-taking system.
+
+**3. Multi-Agent Architectures**
+Specialized sub-agents handle focused tasks with clean context windows. Research agent explores codebase in separate context, reports back summary. Main context stays clean for implementation.
+
+### New Memory Architectures (2026)
+
+**Observational Memory (Mastra, Feb 4, 2026)**
+Two-agent system: Observer watches and records, Reflector extracts patterns. Achieves **3-40x compression** while outperforming RAG on benchmarks. Cuts costs 10x compared to long-context approaches.
+
+**GAM Dual-Agent (NeurIPS 2025)**
+Memorizer + Researcher architecture. JIT retrieval outperforms static summaries. Outperforms both RAG and long-context LLMs on benchmarks.
+
+**Server-Side Compaction (Anthropic Beta, Jan 2026)**
+Automatic context compaction when approaching token thresholds. In 100-turn evaluations: **84% token reduction** while completing workflows that would otherwise fail.
+
+**Context Editing**
+Server-side clearing of stale tool calls/results. 29% improvement alone; **39% improvement** combined with memory tool.
+
+**Token Budget Awareness**
+Claude 4.5+ receives real-time token updates after each tool call:
+`<system_warning>Token usage: 35000/200000; 165000 remaining</system_warning>`
+
+### Practical Rules for KERNEL
+
+- CLAUDE.md: always loaded, under 150 lines. The index, not the encyclopedia.
+- Rules: always loaded. Only universally applicable invariants and heuristics.
+- Skills: metadata at startup (~100 tokens each). Full content on demand.
+- Commands: only when user invokes.
+- Reference docs: only when skill explicitly reads them.
+- Delegate research to subagents. Research consumes heavy context.
+- Use grep/glob/find instead of reading entire files.
+- After compaction: read active.md and AgentDB to restore critical state.
+- Anthropic's #1 prompt tip for 2025-2026: "90% of the time when a system doesn't work, the instructions simply don't make sense when read by someone unfamiliar with the domain."
+
+### Two Failure Modes (Anthropic, Long-Running Agents)
+
+1. Agent tries to do too much at once. Runs out of context mid-implementation. Next session starts with half-implemented, undocumented feature. Fix: incremental progress with commits and documentation at each step.
+
+2. Later agent sees progress, declares the job done prematurely. Fix: explicit done-when criteria in contract. Agent must prove completion with evidence, not just observe that files exist.

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -21,75 +21,47 @@ AgentDB read-start has run. Check past failures—you may have seen this pattern
 Skill-specific: skills/debug/reference/debug-research.md
 </reference>
 
-<scientific_method>
-1. OBSERVE: What exactly failed? Document input, expected, actual.
-2. HYPOTHESIZE: Why might this happen? List 3 possible causes before pursuing any.
-3. PREDICT: If this hypothesis is correct, what else should I see?
-4. TEST: Does the prediction hold? Seek DISCONFIRMING evidence first.
-5. REFINE or REJECT: Based on evidence, narrow or abandon hypothesis.
-6. REPEAT: Until the defect—not the symptom—is isolated.
+<steps>
 
-Write each hypothesis and test result to AgentDB. Prevents circular investigation.
-</scientific_method>
+1. **REPRODUCE** — get specific before touching code.
+   - Document: exact input, expected output, actual output (full stack trace), environment, frequency.
+   - "Sometimes fails" is not a reproduction. Get deterministic.
+   - (gate: can reproduce consistently, OR have added targeted logging to wait for next occurrence)
 
-<phase id="reproduce">
-Before touching code, get SPECIFIC:
-- Input: exact values, sequence, timing that triggers the bug.
-- Expected: what should happen.
-- Actual: what happens instead (full error, stack trace).
-- Environment: versions, OS, relevant state.
-- Frequency: always? sometimes? specific conditions?
+2. **HYPOTHESIZE** — list 3 causes before pursuing any.
+   - Read ALL error output first (anchoring bias mitigation).
+   - Write each hypothesis to AgentDB. Prevents circular re-investigation.
+   - (gate: 3 candidate hypotheses written; none pursued yet)
 
-"It sometimes fails" is NOT a reproduction. Get deterministic.
-If it can't be reproduced, add targeted logging and wait.
-</phase>
+3. **ISOLATE** — binary search, O(log n) not O(n).
+   - **Code**: call chain A→B→C→D→E fails → check midpoint C → recurse into failing half.
+   - **Time**: `git bisect` between known-good and known-bad commit. ~10 tests for 1000 commits.
+   - **Input**: large failing input → split in half → recurse to minimal reproduction case.
+   - Instrument at boundaries: log inputs/outputs at each layer boundary.
+   - Mock external dependencies to isolate which one causes failure.
+   - (gate: failure localized to a specific function/commit/input subset)
 
-<phase id="isolate">
-Binary search is O(log n). Random guessing is O(n). Use binary search.
+4. **ROOT CAUSE** — the error line is the FAILURE. The DEFECT is upstream.
+   - Ask: what assumption was violated? What invariant broke?
+   - If you can't explain WHY it broke, you haven't found root cause.
+   - Top causes by frequency: wrong input shape/type · off-by-one · missing null check · race condition · shared-state mutation · wrong comparison operator · variable scope · swallowed error · API contract mismatch · environment difference.
+   - (gate: can state root cause in one sentence explaining the violated invariant)
 
-CODE: Call chain A→B→C→D→E fails. Check C. Works? Bug in D-E. Fails? Bug in A-C. Recurse.
-TIME: git bisect between known-good and known-bad commit. ~10 tests for 1000 commits.
-INPUT: Large failing input? Split in half. Which half fails? Recurse to minimal case.
+5. **FIX** — root cause, not symptom.
+   - Fix the DEFECT, not the FAILURE site. (Null check at crash site = symptom fix.)
+   - Write regression test that fails before fix, passes after.
+   - Run: original failing case + edge cases + full regression suite.
+   - Commit fix + test together.
+   - (gate: regression test green; original failing case passes)
 
-Instrument at boundaries: log inputs/outputs at each step.
-Mock external dependencies to isolate which one causes failure.
-</phase>
-
-<phase id="root_cause">
-The error line is the FAILURE. The DEFECT is upstream.
-Ask: what assumption was violated? What invariant broke?
-
-<common_causes rank="by_frequency">
-1. Wrong input shape or type
-2. Off-by-one (loop bounds, indices, slicing)
-3. Missing null/undefined check
-4. Race condition or async timing
-5. Mutating shared state (aliasing)
-6. Wrong comparison operator (=, ==, ===, >, >=)
-7. Variable scope (closure captures, shadowing)
-8. Swallowed error (empty catch block)
-9. API contract mismatch
-10. Environment difference
-</common_causes>
-
-If you can't explain WHY it broke, you haven't found root cause.
-</phase>
-
-<phase id="fix">
-1. Fix ROOT CAUSE, not symptom. (Null check at crash site = symptom fix.)
-2. Write test that reproduces original bug. Must fail before fix, pass after.
-3. Run regression: original case + edge cases + happy path.
-4. Commit fix + test together.
-
-Every bug fix MUST include a regression test. No exceptions.
-</phase>
+</steps>
 
 <cognitive_biases>
-<bias id="confirmation">You look for evidence your hypothesis is right. Actively seek DISCONFIRMING evidence instead.</bias>
-<bias id="anchoring">First error message anchors you. Read ALL output first. List 3 causes before pursuing any.</bias>
-<bias id="availability">"Last time it was the database." This time might be different. Past patterns are hypotheses, not conclusions.</bias>
+<bias id="confirmation">Seek DISCONFIRMING evidence first. Ask: "What would I see if my hypothesis were WRONG?"</bias>
+<bias id="anchoring">Read ALL output before investigating. List 3 causes before pursuing any.</bias>
+<bias id="availability">Past patterns are hypotheses, not conclusions. Check AgentDB but test them.</bias>
 <bias id="sunk_cost">15 min with no evidence for hypothesis → abandon it. Write what you tested, move on.</bias>
-<bias id="optimism">"It probably works now." Re-run the EXACT original failing case. "Seems to work" is not evidence.</bias>
+<bias id="optimism">Re-run the EXACT original failing case. "Seems to work" is not evidence.</bias>
 </cognitive_biases>
 
 <anti_patterns>
@@ -101,143 +73,49 @@ Every bug fix MUST include a regression test. No exceptions.
 </anti_patterns>
 
 <when_stuck>
-1. Explain problem in writing (rubber duck—engages System 2 cognition).
+1. Explain problem in writing (rubber duck — engages System 2 cognition).
 2. Read error message carefully. Answer is there 80% of the time.
 3. Simplify to minimal reproduction case.
 4. "What changed?" Check git log, git diff, dependency updates, env changes.
 5. Search exact error message in quotes.
 6. Step away. Bias accumulates under sustained focus.
-7. **Plan Mode**: For complex or sensitive bugs, use Plan Mode to analyze errors and form hypotheses without making any code changes until the approach is approved. Paste stack traces and error messages in Plan Mode first.
-8. **Rewind to pre-bug state**: `Esc+Esc` or `/rewind` opens checkpoint history. Restore code state to before the suspected change without losing conversation context. Faster than manual git reset when the bug was introduced in the current session. Checkpoints persist across terminal closes — they survive session restarts.
-9. **Visibility-first**: Don't describe the problem — show the raw evidence. Paste terminal output, actual error logs, or screenshots directly. Let Claude read the data, not your interpretation of it. A description of a bug introduces your assumptions; the raw output doesn't.
-<!-- Updated 2026-04-14: https://allierays.com/posts/5-techniques-to-debug-claude-code/ -->
+7. **Plan Mode**: Paste stack traces in Plan Mode first. Analyze, form hypotheses, get approval — then switch to Act mode for fixes.
+8. **Rewind**: `Esc+Esc` or `/rewind` restores code to a pre-bug checkpoint without losing conversation context. Checkpoints survive terminal closes.
+9. **Visibility-first**: Paste raw terminal output / error logs / screenshots directly. Raw data beats your interpretation.
 </when_stuck>
-<!-- Updated 2026-03-28: https://code.claude.com/docs/en/best-practices, https://claudelog.com/faqs/how-to-use-claude-code-for-debugging/ -->
-<!-- Updated 2026-04-10: https://code.claude.com/docs/en/best-practices -->
 
 <escalation>
 - 30+ min on single hypothesis with no evidence → abandon it.
 - 3+ hypotheses rejected → step back, re-examine assumptions.
-- 2 failed fix attempts → orchestrator should invoke tearitapart. May be design problem, not implementation.
-- 2+ failed corrections in same session → `/clear` and rewrite the initial prompt incorporating lessons learned. A clean session with a better prompt outperforms a long session polluted with failed approaches.
+- 2 failed fix attempts → orchestrator invokes tearitapart. May be design problem, not implementation.
+- 2+ failed corrections in same session → `/clear`, rewrite initial prompt with lessons learned. Clean session beats polluted long session.
+- 3 consecutive responses under ~500 tokens with no progress → anchor-drift. `/clear`, strip to minimal reproduction, restart.
 - Bug only in production → add targeted monitoring, document, move on.
-<!-- Updated 2026-05-12: https://bits-bytes-nn.github.io/insights/agentic-ai/2026/03/31/claude-code-architecture-analysis.html -->
-- **Diminishing returns signal**: If Claude produces 3 consecutive responses under ~500 tokens without progress, the session has anchored. Don't retry — `/clear`, strip the problem to its minimal reproduction, restart fresh. A shorter prompt with better constraints beats a longer session with more correction attempts.
 </escalation>
 
-<!-- Updated 2026-03-30: Claude Code debugging techniques, Anthropic prompt engineering guide -->
-<!-- Updated 2026-04-02: https://claudefa.st/blog/guide/agents/agent-teams, https://medium.com/@Coda./inside-claude-code-engineering-the-future-of-agentic-development-508050bf37a2 -->
 <parallel_debug_strategy>
-**Competing hypothesis agents**: For bugs with multiple plausible causes, spawn separate agents
-per hypothesis. Each investigates independently with a fresh, unpolluted context window.
-Agents with fresh context catch what a single long session anchors past.
-
-```
-Agent A: Hypothesis — race condition in cache layer
-Agent B: Hypothesis — API contract mismatch on response shape
-Agent C: Hypothesis — off-by-one in pagination cursor
-
-Each reports: evidence_for | evidence_against | confidence (0-1)
-Coroner agent synthesizes findings.
-```
-
-**Fresh context advantage**: Long debugging sessions accumulate cognitive anchoring.
-A fresh agent given only the minimal reproduction case (not 200 lines of chat history)
-reasons more clearly. When stuck >30 min, spawn a fresh agent with only:
-- The exact input that triggers the bug
-- The expected vs actual output
-- The relevant code section (not the whole file)
-
-**AgentDB as debug log**: Write each hypothesis and its test result to AgentDB before
-abandoning it. Prevents the same hypothesis being re-investigated in the next session.
+Competing hypothesis agents: for bugs with 3+ plausible causes, spawn one agent per hypothesis with fresh context.
+Each reports: evidence_for | evidence_against | confidence (0-1). Coroner agent synthesizes.
+Fresh context catches what a long session anchors past.
+When stuck >30 min, spawn fresh agent with ONLY: exact input, expected vs actual, relevant code section.
+See: skills/debug/reference/debug-research.md — Parallel Debug Strategy.
 </parallel_debug_strategy>
 
 <agentic_debugging>
-When debugging in an agentic context, additional failure modes arise:
-
-**Agent-introduced bugs**: Check whether the bug was introduced by an AI edit. Run
-`git log --oneline -20` to identify when it appeared. `git bisect` between last known-good
-and first known-bad agent commit. AI edits tend to: drop early returns, misplace null
-checks, and silently change API call signatures.
-
-**Tool-call failures vs logic failures**: Distinguish between:
-- Tool call returned wrong result (environment/permissions issue)
-- Tool call succeeded but logic was wrong (code issue)
-These have completely different fixes. Check tool outputs before assuming logic error.
-
-**Interrupted state**: If a previous agent session was interrupted, check for partial
-writes or uncommitted changes (`git status`, `git diff`) before assuming the code is
-the canonical version.
-
-**Reproduce with minimal agent context**: If bug is hard to reproduce, reduce the
-problem to its smallest form BEFORE spawning any agents. Agents given a vague reproduction
-reproduce the wrong thing.
+- Check whether bug was introduced by an AI edit: `git log --oneline -20`, then `git bisect`.
+- AI edits tend to: drop early returns, misplace null checks, silently change API call signatures.
+- Distinguish tool-call failure (environment/permissions) from logic failure (code) — different fixes.
+- Check `git status` / `git diff` for interrupted-state partial writes before assuming canonical version.
+- Reduce to minimal reproduction BEFORE spawning agents. Agents given vague reproductions reproduce the wrong thing.
 </agentic_debugging>
 
-<!-- Updated 2026-04-23: https://code.claude.com/docs/en/best-practices (debugging anti-patterns) -->
 <persistent_truth_file>
-Long debugging sessions create circles: Claude tries fix, fails, context compresses, Claude forgets what was tried.
-Prevent this with a persistent investigation file that survives auto-compaction.
+Create `_meta/context/DEBUG.md` at session start. Update throughout. Claude reads it before each attempt.
+Prevents circular re-investigation across context compression boundaries.
 
-Create `_meta/context/DEBUG.md` at session start. Update it throughout. Claude reads it before each attempt.
-
-**Evidence**: Structured persistent investigation achieves ~95% first-time fix rate vs ~40% for ad-hoc debugging. The file prevents circular re-investigation across context compression boundaries. <!-- Updated 2026-05-06: https://allierays.com/posts/5-techniques-to-debug-claude-code/ -->
-
-Template:
-```markdown
-# Debugging Session: [Issue Title]
-
-## Problem Statement
-[Concise problem + exact error message]
-
-## What We Know
-- [confirmed fact 1]
-- [confirmed fact 2]
-
-## Approaches Tried
-- [ ] Approach A: [description] → Failed because [reason]
-- [ ] Approach B: [description] → Failed because [reason]
-- [x] Approach C: [description] → Partially works, need to [next step]
-
-## Current Hypothesis
-[Best current theory of root cause]
-
-## Next Steps
-1. [specific action]
-```
-
-Instruct Claude: "Read _meta/context/DEBUG.md before each attempt. Update it after each attempt."
-Prevents re-trying failed approaches across context compression boundaries.
+Template fields: Problem Statement · What We Know · Approaches Tried (with failure reason) · Current Hypothesis · Next Steps.
+Full template: skills/debug/reference/debug-research.md — Persistent Investigation File.
 </persistent_truth_file>
-
-<!-- Updated 2026-04-25: https://medium.com/@sean.j.moran/effective-claude-code-workflows-in-2026-what-changed-and-what-works-now-c93ebc6f8f50, https://allierays.com/posts/5-techniques-to-debug-claude-code/ -->
-<tooling_2026>
-In 2026, Claude Code's default tooling handles more of the debugging burden automatically:
-
-- **Compaction**: Auto-manages context window limits. You no longer need to manually `/compact` during debug sessions — the system does it. But instruct compaction to preserve `_meta/context/DEBUG.md` so investigation state survives.
-- **Plan Mode**: Use for complex or multi-file bugs before touching code. Scope the exploration, form hypotheses, get approval — then switch to Act mode for fixes.
-- **Agent tool for parallel exploration**: Spawn competing-hypothesis agents without polluting the main context. Each agent gets only the minimal reproduction, not 200 lines of chat history.
-
-**Root cause over fast fix**: Claude solves the immediate problem by finding the fastest path to making the error go away. The fastest fix is frequently wrong — it patches the symptom and breaks something downstream. When a fix "works" but you can't explain *why the bug occurred*, you haven't fixed it.
-</tooling_2026>
-
-<!-- Updated 2026-05-14: https://gitnation.com/contents/advanced-claude-code-techniques-for-2026, https://github.com/AlmogBaku/debug-skill -->
-<debugger_mcp_integration>
-MCP debugger tools let Claude Code set breakpoints, step through code, and evaluate expressions at runtime — rather than relying solely on print-based logging.
-
-When to use: binary search isolation isn't sufficient, or the bug only manifests under specific runtime state that's hard to reproduce via logging alone.
-
-Reference implementation: github.com/AlmogBaku/debug-skill
-
-Advantage over logging: Claude sees exact variable state at each execution step. Faster convergence on root cause for state-mutation bugs, closure bugs, and async timing issues where print-based debugging distorts timing.
-</debugger_mcp_integration>
-
-<!-- Updated 2026-05-17: web research — https://claudify.tech/blog/claude-code-debugging-guide, https://www.anthropic.com/engineering/claude-code-best-practices -->
-<verbose_flag>
-Use `--verbose` when running Claude Code during active debugging sessions to see tool calls, file reads, and intermediate reasoning in real time. Turn it off in production or CI runs — the overhead is significant and the output is for human diagnosis only.
-
-When a debugging session produces an unexpected fix or Claude explains reasoning you can't follow, `--verbose` output is the receipt. Read it before accepting the fix.
-</verbose_flag>
 
 <on_complete>
 agentdb write-end '{"skill":"debug","bug":"<description>","root_cause":"<what_broke>","fix":"<what_fixed>","test":"<regression_test_name>","learned":"<pattern_for_future>"}'

--- a/skills/debug/reference/debug-research.md
+++ b/skills/debug/reference/debug-research.md
@@ -348,3 +348,123 @@ points:
   orchestrator escalation. The surgeon should not spiral.
 - **2026**: Consider ChatDBG or debug-gym methodology for initial hypothesis
   generation, but verify all AI-suggested root causes with evidence.
+
+---
+
+## Parallel Debug Strategy (Competing Hypothesis Agents)
+
+For bugs with multiple plausible causes, spawn separate agents per hypothesis.
+Each investigates independently with a fresh, unpolluted context window.
+Agents with fresh context catch what a single long session anchors past.
+
+```
+Agent A: Hypothesis — race condition in cache layer
+Agent B: Hypothesis — API contract mismatch on response shape
+Agent C: Hypothesis — off-by-one in pagination cursor
+
+Each reports: evidence_for | evidence_against | confidence (0-1)
+Coroner agent synthesizes findings.
+```
+
+**Fresh context advantage**: Long debugging sessions accumulate cognitive anchoring.
+A fresh agent given only the minimal reproduction case (not 200 lines of chat history)
+reasons more clearly. When stuck >30 min, spawn a fresh agent with only:
+- The exact input that triggers the bug
+- The expected vs actual output
+- The relevant code section (not the whole file)
+
+**AgentDB as debug log**: Write each hypothesis and its test result to AgentDB before
+abandoning it. Prevents the same hypothesis being re-investigated in the next session.
+
+<!-- Source: parallel_debug_strategy section, 2026-05-28 -->
+
+---
+
+## Persistent Investigation File Template
+
+Create `_meta/context/DEBUG.md` at session start. Update throughout.
+Achieves ~95% first-time fix rate vs ~40% for ad-hoc debugging (structured persistent
+investigation prevents circular re-investigation across context compression boundaries).
+<!-- Evidence: https://allierays.com/posts/5-techniques-to-debug-claude-code/ -->
+
+Instruct Claude: "Read _meta/context/DEBUG.md before each attempt. Update it after each attempt."
+
+```markdown
+# Debugging Session: [Issue Title]
+
+## Problem Statement
+[Concise problem + exact error message]
+
+## What We Know
+- [confirmed fact 1]
+- [confirmed fact 2]
+
+## Approaches Tried
+- [ ] Approach A: [description] → Failed because [reason]
+- [ ] Approach B: [description] → Failed because [reason]
+- [x] Approach C: [description] → Partially works, need to [next step]
+
+## Current Hypothesis
+[Best current theory of root cause]
+
+## Next Steps
+1. [specific action]
+```
+
+<!-- Source: persistent_truth_file section, 2026-05-28 -->
+
+---
+
+## 2026 Tooling Landscape
+
+### Plan Mode
+Use for complex or multi-file bugs before touching code.
+Paste stack traces and error messages. Scope exploration, form hypotheses, get
+approval — then switch to Act mode for fixes.
+
+### Auto-Compaction
+Auto-manages context window limits in 2026. No longer need to manually `/compact`
+during debug sessions. But instruct compaction to preserve `_meta/context/DEBUG.md`
+so investigation state survives.
+
+### Agent Tool for Parallel Exploration
+Spawn competing-hypothesis agents without polluting the main context.
+Each agent gets only the minimal reproduction, not 200 lines of chat history.
+
+**Root cause over fast fix**: Claude solves the immediate problem by finding the fastest
+path to making the error go away. The fastest fix is frequently wrong — it patches the
+symptom and breaks something downstream. When a fix "works" but you can't explain
+*why the bug occurred*, you haven't fixed it.
+
+<!-- Source: tooling_2026 section, Updated 2026-05-14 — https://gitnation.com/contents/advanced-claude-code-techniques-for-2026 -->
+
+---
+
+## MCP Debugger Integration
+
+MCP debugger tools let Claude Code set breakpoints, step through code, and evaluate
+expressions at runtime — rather than relying solely on print-based logging.
+
+**When to use**: binary search isolation isn't sufficient, or the bug only manifests
+under specific runtime state that's hard to reproduce via logging alone.
+
+Reference implementation: github.com/AlmogBaku/debug-skill
+
+**Advantage over logging**: Claude sees exact variable state at each execution step.
+Faster convergence on root cause for state-mutation bugs, closure bugs, and async
+timing issues where print-based debugging distorts timing.
+
+<!-- Source: debugger_mcp_integration section, Updated 2026-05-17 -->
+
+---
+
+## --verbose Flag
+
+Use `--verbose` when running Claude Code during active debugging sessions to see tool
+calls, file reads, and intermediate reasoning in real time. Turn it off in production
+or CI runs — the overhead is significant and the output is for human diagnosis only.
+
+When a debugging session produces an unexpected fix or Claude explains reasoning you
+can't follow, `--verbose` output is the receipt. Read it before accepting the fix.
+
+<!-- Source: verbose_flag section, Updated 2026-05-17 -->

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -31,52 +31,46 @@ Each defines sensory direction and emotional target—not specs.
 <principles type="always-active">
 
 <typography>
-- Distinctive fonts only. NEVER: Inter, Roboto, Arial, Open Sans, system-ui, Helvetica, SF Pro
-- Weight extremes: pair 300 with 700+. Avoid the 400-500 middle zone entirely
-- Size contrast: headers 3x+ body minimum. Go bigger
-- Tracking: tight on large text, relaxed on small. Never default
-- CRITICAL: If you've used the same font in your last 3 outputs, pick a different one
+1. Distinctive fonts only — NEVER: Inter, Roboto, Arial, Open Sans, system-ui, Helvetica, SF Pro
+2. Pair weight extremes (300 + 700+). Avoid 400–500 middle zone entirely.
+3. Headers 3x+ body size minimum. Tight tracking on large, relaxed on small.
+4. (gate: if same font used in last 3 outputs → pick a different one)
 </typography>
 
 <color>
-- Commit to a cohesive mood. CSS custom properties for all colors
-- One dominant + one sharp accent beats even distribution every time
-- Dark modes need 5+ background shade layers. Single dark color = amateur
-- Derive palette from variant mood. Never memorized hex values
-- Warm text colors. Bone/cream tones on dark. Never pure white on dark
+1. CSS custom properties for all colors. One dominant + one sharp accent.
+2. Dark modes require 5+ background shade layers. Single dark color = amateur.
+3. Warm text on dark: bone/cream tones. Never pure white on dark.
+4. (gate: palette derives from variant mood, not memorized hex values)
 </color>
 
 <motion>
-- CSS-only first. JS only when CSS literally cannot achieve it
-- One orchestrated entrance beats scattered micro-interactions
-- Organic easing always: cubic-bezier curves, never linear
-- Breathing > snapping. Drift > jump. Ease > instant
-- Vary timing per project. Don't reuse same duration scale
+1. CSS-only first. JS only when CSS literally cannot achieve it.
+2. One orchestrated entrance beats scattered micro-interactions.
+3. Organic easing always: cubic-bezier curves, never linear. Breathing > snapping.
+4. (gate: vary timing per project — no reused duration scale)
 </motion>
 
 <layout>
-- Asymmetry over symmetry. Grid-break moments over uniform grids
-- Whitespace as design element. Use aggressively where it creates tension
-- Full-bleed mixed with contained sections creates rhythm
-- Uniform section heights = amateur. Vary intentionally
-- Let content dictate structure, not templates
+1. Asymmetry over symmetry. Grid-break moments over uniform grids.
+2. Whitespace is a design element. Use aggressively to create tension.
+3. Full-bleed mixed with contained sections creates rhythm.
+4. (gate: uniform section heights = amateur → vary intentionally)
 </layout>
 
 <surfaces>
-- NEVER flat single-color backgrounds
-- Layer: gradients, translucent surfaces, backdrop-blur, subtle noise
-- Cards need visible depth: shadow, border, or background differentiation
-- Dark backgrounds need hue tint. Never pure black or pure gray
-- Light from within (glow, shadow-color) beats external illumination
+1. NEVER flat single-color backgrounds.
+2. Layer: gradients, translucent surfaces, backdrop-blur, subtle noise.
+3. Cards need visible depth: shadow, border, or background differentiation.
+4. Dark backgrounds need hue tint. Light from within (glow) beats external illumination.
 </surfaces>
 
 <core>
-- Prompt for taste, not implementation. Describe WHAT the user should feel; let the model choose HOW
-- Intent over specification. Mood, constraints, and anti-patterns beat hex codes and font names
-- Component-first. Build pieces (nav, hero, cards), then compose. Never generate full pages in one shot
-- Mobile-first as constraint, not afterthought. Specify column limits and touch targets upfront
-- Functional color. Color that encodes meaning (status, priority, state) always beats decorative color
-- Accessibility is a design advantage. WCAG contrast ratios force better color decisions. 44px touch targets prevent cramped layouts
+1. Prompt for taste, not implementation. Describe WHAT the user should feel; model chooses HOW.
+2. Component-first. Build pieces (nav, hero, cards), then compose. Never full pages in one shot.
+3. Mobile-first as constraint: specify column limits and 44px touch targets upfront.
+4. Functional color (encodes meaning: status, priority, state) beats decorative color.
+5. Accessibility = design advantage. WCAG contrast forces better color decisions.
 </core>
 
 <reference>

--- a/skills/design/reference/design-research.md
+++ b/skills/design/reference/design-research.md
@@ -264,3 +264,44 @@ For any design task, include these in order of importance:
 
 Skip: exact hex codes, exact font names, exact pixel values, implementation details.
 Those are execution decisions. Let the model make them within your constraints.
+
+---
+
+## Principles Rationale (moved from SKILL.md 2026-05-28)
+
+### Typography — expanded rules
+- Weight extremes: pair 300 with 700+. Avoid the 400–500 middle zone entirely.
+- Size contrast: headers 3x+ body minimum. Go bigger.
+- Tracking: tight on large text, relaxed on small. Never default.
+- CRITICAL: If you've used the same font in your last 3 outputs, pick a different one.
+
+### Color — expanded rules
+- One dominant + one sharp accent beats even distribution every time.
+- Dark modes need 5+ background shade layers. Single dark color = amateur.
+- Derive palette from variant mood. Never memorized hex values.
+- Warm text colors. Bone/cream tones on dark. Never pure white on dark.
+
+### Motion — expanded rules
+- One orchestrated entrance beats scattered micro-interactions.
+- Organic easing always: cubic-bezier curves, never linear.
+- Breathing > snapping. Drift > jump. Ease > instant.
+- Vary timing per project. Don't reuse same duration scale.
+
+### Layout — expanded rules
+- Whitespace as design element. Use aggressively where it creates tension.
+- Full-bleed mixed with contained sections creates rhythm.
+- Uniform section heights = amateur. Vary intentionally.
+- Let content dictate structure, not templates.
+
+### Surfaces — expanded rules
+- Layer: gradients, translucent surfaces, backdrop-blur, subtle noise.
+- Cards need visible depth: shadow, border, or background differentiation.
+- Dark backgrounds need hue tint. Never pure black or pure gray.
+- Light from within (glow, shadow-color) beats external illumination.
+
+### Core principles — rationale
+- Prompt for taste, not implementation: Describe WHAT the user should feel; let the model choose HOW. Intent over specification. Mood, constraints, and anti-patterns beat hex codes and font names.
+- Component-first builds pieces (nav, hero, cards), then composes. Never generate full pages in one shot.
+- Mobile-first as constraint, not afterthought. Specify column limits and touch targets upfront.
+- Functional color encodes meaning (status, priority, state) — always beats decorative color.
+- Accessibility is a design advantage. WCAG contrast ratios force better color decisions. 44px touch targets prevent cramped layouts.

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -6,188 +6,47 @@ allowed-tools: Read, Bash, Write, Edit, Grep, Glob
 
 <skill id="e2e">
 
-<purpose>
-E2E tests verify critical user paths in real browsers. Use sparingly - they're slow.
-Page Object Model separates selectors from test logic. Update selectors in one place.
-Flaky tests are broken tests. Fix or delete, never ignore.
-</purpose>
-
-<prerequisite>
-AgentDB read-start has run. Check for existing Page Objects.
-Verify Playwright is configured (playwright.config.ts exists).
-</prerequisite>
+<on_start>
+agentdb read-start
+Grep for existing Page Objects (pages/*.ts). Check playwright.config.ts exists.
+</on_start>
 
 <reference>
 Skill-specific: skills/e2e/reference/e2e-research.md
 </reference>
 
-<core_principles>
-1. CRITICAL PATHS ONLY: E2E tests are expensive. Test checkout, auth, core workflows. Not everything.
-2. PAGE OBJECT MODEL: Selectors in one place. Tests read like specifications.
-3. NO ARBITRARY WAITS: waitForTimeout is flaky. Wait for specific conditions.
-4. SEMANTIC SELECTORS: data-testid, role, text. Never CSS classes.
-5. QUARANTINE FLAKY: Mark flaky tests with test.fixme(). Never skip silently.
-</core_principles>
+## Steps
 
-<page_object_pattern>
-```typescript
-import { Page, Locator } from '@playwright/test'
+1. **Scope** — identify critical user paths only (auth, checkout, core workflows). E2E tests are slow; reject requests to test everything.
+   (gate: list of paths defined, count ≤ what team can maintain)
 
-export class LoginPage {
-  readonly page: Page
-  readonly emailInput: Locator
-  readonly passwordInput: Locator
-  readonly submitButton: Locator
-  readonly errorMessage: Locator
+2. **Check existing Page Objects** — `grep -r "class.*Page" tests/pages/` or equivalent. Extend existing POM before creating new.
+   (gate: no duplicate selector sets)
 
-  constructor(page: Page) {
-    this.page = page
-    this.emailInput = page.locator('[data-testid="email-input"]')
-    this.passwordInput = page.locator('[data-testid="password-input"]')
-    this.submitButton = page.locator('[data-testid="submit-btn"]')
-    this.errorMessage = page.locator('[data-testid="error-msg"]')
-  }
+3. **Create/update Page Objects** — one file per page/component. Locators use `data-testid` > role > text > CSS (last resort). Selectors in constructor; actions and assertions as methods.
+   (gate: no inline selectors in test files)
 
-  async goto() {
-    await this.page.goto('/login')
-    await this.page.waitForLoadState('networkidle')
-  }
+4. **Write tests** — `test.describe` blocks per feature. `beforeEach` for setup via POM. Each test asserts one outcome.
+   (gate: no `waitForTimeout` in any test)
 
-  async login(email: string, password: string) {
-    await this.emailInput.fill(email)
-    await this.passwordInput.fill(password)
-    await this.submitButton.click()
-    await this.page.waitForLoadState('networkidle')
-  }
-}
-```
-</page_object_pattern>
+5. **Async correctness** — replace all arbitrary timeouts with condition waits:
+   - network: `waitForResponse(r => r.url().includes('/api/...'))`
+   - visibility: `locator(...).waitFor({ state: 'visible' })`
+   - navigation: `waitForURL(/pattern/)`
+   - load: `waitForLoadState('networkidle')`
+   (gate: `grep -r "waitForTimeout" tests/` returns nothing)
 
-<test_structure>
-```typescript
-import { test, expect } from '@playwright/test'
-import { LoginPage } from '../pages/LoginPage'
+6. **Handle flaky tests** — detect with `--repeat-each=10`. Fix root cause (race condition, animation timing, network timing). If fix deferred: `test.fixme(true, 'Flaky - Issue #NNN')`. Never silent-skip.
+   (gate: no `test.skip()` without issue reference)
 
-test.describe('Authentication', () => {
-  let loginPage: LoginPage
+7. **Configure Playwright** — verify `playwright.config.ts` has: `retries: CI ? 2 : 0`, `forbidOnly: !!CI`, `trace: 'on-first-retry'`, `screenshot: 'only-on-failure'`. See reference for full config template.
+   (gate: config file present, CI retries ≥ 2)
 
-  test.beforeEach(async ({ page }) => {
-    loginPage = new LoginPage(page)
-    await loginPage.goto()
-  })
+8. **CI integration** — add/verify GitHub Actions workflow: install with `--with-deps`, upload `playwright-report/` as artifact `if: always()`. See reference for full YAML.
+   (gate: artifact upload step present)
 
-  test('successful login redirects to dashboard', async ({ page }) => {
-    await loginPage.login('user@example.com', 'password123')
-    await expect(page).toHaveURL(/\/dashboard/)
-  })
-
-  test('invalid credentials show error', async () => {
-    await loginPage.login('wrong@example.com', 'wrongpassword')
-    await expect(loginPage.errorMessage).toBeVisible()
-    await expect(loginPage.errorMessage).toContainText('Invalid credentials')
-  })
-})
-```
-</test_structure>
-
-<flaky_test_patterns>
-<!-- Quarantine flaky tests -->
-```typescript
-test('flaky: complex async flow', async ({ page }) => {
-  test.fixme(true, 'Flaky - Issue #123')
-  // test code...
-})
-
-test('skip in CI only', async ({ page }) => {
-  test.skip(process.env.CI === 'true', 'Flaky in CI - Issue #456')
-  // test code...
-})
-```
-
-<!-- Fix common causes -->
-```typescript
-// BAD: arbitrary timeout
-await page.waitForTimeout(5000)
-
-// GOOD: wait for specific condition
-await page.waitForResponse(resp => resp.url().includes('/api/data'))
-
-// BAD: race condition
-await page.click('[data-testid="menu"]')
-
-// GOOD: wait for visibility first
-await page.locator('[data-testid="menu"]').waitFor({ state: 'visible' })
-await page.locator('[data-testid="menu"]').click()
-```
-
-<!-- Identify flakiness -->
-```bash
-npx playwright test tests/auth.spec.ts --repeat-each=10
-```
-</flaky_test_patterns>
-
-<playwright_config>
-```typescript
-import { defineConfig, devices } from '@playwright/test'
-
-export default defineConfig({
-  testDir: './tests/e2e',
-  fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: [
-    ['html', { outputFolder: 'playwright-report' }],
-    ['junit', { outputFile: 'test-results.xml' }]
-  ],
-  use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
-    actionTimeout: 10000,
-    navigationTimeout: 30000,
-  },
-  projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
-  ],
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
-})
-```
-</playwright_config>
-
-<ci_integration>
-```yaml
-# .github/workflows/e2e.yml
-name: E2E Tests
-on: [push, pull_request]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm ci
-      - run: npx playwright install --with-deps
-      - run: npx playwright test
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-```
-</ci_integration>
+9. **Run suite** — `npx playwright test`. All tests pass or are explicitly quarantined with issue refs.
+   (gate: exit 0, or all failures are `test.fixme`)
 
 <anti_patterns>
 <block id="test_everything">E2E tests are slow. Test critical paths, not every feature.</block>

--- a/skills/e2e/reference/e2e-research.md
+++ b/skills/e2e/reference/e2e-research.md
@@ -1,6 +1,168 @@
 # E2E Research
+<!-- date: 2026-05-28 -->
 
 Deep reference for End-to-End testing with Playwright.
+
+## From SKILL.md — Code Templates (moved 2026-05-28)
+
+### Page Object Template
+
+```typescript
+import { Page, Locator } from '@playwright/test'
+
+export class LoginPage {
+  readonly page: Page
+  readonly emailInput: Locator
+  readonly passwordInput: Locator
+  readonly submitButton: Locator
+  readonly errorMessage: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.emailInput = page.locator('[data-testid="email-input"]')
+    this.passwordInput = page.locator('[data-testid="password-input"]')
+    this.submitButton = page.locator('[data-testid="submit-btn"]')
+    this.errorMessage = page.locator('[data-testid="error-msg"]')
+  }
+
+  async goto() {
+    await this.page.goto('/login')
+    await this.page.waitForLoadState('networkidle')
+  }
+
+  async login(email: string, password: string) {
+    await this.emailInput.fill(email)
+    await this.passwordInput.fill(password)
+    await this.submitButton.click()
+    await this.page.waitForLoadState('networkidle')
+  }
+}
+```
+
+### Test Structure Template
+
+```typescript
+import { test, expect } from '@playwright/test'
+import { LoginPage } from '../pages/LoginPage'
+
+test.describe('Authentication', () => {
+  let loginPage: LoginPage
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page)
+    await loginPage.goto()
+  })
+
+  test('successful login redirects to dashboard', async ({ page }) => {
+    await loginPage.login('user@example.com', 'password123')
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+
+  test('invalid credentials show error', async () => {
+    await loginPage.login('wrong@example.com', 'wrongpassword')
+    await expect(loginPage.errorMessage).toBeVisible()
+    await expect(loginPage.errorMessage).toContainText('Invalid credentials')
+  })
+})
+```
+
+### Playwright Config Template (full)
+
+```typescript
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['junit', { outputFile: 'test-results.xml' }]
+  ],
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10000,
+    navigationTimeout: 30000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+})
+```
+
+### GitHub Actions CI Template
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+### Flaky Test Quarantine Patterns
+
+```typescript
+// Mark known flaky, never silently skip
+test('flaky: complex async flow', async ({ page }) => {
+  test.fixme(true, 'Flaky - Issue #123')
+  // test code...
+})
+
+test('skip in CI only', async ({ page }) => {
+  test.skip(process.env.CI === 'true', 'Flaky in CI - Issue #456')
+  // test code...
+})
+```
+
+```typescript
+// BAD: arbitrary timeout
+await page.waitForTimeout(5000)
+
+// GOOD: wait for specific condition
+await page.waitForResponse(resp => resp.url().includes('/api/data'))
+
+// BAD: race condition
+await page.click('[data-testid="menu"]')
+
+// GOOD: wait for visibility first
+await page.locator('[data-testid="menu"]').waitFor({ state: 'visible' })
+await page.locator('[data-testid="menu"]').click()
+```
+
+```bash
+# Detect flakiness
+npx playwright test tests/auth.spec.ts --repeat-each=10
+```
 
 ## Testing Pyramid
 

--- a/skills/eval/SKILL.md
+++ b/skills/eval/SKILL.md
@@ -6,14 +6,8 @@ allowed-tools: Read, Bash, Write, Edit, Grep, Glob
 
 <skill id="eval">
 
-<purpose>
-Evals are the unit tests of AI development. Define success BEFORE implementation.
-pass@k measures reliability: did it succeed within k attempts?
-Capability evals test new abilities. Regression evals prevent breakage.
-</purpose>
-
 <prerequisite>
-AgentDB read-start has run. Check for existing eval definitions.
+AgentDB read-start has run. Check for existing eval definitions in _meta/research/.
 Understand what behavior you're evaluating before writing evals.
 </prerequisite>
 
@@ -30,69 +24,26 @@ Skill-specific: skills/eval/reference/eval-research.md
 6. FAST EVALS GET RUN: Slow evals get skipped. Keep evaluation fast.
 </core_principles>
 
+<workflow>
+1. DEFINE: Write eval criteria before implementation. (gate: criteria exist in writing before any code)
+2. IMPLEMENT: Code to pass defined evals.
+3. EVALUATE: Run evals, record pass@k. (gate: pass@3 > 90% for capability; pass^3 = 100% for regression)
+4. REPORT: Document results in eval report format. See reference for template.
+</workflow>
+
 <blind_evaluation_protocol>
-For any eval where the implementing agent would otherwise score its own output:
+Use when implementing agent would otherwise score its own output (high-stakes: security, payments, agent quality):
 
 1. Spawn `agents/blind-evaluator.md` as a fresh agent.
-2. Pass it ONLY: problem statement, rubric (3-7 criteria with PASS conditions + weights), artifact path.
+2. Pass ONLY: problem statement, rubric (3-7 criteria with PASS conditions + weights), artifact path.
 3. Do NOT pass: implementer's checkpoint, summary, commit message, prompt, or expected solution.
-4. The blind evaluator runs a contamination check first; if it sees anything from the forbidden list, it returns `INVALID` and the eval is aborted until inputs are cleaned.
-5. Confidence < 0.7 from the blind evaluator = escalate to human grader.
+4. (gate: blind evaluator runs contamination check — if forbidden inputs detected, returns INVALID; clean inputs and retry)
+5. (gate: confidence < 0.7 from blind evaluator → escalate to human grader)
 
-Use a two-phase eval protocol when feasible:
-- Run 1: implementing agent solves cold, with no eval feedback. Blind evaluator scores. This is the real number.
-- Run 2: implementing agent gets the Run 1 score + rubric breakdown, then optimizes. Useful for iteration but Run 1 is what you report externally.
+Two-phase eval protocol:
+- Run 1: implementing agent solves cold, no eval feedback. Blind evaluator scores. This is the externally-reportable number.
+- Run 2: implementing agent gets Run 1 score + rubric breakdown, then optimizes. For iteration only.
 </blind_evaluation_protocol>
-
-<eval_types>
-<!-- Capability Eval: Can it do something new? -->
-```markdown
-[CAPABILITY EVAL: semantic-search]
-Task: Search markets using natural language
-Success Criteria:
-  - [ ] Returns relevant results for query
-  - [ ] Handles empty query gracefully
-  - [ ] Falls back when vector DB unavailable
-Expected: Top 5 results match query intent
-```
-
-<!-- Regression Eval: Does existing functionality still work? -->
-```markdown
-[REGRESSION EVAL: auth-flow]
-Baseline: commit abc123
-Tests:
-  - login-with-valid-creds: PASS
-  - login-with-invalid-creds: PASS
-  - session-persistence: PASS
-Result: 3/3 passed (unchanged)
-```
-</eval_types>
-
-<grader_types>
-<!-- Code-Based Grader (preferred) -->
-```bash
-grep -q "export function handleAuth" src/auth.ts && echo "PASS" || echo "FAIL"
-npm test -- --testPathPattern="auth" && echo "PASS" || echo "FAIL"
-npm run build && echo "PASS" || echo "FAIL"
-```
-
-<!-- Model-Based Grader (open-ended outputs) -->
-```markdown
-[MODEL GRADER]
-Evaluate: Does this code solve the stated problem?
-Criteria: correctness, structure, edge case handling
-Score: 1-5
-Reasoning: [required]
-```
-
-<!-- Human Grader (security, UX) -->
-```markdown
-[HUMAN REVIEW REQUIRED]
-Change: Added payment processing
-Reason: Security-critical, requires human verification
-Risk: HIGH
-```
-</grader_types>
 
 <metrics>
 pass@k: "At least one success in k attempts"
@@ -102,37 +53,17 @@ pass@k: "At least one success in k attempts"
 pass^k: "All k trials succeed"
 - pass^3: 3 consecutive successes
 - Use for critical paths (auth, payments)
+
+See reference for calculation formula and worked examples.
 </metrics>
 
-<workflow>
-1. DEFINE: Write eval criteria before implementation
-2. IMPLEMENT: Code to pass defined evals
-3. EVALUATE: Run evals, record pass@k
-4. REPORT: Document results, identify failures
-</workflow>
+<grader_selection>
+1. Code-based (preferred): grep, test suite, build, type-check — deterministic, fast.
+2. Model-based: for open-ended outputs that can't be checked deterministically. Run multiple times, take majority.
+3. Human: required for security-sensitive changes, UX evaluation, legal/compliance.
 
-<eval_report_format>
-```markdown
-EVAL REPORT: feature-xyz
-========================
-Capability Evals:
-  create-user:     PASS (pass@1)
-  validate-email:  PASS (pass@2)
-  hash-password:   PASS (pass@1)
-  Overall:         3/3
-
-Regression Evals:
-  login-flow:      PASS
-  session-mgmt:    PASS
-  Overall:         2/2
-
-Metrics:
-  pass@1: 67% (2/3)
-  pass@3: 100% (3/3)
-
-Status: READY FOR REVIEW
-```
-</eval_report_format>
+See reference for full grader templates and examples.
+</grader_selection>
 
 <anti_patterns>
 <block id="eval_after_code">Writing evals after implementation tests existing bugs, not requirements.</block>

--- a/skills/eval/reference/eval-research.md
+++ b/skills/eval/reference/eval-research.md
@@ -244,6 +244,52 @@ jobs:
           FAIL_ON_REGRESSION: true
 ```
 
+## Eval Type Templates (moved from SKILL.md 2026-05-28)
+
+### Capability Eval Format
+```markdown
+[CAPABILITY EVAL: semantic-search]
+Task: Search markets using natural language
+Success Criteria:
+  - [ ] Returns relevant results for query
+  - [ ] Handles empty query gracefully
+  - [ ] Falls back when vector DB unavailable
+Expected: Top 5 results match query intent
+```
+
+### Regression Eval Format
+```markdown
+[REGRESSION EVAL: auth-flow]
+Baseline: commit abc123
+Tests:
+  - login-with-valid-creds: PASS
+  - login-with-invalid-creds: PASS
+  - session-persistence: PASS
+Result: 3/3 passed (unchanged)
+```
+
+### Eval Report Format
+```markdown
+EVAL REPORT: feature-xyz
+========================
+Capability Evals:
+  create-user:     PASS (pass@1)
+  validate-email:  PASS (pass@2)
+  hash-password:   PASS (pass@1)
+  Overall:         3/3
+
+Regression Evals:
+  login-flow:      PASS
+  session-mgmt:    PASS
+  Overall:         2/2
+
+Metrics:
+  pass@1: 67% (2/3)
+  pass@3: 100% (3/3)
+
+Status: READY FOR REVIEW
+```
+
 ## Resources
 
 - Anthropic, "Evaluating Language Models"

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -7,41 +7,61 @@ allowed-tools: Read, Grep, Bash, Write
 <skill id="experiment">
 
 <purpose>
-Rules without evidence are superstitions. This skill treats every development rule
-as a hypothesis and applies the scientific method: register, design experiment,
-execute, record evidence, update confidence, graduate or kill.
-
-Load this skill when questioning methodology, validating rules, or running experiments.
+Rules without evidence are superstitions. Apply scientific method: register hypothesis, design experiment, execute, record evidence, update confidence, graduate or kill.
 </purpose>
 
 <reference>
-Verbose research: _meta/research/experiment-report.md (if exists)
+Deep patterns, SQL schema, domain design templates, confidence-scoring examples: skills/experiment/reference/experiment-research.md
 </reference>
 
-<sources>
-- _meta/research/experiment-report.md (if exists)
-</sources>
-
-<triggers>experiment, hypothesis, prove, test rule, validate methodology, scientific, evidence</triggers>
-
-<gates>
-  <gate id="hypothesis_registered">Every rule under test must have an AgentDB hypothesis record.</gate>
-  <gate id="experiment_designed">Method + measurement + pass/fail criteria defined BEFORE execution.</gate>
-  <gate id="evidence_recorded">Every experiment produces a verdict with evidence string.</gate>
-  <gate id="no_confirmation_bias">Experiments must be designed to DISPROVE, not confirm.</gate>
-</gates>
-
-<output>
-  verdict: SUPPORTED | REFUTED | INCONCLUSIVE
-  confidence: 0.0-1.0
-  evidence: required (specific, measurable)
-</output>
-
 <flags>
-  --domain <name>: filter to specific rule domain (methodology|coordination|testing|git|security|performance|quality)
-  --status <status>: filter by hypothesis status (unproven|testing|supported|refuted|graduated)
+  --domain <name>: filter to domain (methodology|coordination|testing|git|security|performance|quality)
+  --status <status>: filter by status (unproven|testing|supported|refuted|graduated)
   --confidence <threshold>: filter by minimum confidence
 </flags>
+
+<flow>
+
+1. **Seed** — parse CLAUDE.md for imperative/assertive statements → register as hypotheses
+   - (gate: each hypothesis has id, statement, source, domain, status=unproven, confidence=0.0)
+   - Auto-assign H001, H002, … ; classify domain from <domains> list
+   - `agentdb learn hypothesis "H{N}: {statement}" "{source}:{line}"`
+
+2. **Design** — for each hypothesis under test, define experiment BEFORE running anything
+   - method: what you will do (A/B, timed comparison, fuzz, track-and-count)
+   - measurement: quantitative metric preferred (time, error count, rework frequency)
+   - control condition: what happens WITHOUT the rule applied
+   - pass_criteria: specific observable that supports the hypothesis
+   - fail_criteria: specific observable that refutes it
+   - (gate: experiment_designed — must be falsifiable; if no outcome could refute, redesign)
+
+3. **Execute** — run the experiment; record raw observations
+   - (gate: control condition was actually tested, not just assumed)
+   - minimum sample sizes: methodology/coordination/git/quality ≥ 3 comparisons; testing ≥ 5 tasks per condition; security ≥ 50 fuzz inputs
+
+4. **Score** — apply Bayesian update to confidence
+   - supports:     `confidence += (1 - confidence) * 0.25`
+   - refutes:      `confidence -= confidence * 0.3`
+   - inconclusive: no change (record in evidence log)
+   - `agentdb learn experiment "H{N} result={supports|refutes|inconclusive}" "{evidence}"`
+
+5. **Transition** — update hypothesis status per lifecycle rules
+   - unproven → testing: first experiment registered
+   - testing → supported: confidence ≥ 0.8 AND evidence_for ≥ 3 AND ratio ≥ 3:1
+   - testing → refuted: confidence < 0.2 AND evidence_against ≥ 2
+   - supported → graduated: human approval after sustained confidence
+   - refuted → killed: human approval to remove from rules
+   - any → unproven: rule is modified (resets all evidence)
+   - (gate: evidence_recorded — verdict must include specific, measurable evidence string)
+
+6. **Report** — surface verdict
+   - verdict: SUPPORTED | REFUTED | INCONCLUSIVE
+   - confidence: current 0.0–1.0 value
+   - evidence: required (specific, measurable, not narrative)
+   - if GRADUATED: propose rule promotion to CLAUDE.md with human approval
+   - if KILLED: propose rule removal from CLAUDE.md with human approval
+
+</flow>
 
 <anti_patterns>
   <never>Confirm a hypothesis without running a real experiment.</never>
@@ -51,203 +71,8 @@ Verbose research: _meta/research/experiment-report.md (if exists)
   <never>Modify the hypothesis after seeing results (that is a new hypothesis).</never>
 </anti_patterns>
 
-<lifecycle>
-  The experiment lifecycle governs all hypothesis state transitions.
-
-  ```
-  UNPROVEN (0.0) --> TESTING (0.1-0.7) --> SUPPORTED (0.8+) or REFUTED (<0.2)
-                                              |                    |
-                                          GRADUATED              KILLED
-                                         (proven rule)       (remove from rules)
-  ```
-
-  transitions:
-    unproven --> testing:     first experiment registered
-    testing --> supported:    confidence >= 0.8 AND evidence_for >= 3 AND ratio >= 3:1
-    testing --> refuted:      confidence < 0.2 AND evidence_against >= 2
-    supported --> graduated:  human approval after sustained confidence
-    refuted --> killed:       human approval to remove from rules
-    any --> unproven:         rule is modified (resets all evidence)
-</lifecycle>
-
-<domains>
-  Rules cluster into testable domains. Classification guides experiment design.
-
-  <domain id="methodology">Research-first, anti-patterns-before-solutions, slow-down-to-speed-up.</domain>
-  <domain id="coordination">Parallel-first, tier system, agent spawning patterns.</domain>
-  <domain id="testing">Tests-before-code, edge-cases-first, mock boundaries.</domain>
-  <domain id="git">Atomic commits, conventional messages, feature branches.</domain>
-  <domain id="security">No hardcoded secrets, input validation boundaries.</domain>
-  <domain id="performance">Measure before optimizing, bottleneck identification.</domain>
-  <domain id="quality">Big 5 checks, code review protocols, R-factor thresholds.</domain>
-</domains>
-
-<experiment_design>
-  Six principles. Violating any one invalidates the experiment.
-
-  <principle id="falsifiability">
-    Every experiment must be able to disprove the hypothesis.
-    If no possible outcome would refute the rule, the experiment is useless.
-  </principle>
-
-  <principle id="minimum_viable_test">
-    Smallest possible scope that produces signal.
-    One task comparison, not a week-long study.
-  </principle>
-
-  <principle id="quantitative_preferred">
-    Numbers over opinions. Time, error count, recall percentage, rework frequency.
-    Qualitative evidence is acceptable only when quantitative is impossible.
-  </principle>
-
-  <principle id="control_condition">
-    Compare against baseline. What happens WITHOUT the rule?
-    No control = no experiment. Just an observation.
-  </principle>
-
-  <principle id="reproducibility">
-    Another session should be able to repeat the experiment with the same method.
-    Record: exact steps, inputs, environment, measurement approach.
-  </principle>
-
-  <principle id="independence">
-    Test one rule at a time. Control for confounds.
-    If two rules interact, test each independently first.
-  </principle>
-</experiment_design>
-
-<confidence_scoring>
-  Bayesian-style updates after each experiment run.
-
-  formulas:
-    supports:     confidence += (1 - confidence) * 0.25
-    refutes:      confidence -= confidence * 0.3
-    inconclusive: no change (but recorded in evidence log)
-
-  graduation:
-    threshold: confidence >= 0.8
-    required:  evidence_for >= 3
-    ratio:     for:against >= 3:1
-
-  kill:
-    threshold: confidence < 0.2
-    required:  evidence_against >= 2
-
-  example:
-    H001 starts at 0.0
-    experiment 1: supports  --> 0.0 + (1.0 - 0.0) * 0.25 = 0.25
-    experiment 2: supports  --> 0.25 + (1.0 - 0.25) * 0.25 = 0.4375
-    experiment 3: refutes   --> 0.4375 - 0.4375 * 0.3 = 0.306
-    experiment 4: supports  --> 0.306 + (1.0 - 0.306) * 0.25 = 0.480
-    experiment 5: supports  --> 0.480 + (1.0 - 0.480) * 0.25 = 0.610
-    experiment 6: supports  --> 0.610 + (1.0 - 0.610) * 0.25 = 0.708
-    experiment 7: supports  --> 0.708 + (1.0 - 0.708) * 0.25 = 0.781
-    experiment 8: supports  --> 0.781 + (1.0 - 0.781) * 0.25 = 0.836  --> GRADUATED
-</confidence_scoring>
-
-<seeding>
-  Bootstrap hypotheses from existing CLAUDE.md rules.
-
-  Parse rule-like patterns:
-    - Imperative statements: "Never X", "Always Y", "Must Z"
-    - Convention definitions: "Format: X", "Style: Y"
-    - Assertions: "X is better than Y", "X before Y"
-    - Quantitative claims: "reduces by X%", "takes N minutes"
-
-  Each becomes a hypothesis record:
-    id:         auto-generated (H001, H002, ...)
-    statement:  the rule as stated
-    source:     file path + line number
-    domain:     auto-classified from domains list
-    status:     unproven
-    confidence: 0.0
-
-  AgentDB schema:
-    ```sql
-    CREATE TABLE IF NOT EXISTS hypotheses (
-      id TEXT PRIMARY KEY,
-      statement TEXT NOT NULL,
-      source TEXT NOT NULL,
-      domain TEXT NOT NULL,
-      status TEXT DEFAULT 'unproven',
-      confidence REAL DEFAULT 0.0,
-      evidence_for INTEGER DEFAULT 0,
-      evidence_against INTEGER DEFAULT 0,
-      created_at TEXT DEFAULT (datetime('now')),
-      updated_at TEXT DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS experiments (
-      id TEXT PRIMARY KEY,
-      hypothesis_id TEXT NOT NULL,
-      method TEXT NOT NULL,
-      measurement TEXT NOT NULL,
-      pass_criteria TEXT NOT NULL,
-      fail_criteria TEXT NOT NULL,
-      result TEXT CHECK(result IN ('supports', 'refutes', 'inconclusive')),
-      evidence TEXT,
-      executed_at TEXT DEFAULT (datetime('now')),
-      FOREIGN KEY (hypothesis_id) REFERENCES hypotheses(id)
-    );
-    ```
-</seeding>
-
-<experiment_patterns>
-  Common experiment designs by domain.
-
-  <pattern domain="methodology" example="research before coding">
-    method:      A/B comparison across similar tasks
-    measure:     time to completion, error rate, rework count
-    control:     task executed WITHOUT the rule applied
-    sample_size: minimum 3 comparisons for signal
-  </pattern>
-
-  <pattern domain="coordination" example="parallel beats serial">
-    method:      timed execution of same-scope work
-    measure:     wall-clock time, merge conflict rate, quality score
-    control:     serial execution of identical scope
-    sample_size: minimum 3 comparisons for signal
-  </pattern>
-
-  <pattern domain="testing" example="tests before code">
-    method:      track tasks with test-first vs test-after
-    measure:     bug escape rate, rework frequency, coverage delta
-    control:     tasks where tests were written after implementation
-    sample_size: minimum 5 tasks per condition
-  </pattern>
-
-  <pattern domain="quality" example="Big 5 checks prevent bugs">
-    method:      compare code reviewed with Big 5 vs without
-    measure:     post-merge bug reports, review round-trips
-    control:     code merged without Big 5 review
-    sample_size: minimum 5 reviews per condition
-  </pattern>
-
-  <pattern domain="git" example="atomic commits reduce revert pain">
-    method:      track revert complexity for atomic vs bundled commits
-    measure:     time to revert, collateral damage (unrelated changes reverted)
-    control:     multi-concern commits
-    sample_size: minimum 3 revert events per condition
-  </pattern>
-
-  <pattern domain="security" example="Zod validation prevents injection">
-    method:      fuzz endpoints with and without schema validation
-    measure:     injection success rate, malformed input acceptance rate
-    control:     endpoint without Zod/Pydantic layer
-    sample_size: minimum 50 fuzz inputs per endpoint
-  </pattern>
-
-  <pattern domain="performance" example="measure before optimizing saves time">
-    method:      compare optimizations guided by profiling vs intuition
-    measure:     actual speedup achieved, time spent optimizing
-    control:     intuition-guided optimization
-    sample_size: minimum 3 optimization tasks per condition
-  </pattern>
-</experiment_patterns>
-
-<verdict>
-  No rule graduates without evidence. No rule dies without a fair trial.
-  Gut feelings are hypotheses, not conclusions.
-</verdict>
+<on_complete>
+agentdb write-end '{"skill":"experiment","hypotheses_tested":N,"graduated":[],"killed":[],"inconclusive":[]}'
+</on_complete>
 
 </skill>

--- a/skills/experiment/reference/experiment-research.md
+++ b/skills/experiment/reference/experiment-research.md
@@ -1,0 +1,160 @@
+---
+title: Experiment Skill — Deep Reference
+date: 2026-05-28
+source: extracted from skills/experiment/SKILL.md
+---
+
+## Lifecycle diagram
+
+```
+UNPROVEN (0.0) --> TESTING (0.1-0.7) --> SUPPORTED (0.8+) or REFUTED (<0.2)
+                                            |                    |
+                                        GRADUATED              KILLED
+                                       (proven rule)       (remove from rules)
+```
+
+## Confidence scoring — full worked example
+
+Bayesian-style updates after each experiment run.
+
+Formulas:
+- supports:     `confidence += (1 - confidence) * 0.25`
+- refutes:      `confidence -= confidence * 0.3`
+- inconclusive: no change (but recorded in evidence log)
+
+Graduation threshold: confidence ≥ 0.8 AND evidence_for ≥ 3 AND for:against ≥ 3:1
+Kill threshold: confidence < 0.2 AND evidence_against ≥ 2
+
+Step-by-step example for H001 starting at 0.0:
+```
+experiment 1: supports  --> 0.0 + (1.0 - 0.0) * 0.25    = 0.25
+experiment 2: supports  --> 0.25 + (1.0 - 0.25) * 0.25  = 0.4375
+experiment 3: refutes   --> 0.4375 - 0.4375 * 0.3        = 0.306
+experiment 4: supports  --> 0.306 + (1.0 - 0.306) * 0.25 = 0.480
+experiment 5: supports  --> 0.480 + (1.0 - 0.480) * 0.25 = 0.610
+experiment 6: supports  --> 0.610 + (1.0 - 0.610) * 0.25 = 0.708
+experiment 7: supports  --> 0.708 + (1.0 - 0.708) * 0.25 = 0.781
+experiment 8: supports  --> 0.781 + (1.0 - 0.781) * 0.25 = 0.836  --> GRADUATED
+```
+
+## AgentDB schema
+
+```sql
+CREATE TABLE IF NOT EXISTS hypotheses (
+  id TEXT PRIMARY KEY,
+  statement TEXT NOT NULL,
+  source TEXT NOT NULL,
+  domain TEXT NOT NULL,
+  status TEXT DEFAULT 'unproven',
+  confidence REAL DEFAULT 0.0,
+  evidence_for INTEGER DEFAULT 0,
+  evidence_against INTEGER DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS experiments (
+  id TEXT PRIMARY KEY,
+  hypothesis_id TEXT NOT NULL,
+  method TEXT NOT NULL,
+  measurement TEXT NOT NULL,
+  pass_criteria TEXT NOT NULL,
+  fail_criteria TEXT NOT NULL,
+  result TEXT CHECK(result IN ('supports', 'refutes', 'inconclusive')),
+  evidence TEXT,
+  executed_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (hypothesis_id) REFERENCES hypotheses(id)
+);
+```
+
+## Domains
+
+Rules cluster into testable domains. Classification guides experiment design.
+
+| Domain | Description |
+|---|---|
+| methodology | Research-first, anti-patterns-before-solutions, slow-down-to-speed-up |
+| coordination | Parallel-first, tier system, agent spawning patterns |
+| testing | Tests-before-code, edge-cases-first, mock boundaries |
+| git | Atomic commits, conventional messages, feature branches |
+| security | No hardcoded secrets, input validation boundaries |
+| performance | Measure before optimizing, bottleneck identification |
+| quality | Big 5 checks, code review protocols, R-factor thresholds |
+
+## Seeding — parsing rules from CLAUDE.md
+
+Bootstrap hypotheses from existing CLAUDE.md rules.
+
+Parse rule-like patterns:
+- Imperative statements: "Never X", "Always Y", "Must Z"
+- Convention definitions: "Format: X", "Style: Y"
+- Assertions: "X is better than Y", "X before Y"
+- Quantitative claims: "reduces by X%", "takes N minutes"
+
+Each becomes a hypothesis record:
+- id: auto-generated (H001, H002, ...)
+- statement: the rule as stated
+- source: file path + line number
+- domain: auto-classified from domains list
+- status: unproven
+- confidence: 0.0
+
+## Experiment design principles
+
+Six principles. Violating any one invalidates the experiment.
+
+1. **Falsifiability** — Every experiment must be able to disprove the hypothesis. If no possible outcome would refute the rule, the experiment is useless.
+
+2. **Minimum viable test** — Smallest possible scope that produces signal. One task comparison, not a week-long study.
+
+3. **Quantitative preferred** — Numbers over opinions. Time, error count, recall percentage, rework frequency. Qualitative evidence is acceptable only when quantitative is impossible.
+
+4. **Control condition** — Compare against baseline. What happens WITHOUT the rule? No control = no experiment. Just an observation.
+
+5. **Reproducibility** — Another session should be able to repeat the experiment with the same method. Record: exact steps, inputs, environment, measurement approach.
+
+6. **Independence** — Test one rule at a time. Control for confounds. If two rules interact, test each independently first.
+
+## Experiment patterns by domain
+
+### methodology (example: research before coding)
+- method: A/B comparison across similar tasks
+- measure: time to completion, error rate, rework count
+- control: task executed WITHOUT the rule applied
+- sample_size: minimum 3 comparisons for signal
+
+### coordination (example: parallel beats serial)
+- method: timed execution of same-scope work
+- measure: wall-clock time, merge conflict rate, quality score
+- control: serial execution of identical scope
+- sample_size: minimum 3 comparisons for signal
+
+### testing (example: tests before code)
+- method: track tasks with test-first vs test-after
+- measure: bug escape rate, rework frequency, coverage delta
+- control: tasks where tests were written after implementation
+- sample_size: minimum 5 tasks per condition
+
+### quality (example: Big 5 checks prevent bugs)
+- method: compare code reviewed with Big 5 vs without
+- measure: post-merge bug reports, review round-trips
+- control: code merged without Big 5 review
+- sample_size: minimum 5 reviews per condition
+
+### git (example: atomic commits reduce revert pain)
+- method: track revert complexity for atomic vs bundled commits
+- measure: time to revert, collateral damage (unrelated changes reverted)
+- control: multi-concern commits
+- sample_size: minimum 3 revert events per condition
+
+### security (example: Zod validation prevents injection)
+- method: fuzz endpoints with and without schema validation
+- measure: injection success rate, malformed input acceptance rate
+- control: endpoint without Zod/Pydantic layer
+- sample_size: minimum 50 fuzz inputs per endpoint
+
+### performance (example: measure before optimizing saves time)
+- method: compare optimizations guided by profiling vs intuition
+- measure: actual speedup achieved, time spent optimizing
+- control: intuition-guided optimization
+- sample_size: minimum 3 optimization tasks per condition

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -28,6 +28,51 @@ Skill-specific: skills/git/reference/git-research.md
 5. COMMIT OFTEN: Every working state gets a commit. Max 30 min between commits.
 </core_principles>
 
+<workflow>
+
+  <step id="1" name="preflight">
+    1. `git status` — note branch, dirty files, untracked.
+    2. Dirty at task start? Stop. Commit, stash, or discard prior state first.
+    3. Tier 2+: confirm you are NOT on main. Create branch: `git checkout -b {type}/{name}`.
+    (gate: clean working tree OR explicit decision made)
+  </step>
+
+  <step id="2" name="snapshot">
+    4. Record HEAD sha to AgentDB before any work: `git rev-parse HEAD`.
+    (gate: sha written to AgentDB — rollback target exists)
+  </step>
+
+  <step id="3" name="commit">
+    5. Stage specific files only: `git add {file}` — never `git add -A` or `git add .`.
+    6. Write message: `{type}({scope}): {description}` in imperative mood.
+       — Forbidden: wip, update, misc, auto commit, Co-Authored-By, "Generated with"
+    7. Commit. Never `--no-verify` (fix the gate instead; see hook carve-outs in CLAUDE.md).
+    (gate: `git log --oneline -1` shows correct message; no forbidden strings)
+  </step>
+
+  <step id="4" name="scope_check">
+    8. `git diff --stat {base}..HEAD` — only contracted files changed.
+    9. No leaked secrets: `git diff HEAD~1 | grep -i "key\|token\|secret\|password"`.
+    (gate: diff matches contract scope; zero secret leaks)
+  </step>
+
+  <step id="5" name="push">
+    10. Feature branch: push freely after gates pass.
+    11. main / master: STOP — requires explicit user say-so (I0.8).
+    12. Never bare `--force`. If needed: `--force-with-lease` only.
+    (gate: user confirmed OR branch is not main)
+  </step>
+
+  <step id="6" name="pr_review">
+    13. Keep diffs ≤500 lines. >500 lines: split the PR first.
+    14. AI review before human review (sequence: AI → fix → human). Never parallelize.
+    15. PR description for AI-assisted work must answer: AI role / prompt / human contribution.
+    16. "Nit:" prefix for optional style comments.
+    (gate: diff ≤500 lines; review sequence followed)
+  </step>
+
+</workflow>
+
 <branch_strategy>
 - main: Always deployable. Never commit directly for tier 2+.
 - feature/{name}: New functionality
@@ -41,18 +86,6 @@ Profile-gated workflow:
   github-production: feature branches always, PRs REQUIRED, review REQUIRED
 </branch_strategy>
 
-<commit_messages>
-Good:
-- feat: add user authentication endpoint
-- fix: resolve race condition in cache invalidation
-- refactor: extract validation logic to separate module
-
-Bad:
-- fixed stuff
-- WIP
-- updates
-</commit_messages>
-
 <anti_patterns>
 - Committing to main directly for multi-file changes
 - "WIP" commits that never get squashed
@@ -60,101 +93,8 @@ Bad:
 - Force pushing to shared branches
 - Skipping commit messages
 - Including AI tool attribution in commit messages (Co-Authored-By, "Generated with Claude Code", etc.)
+- git add -A / git add . (catches unintended files)
+- Parallelize AI + human review (humans see noisy diff, duplicate feedback)
 </anti_patterns>
-
-<!-- Updated 2026-03-30: Claude Code best practices, Anthropic prompt engineering guide -->
-<agentic_git_discipline>
-Agentic workflows introduce new git failure modes. Mitigate them:
-
-**Pre-task snapshot**: Before any agent starts work, record the HEAD commit SHA in AgentDB.
-If the task needs rollback, you know exactly where to return.
-
-```bash
-# Record before agent work
-git rev-parse HEAD  # save this to AgentDB
-
-# Rollback if needed
-git reset --hard <saved-sha>
-```
-
-**Dirty-state check**: If `git status` shows uncommitted changes at task start, stop.
-Prior agent left state. Commit, stash, or discard before proceeding — never silently overwrite.
-
-**Branch-per-agent for tier 2+**: Each agent working on distinct features gets its own
-branch. Merging branches (not rebasing) preserves intent and makes conflicts explicit.
-
-**Squash before merge**: Agent commits tend to be fine-grained and mechanical.
-Squash to one meaningful commit per feature before merging to main. Message should
-describe the feature, not the implementation steps.
-
-**No force-push to shared branches**: An agent force-pushing destroys another agent's
-or human's commits silently. Use `--force-with-lease` only, never bare `--force`.
-</agentic_git_discipline>
-
-<!-- Updated 2026-04-04: AI code review best practices, https://collinwilkins.com/articles/ai-code-review-best-practices-approaches-tools.html -->
-<diff_sizing>
-Diff size is the single biggest lever for AI code review quality:
-
-- **50-200 lines**: optimal — AI catches logic errors, security issues, edge cases
-- **200-500 lines**: acceptable — AI catches obvious issues, misses subtle interactions
-- **500+ lines**: degraded — AI overwhelmed, misses important context, feedback generic
-- **1000+ lines**: near-useless — context saturation, review becomes superficial
-
-Rule: if a diff exceeds 500 lines, split the PR before requesting AI review.
-
-<!-- Updated 2026-05-10: https://www.codeant.ai/blogs/good-code-review-practices-guide, https://codeintelligently.com/blog/ai-code-quality-guide-2026 -->
-**Team-level PR size target**: Set P50 PR size < 300 LOC as a team metric (median PR, not max). Teams that track this and enforce it see 40-60% reduction in review time. Track with: `git log --oneline -20 --shortstat | grep -E "changed"`. The 500-line hard cap is the ceiling; 300-line P50 is the steady-state goal.
-
-**AI review before human review**: Run AI review (~90 seconds) before requesting human review.
-Developer fixes cheap issues first, humans see a cleaner diff and focus on intent and design.
-Sequence: AI review → fix → human review. Not parallel.
-</diff_sizing>
-
-
-<!-- Updated 2026-04-14: https://javaworldmag.com/evolving-code-reviews-with-ai-in-2026/ -->
-<ai_pr_transparency>
-When merging AI-assisted work, PR descriptions should answer three questions:
-
-1. **What was the AI's role?** (generated scaffold, wrote tests, suggested approach, full implementation)
-2. **What prompt or instructions drove it?** (as important as a commit message — reviewers evaluate the generation process, not just the output)
-3. **What was the human contribution?** (reviewed, modified, architecture decisions, requirements)
-
-Reviewers then focus on: design decisions, architecture fit, business logic correctness — not line-by-line syntax the AI already handled.
-
-This is not ceremony — it's the minimum for a meaningful review of AI-assisted code. Without it, reviewers are auditing output with no context on how it was generated.
-</ai_pr_transparency>
-
-<!-- Updated 2026-04-23: https://stackoverflow.blog/2026/03/26/coding-guidelines-for-ai-agents-and-people-too/, https://javaworldmag.com/evolving-code-reviews-with-ai-in-2026/ -->
-<review_conventions>
-**"Nit:" prefix for optional comments**: Prefix style-only feedback with "Nit:" to signal it's optional.
-Prevents authors from treating cosmetic suggestions as blockers.
-
-```
-# Required (no prefix)
-"Line 24: userId could be null here — add validation before the DB call"
-
-# Optional (Nit prefix)
-"Nit: 'x' would be clearer as 'userCount'"
-```
-
-Without the prefix, reviewers and authors waste cycles on non-critical changes.
-
-**AI-first review sequence**: AI review catches style/logic issues BEFORE human review.
-Sequence: AI review (90s) → author fixes cheap issues → human reviews cleaner diff.
-Humans then focus on architecture, business logic, and intent — not nitpicks the AI already caught.
-Never parallelize AI + human review: humans see a noisier diff and duplicate AI feedback.
-</review_conventions>
-
-<!-- Updated 2026-05-14: https://www.codeant.ai/blogs/good-code-review-practices-guide, https://codeintelligently.com/blog/ai-code-quality-guide-2026 -->
-<tiered_review_risk>
-Not all changes warrant the same review depth. Route by tier to capture the 40-60% review time reduction without sacrificing judgment on critical changes:
-
-- **Tier 1 — AI handles completely**: style, formatting, naming, simple logic, boilerplate, test assertions
-- **Tier 2 — AI + quick human skim**: error handling, input validation, moderate business logic
-- **Tier 3 — human required**: architecture decisions, security-sensitive paths, auth/payments/PII, anything affecting critical systems
-
-The review time savings come from AI absorbing Tier 1 entirely — not from replacing Tier 3 judgment.
-Complex architectural decisions and business logic in critical flows always need a human eye.
-</tiered_review_risk>
 
 </skill>

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -97,4 +97,8 @@ Profile-gated workflow:
 - Parallelize AI + human review (humans see noisy diff, duplicate feedback)
 </anti_patterns>
 
+<on_complete>
+agentdb write-end '{"skill":"git","commits":N,"atomic":true,"convention":"pass"}'
+</on_complete>
+
 </skill>

--- a/skills/git/reference/git-research.md
+++ b/skills/git/reference/git-research.md
@@ -163,3 +163,114 @@ Handoff:
 - Validator agent checks commit format before allowing merge.
 - No AI attribution: never Co-Authored-By, never tool signatures.
 - Tag milestones: git tag -a v{X} -m "{description}".
+
+---
+
+## Agentic Git Discipline (moved from SKILL.md 2026-05-28)
+
+Agentic workflows introduce new git failure modes. Mitigate them:
+
+**Pre-task snapshot**: Before any agent starts work, record the HEAD commit SHA in AgentDB.
+If the task needs rollback, you know exactly where to return.
+
+```bash
+# Record before agent work
+git rev-parse HEAD  # save this to AgentDB
+
+# Rollback if needed
+git reset --hard <saved-sha>
+```
+
+**Dirty-state check**: If `git status` shows uncommitted changes at task start, stop.
+Prior agent left state. Commit, stash, or discard before proceeding — never silently overwrite.
+
+**Branch-per-agent for tier 2+**: Each agent working on distinct features gets its own
+branch. Merging branches (not rebasing) preserves intent and makes conflicts explicit.
+
+**Squash before merge**: Agent commits tend to be fine-grained and mechanical.
+Squash to one meaningful commit per feature before merging to main. Message should
+describe the feature, not the implementation steps.
+
+**No force-push to shared branches**: An agent force-pushing destroys another agent's
+or human's commits silently. Use `--force-with-lease` only, never bare `--force`.
+
+---
+
+## Diff Sizing for AI Code Review (moved from SKILL.md 2026-05-28)
+
+<!-- Sources: https://collinwilkins.com/articles/ai-code-review-best-practices-approaches-tools.html (2026-04-04),
+     https://www.codeant.ai/blogs/good-code-review-practices-guide, https://codeintelligently.com/blog/ai-code-quality-guide-2026 (2026-05-10) -->
+
+Diff size is the single biggest lever for AI code review quality:
+
+- **50-200 lines**: optimal — AI catches logic errors, security issues, edge cases
+- **200-500 lines**: acceptable — AI catches obvious issues, misses subtle interactions
+- **500+ lines**: degraded — AI overwhelmed, misses important context, feedback generic
+- **1000+ lines**: near-useless — context saturation, review becomes superficial
+
+Rule: if a diff exceeds 500 lines, split the PR before requesting AI review.
+
+**Team-level PR size target**: Set P50 PR size < 300 LOC as a team metric (median PR, not max).
+Teams that track this and enforce it see 40-60% reduction in review time.
+Track with: `git log --oneline -20 --shortstat | grep -E "changed"`.
+The 500-line hard cap is the ceiling; 300-line P50 is the steady-state goal.
+
+**AI review before human review**: Run AI review (~90 seconds) before requesting human review.
+Developer fixes cheap issues first, humans see a cleaner diff and focus on intent and design.
+Sequence: AI review → fix → human review. Not parallel.
+
+---
+
+## AI PR Transparency (moved from SKILL.md 2026-05-28)
+
+<!-- Source: https://javaworldmag.com/evolving-code-reviews-with-ai-in-2026/ (2026-04-14) -->
+
+When merging AI-assisted work, PR descriptions should answer three questions:
+
+1. **What was the AI's role?** (generated scaffold, wrote tests, suggested approach, full implementation)
+2. **What prompt or instructions drove it?** (as important as a commit message — reviewers evaluate the generation process, not just the output)
+3. **What was the human contribution?** (reviewed, modified, architecture decisions, requirements)
+
+Reviewers then focus on: design decisions, architecture fit, business logic correctness — not line-by-line syntax the AI already handled.
+
+This is not ceremony — it's the minimum for a meaningful review of AI-assisted code. Without it, reviewers are auditing output with no context on how it was generated.
+
+---
+
+## Review Conventions (moved from SKILL.md 2026-05-28)
+
+<!-- Sources: https://stackoverflow.blog/2026/03/26/coding-guidelines-for-ai-agents-and-people-too/,
+     https://javaworldmag.com/evolving-code-reviews-with-ai-in-2026/ (2026-04-23) -->
+
+**"Nit:" prefix for optional comments**: Prefix style-only feedback with "Nit:" to signal it's optional.
+Prevents authors from treating cosmetic suggestions as blockers.
+
+```
+# Required (no prefix)
+"Line 24: userId could be null here — add validation before the DB call"
+
+# Optional (Nit prefix)
+"Nit: 'x' would be clearer as 'userCount'"
+```
+
+Without the prefix, reviewers and authors waste cycles on non-critical changes.
+
+**AI-first review sequence**: AI review catches style/logic issues BEFORE human review.
+Sequence: AI review (90s) → author fixes cheap issues → human reviews cleaner diff.
+Humans then focus on architecture, business logic, and intent — not nitpicks the AI already caught.
+Never parallelize AI + human review: humans see a noisier diff and duplicate AI feedback.
+
+---
+
+## Tiered Review Risk (moved from SKILL.md 2026-05-28)
+
+<!-- Sources: https://www.codeant.ai/blogs/good-code-review-practices-guide, https://codeintelligently.com/blog/ai-code-quality-guide-2026 (2026-05-14) -->
+
+Not all changes warrant the same review depth. Route by tier to capture the 40-60% review time reduction without sacrificing judgment on critical changes:
+
+- **Tier 1 — AI handles completely**: style, formatting, naming, simple logic, boilerplate, test assertions
+- **Tier 2 — AI + quick human skim**: error handling, input validation, moderate business logic
+- **Tier 3 — human required**: architecture decisions, security-sensitive paths, auth/payments/PII, anything affecting critical systems
+
+The review time savings come from AI absorbing Tier 1 entirely — not from replacing Tier 3 judgment.
+Complex architectural decisions and business logic in critical flows always need a human eye.

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -24,14 +24,14 @@ Skill-specific: skills/orchestration/reference/orchestration-research.md
 1. CONTRACTS FIRST: Observable goal, bounded scope, clear failure conditions.
 2. AGENTDB IS THE BUS: Agents don't report verbally. They write to DB.
 3. NEVER ASSUME: Always read checkpoint/verdict before proceeding.
-4. VERIFY BY FILE, NOT BY RECEIPT: Subagent return-summaries are pointers. Open the deliverable file and read it before marking the contract DONE. A surgeon's "I implemented X" is intent; the file is evidence.
-5. PARALLEL DEFAULT: Independent tasks = concurrent agents — but only when files do not overlap. Shared files = serialize.
+4. VERIFY BY FILE, NOT BY RECEIPT: Open the deliverable file before marking DONE. Receipt = intent; file = evidence.
+5. PARALLEL DEFAULT: Independent files = concurrent agents. Shared files = serialize.
 6. FAIL FAST: Surface blockers immediately. Don't hide failures.
 </core_principles>
 
 <fault_tolerance>
 4 required layers:
-1. RETRY: Transient failures (timeout, rate limit) → backoff, max 3 attempts
+1. RETRY: Transient failures → backoff, max 3 attempts
 2. FALLBACK: Model/provider failure → route to alternative
 3. CLASSIFICATION: Categorize failure type before choosing recovery
 4. CHECKPOINTING: Write state to AgentDB at every boundary
@@ -39,54 +39,40 @@ Skill-specific: skills/orchestration/reference/orchestration-research.md
 
 <worktree_isolation>
 Use git worktree isolation for tier 2+ when multiple surgeons run in parallel.
-
-**When**: Tier 2+ with 2+ concurrent surgeons touching different files.
-**How**: Claude Code natively supports `isolation: "worktree"` on the Agent tool.
-  - Each surgeon gets an isolated repo copy
-  - If changes are made, worktree path and branch are returned
-  - If no changes, worktree auto-cleans
-
-**Pattern**:
-```
-Agent tool call:
-  subagent_type: kernel:surgeon
-  isolation: "worktree"
-  prompt: "Contract CR-xxx: implement..."
-```
-
-**Merge protocol**: After surgeon completes, orchestrator reviews branch diff, then merges to main working tree.
-**Failure mode**: Surgeon fails → worktree abandoned (no main pollution). Read AgentDB checkpoint for details.
-**Tier 1**: Don't use worktrees. Unnecessary overhead for 1-2 file changes.
+- Set `isolation: "worktree"` on Agent tool call
+- Each surgeon gets isolated repo copy; failed work abandoned (no main pollution)
+- Merge protocol: review branch diff → merge to main working tree
+- Tier 1: skip worktrees (unnecessary overhead)
 </worktree_isolation>
 
 <worktree_safety>
 Constraint enforcement for parallel agents. Prevents scope creep and file conflicts.
 
 **Contract constraints (mandatory for tier 2+)**:
-- Every contract MUST include `constraints.files`: an exhaustive list of files the agent may touch.
+- Every contract MUST include `constraints.files`: exhaustive list of files agent may touch.
 - Format: `{"goal":"X","files":["a.sh"],"constraints":{"files":["a.sh","b.md"]},"tier":2}`
 - No two concurrent contracts may have overlapping `constraints.files`.
 
 **Pre-spawn validation**:
-- `git status --porcelain` must be empty or all changes stashed before spawning agents.
-- Each surgeon's constraint list must be disjoint from all other active surgeons.
+1. `git status --porcelain` must be clean or stashed before spawning.
+2. Each surgeon's constraint list must be disjoint from all active surgeons.
 
 **Post-agent validation**:
-- Read surgeon's checkpoint from AgentDB.
-- Run `git diff --name-only {base}..{surgeon_branch}` on the surgeon's branch.
-- Every file in the diff MUST appear in that contract's `constraints.files`.
-- If any file is out of scope: REJECT the agent's output. Do not merge. Re-contract.
+1. Read surgeon's checkpoint from AgentDB.
+2. Run `git diff --name-only {base}..{surgeon_branch}`.
+3. Every file in diff MUST appear in `constraints.files`.
+4. Out-of-scope file → REJECT output. Do not merge. Re-contract.
 
 **Merge protocol**:
 - Validate constraints before merging surgeon branch to main.
-- If constraints violated: abandon branch, log failure, re-contract with corrected scope.
+- If violated: abandon branch, log failure, re-contract with corrected scope.
 </worktree_safety>
 
 <context_transfer>
 Every agent boundary is lossy compression.
-- Pre-transfer: Write structured briefing to AgentDB
-- Post-transfer: Read AgentDB + active.md to restore
-- Never rely on conversation history across agents
+1. Pre-transfer: Write structured briefing to AgentDB
+2. Post-transfer: Read AgentDB + active.md to restore
+3. Never rely on conversation history across agents
 </context_transfer>
 
 <knowledge_injection>
@@ -108,13 +94,14 @@ Every agent boundary is lossy compression.
   rule: inject BEFORE spawn. Never let agents discover context at runtime.
   rule: orchestrator owns injection. Agents don't call inject-context themselves.
 </knowledge_injection>
+
 <progressive_autonomy>
-  Confidence-based human escalation. Higher confidence = less human involvement.
+  Confidence-based human escalation:
 
   levels:
-    supervised:    confidence < 0.6 — human confirms every decision
-    semi_autonomous: 0.6 <= confidence < 0.8 — human confirms tier 2+ only
-    autonomous:    confidence >= 0.8 — human reviews results, not decisions
+    supervised:       confidence < 0.6 — human confirms every decision
+    semi_autonomous:  0.6 <= confidence < 0.8 — human confirms tier 2+ only
+    autonomous:       confidence >= 0.8 — human reviews results, not decisions
 
   escalation_triggers:
     - confidence below threshold for current level
@@ -122,11 +109,6 @@ Every agent boundary is lossy compression.
     - scope exceeds contract by >20%
     - security-sensitive change detected
     - breaking change to public API
-
-  measurement:
-    agent_confidence: from reviewer 11-phase scoring
-    historical_accuracy: from approval-learner pattern matching
-    domain_familiarity: from agentdb learning count in this domain
 
   rule: start supervised. Earn autonomy through consistent quality.
   rule: any security concern instantly drops to supervised level.
@@ -140,132 +122,66 @@ Every agent boundary is lossy compression.
     tier_2: medium cost (orchestrator + surgeon)
     tier_3: high cost (full council)
 
-  tracking:
-    - agentdb emit tracks token usage per agent per session
-    - orchestrator monitors cumulative cost across spawned agents
-    - budget injected into agent context: "Remaining budget: ~{N} tokens"
-
   alerts:
     50%: normal — continue
     80%: warn — simplify approach
     95%: critical — wrap up, checkpoint, stop spawning
 
-  self_regulation:
-    - agent sees remaining budget in injected context
-    - high budget: explore multiple approaches
-    - low budget: pick simplest viable approach
-    - exhausted: checkpoint and report to human
+  preflight (orchestrator enforces before any autonomous loop):
+    1. Confirm `max_budget_usd` is set on contract.
+    2. If unset: AskUserQuestion — set ceiling or proceed unbounded.
+    3. Track cumulative cost via agentdb emit. Hard stop at 100%.
 
   rule: never exceed budget silently. Alert at 80%, hard stop at 95%.
   rule: budget is per-contract, not per-session.
 </budget_awareness>
 
-<max_budget_usd_invariant>
-  **`max_budget_usd` is mandatory infrastructure, not optional config.** Treat it like a circuit
-  breaker, not a preference. One stuck retry loop at $0.40-0.60/query × hundreds of retries
-  becomes a silent four-figure invoice. The cap is the only thing standing between you and that.
-
-  Required for:
-  - Any /kernel:forge autonomous run (heat → hammer → quench → temper → anneal loops)
-  - Any multi-agent spawn (tier 2+) where total cost is unbounded by the human in the loop
-  - Any "run overnight" or "let it iterate until done" pattern
-  - Any agentdb antibody-search-driven loop where match counts determine spawn counts
-
-  Preflight protocol (orchestrator enforces):
-  1. Before spawning any autonomous loop, confirm `max_budget_usd` is set on the contract.
-  2. If unset: AskUserQuestion — "About to start an autonomous loop with no cost cap. Set a
-     ceiling, or proceed unbounded? Default: $5 for tier 2, $15 for tier 3."
-  3. Track cumulative cost via agentdb emit. Hard stop at 100%, soft warn at 80%.
-  4. Hitting the cap is not a failure — it's the safety mechanism working. Report and stop.
-
-  Why this is an invariant, not a guideline: cost overruns are silent until billing fires. There
-  is no in-session signal that something is going wrong. The cap is the signal.
-</max_budget_usd_invariant>
-
 <checkpoint_recovery>
   Resume from last good state, not restart from scratch. Saves 40-60% on failures.
 
-  checkpoint_schema:
-    agent_id: which agent was working
-    step: last completed step number
-    state: JSON blob of current progress
-    files_modified: list of files changed so far
-    tests_passing: count of passing tests at this point
-    timestamp: when checkpoint was written
-
   protocol:
-    on_spawn: check agentdb for existing checkpoint with same contract_id
-    if_found: resume from step + 1, skip completed work
-    if_not_found: start fresh
-    on_each_step: write checkpoint via agentdb write-end
-    on_failure: checkpoint is preserved — next spawn resumes
+    1. on_spawn: check agentdb for existing checkpoint with same contract_id
+    2. if_found: resume from step + 1, skip completed work
+    3. if_not_found: start fresh
+    4. on_each_step: write checkpoint via agentdb write-end
+    5. on_failure: checkpoint preserved — next spawn resumes
 
   version_safety:
-    - each checkpoint stores list of files_modified
     - on resume: verify files haven't changed since checkpoint
     - if changed externally: invalidate checkpoint, start fresh
-    - prevents "double update" from stale state
-
-  integration:
-    - surgeon writes checkpoint after each file modification
-    - forge checks for checkpoint before each heat cycle
-    - orchestrator reads checkpoint to determine resume point
 
   rule: always checkpoint before risky operations.
   rule: checkpoint is cheap. Not checkpointing is expensive.
 </checkpoint_recovery>
 
 <entropy_adaptive>
-  Dynamic agent orchestration based on task entropy. Replace fixed workflows with adaptive coordination.
+  Dynamic orchestration based on task entropy.
 
   entropy_measurement:
-    low:    familiar pattern, existing tests, clear scope → streamline (fewer agents, faster)
-    medium: some unknowns, partial test coverage → standard workflow
-    high:   unfamiliar tech, no tests, cross-cutting → full council + extra research
-
-  signals:
-    - agentdb learning count in domain (high count = low entropy)
-    - test coverage for affected files (high coverage = low entropy)
-    - number of recent failures in domain (high failures = high entropy)
-    - file co-change complexity (many co-changes = high entropy)
-    - triage agent classification (low/medium/high/epic)
+    low:    familiar pattern, existing tests, clear scope
+    medium: some unknowns, partial coverage
+    high:   unfamiliar tech, no tests, cross-cutting
 
   adaptation:
-    low_entropy:
-      skip: researcher, scout
-      use: surgeon directly (tier 1 behavior even for tier 2 file counts)
-      rationale: known territory, don't waste tokens on research
-
-    medium_entropy:
-      standard: researcher → surgeon → validator
-      skip: adversary (unless security-sensitive)
-      rationale: some unknowns but manageable risk
-
-    high_entropy:
-      full: researcher + scout → triage → understudier → surgeon → adversary → reviewer
-      add: coroner on failure (automatic post-mortem)
-      rationale: maximum coverage, expect failures, learn from them
+    low_entropy:    skip researcher+scout; surgeon directly
+    medium_entropy: researcher → surgeon → validator; skip adversary
+    high_entropy:   full council + coroner on failure
 
   override:
     - security-sensitive changes always get full pipeline regardless of entropy
     - human can force entropy level via AskUserQuestion
     - first session in new project always starts at high entropy
 
-  integration:
-    - triage agent outputs entropy estimate alongside complexity
-    - forge heat phase measures entropy before choosing approach count
-    - ingest classify step uses entropy to decide research depth
-
-  rule: entropy decreases as learnings accumulate. Reward the system for learning.
+  rule: entropy decreases as learnings accumulate.
   rule: never skip security checks regardless of entropy level.
 </entropy_adaptive>
 
 <anti_patterns>
 - Holding context in memory instead of AgentDB
 - Assuming agent completed without reading DB
-- Trusting subagent receipts as evidence — receipts describe intent; files describe reality. Open the file before approving the checkpoint.
-- Parallel agents touching shared files — produces N-way merge conflicts even when "zero-overlap" was planned, because agents independently fix common lint/format issues. Serialize when files share imports.
-- Serial execution when parallel is genuinely safe (independent files, independent state)
+- Trusting subagent receipts as evidence — receipts describe intent; files describe reality
+- Parallel agents touching shared files — produces N-way merge conflicts
+- Serial execution when parallel is genuinely safe
 - Retrying without new context from failure
 </anti_patterns>
 

--- a/skills/orchestration/reference/orchestration-research.md
+++ b/skills/orchestration/reference/orchestration-research.md
@@ -200,3 +200,86 @@ Every design decision maps to patterns above:
 - Anti-patterns: prevent scope creep and silent failure.
 - Adversary agent: implements adversarial verification pattern.
 - Parallel orchestration: implements fan-out/fan-in with merge.
+
+---
+
+## max_budget_usd Invariant (moved from SKILL.md 2026-05-28)
+
+`max_budget_usd` is mandatory infrastructure, not optional config. Treat it like a circuit
+breaker, not a preference. One stuck retry loop at $0.40-0.60/query × hundreds of retries
+becomes a silent four-figure invoice. The cap is the only thing standing between you and that.
+
+Required for:
+- Any /kernel:forge autonomous run (heat → hammer → quench → temper → anneal loops)
+- Any multi-agent spawn (tier 2+) where total cost is unbounded by the human in the loop
+- Any "run overnight" or "let it iterate until done" pattern
+- Any agentdb antibody-search-driven loop where match counts determine spawn counts
+
+Why this is an invariant, not a guideline: cost overruns are silent until billing fires.
+There is no in-session signal that something is going wrong. The cap is the signal.
+
+---
+
+## Entropy Adaptive — Detail (moved from SKILL.md 2026-05-28)
+
+entropy signals:
+- agentdb learning count in domain (high count = low entropy)
+- test coverage for affected files (high coverage = low entropy)
+- number of recent failures in domain (high failures = high entropy)
+- file co-change complexity (many co-changes = high entropy)
+- triage agent classification (low/medium/high/epic)
+
+adaptation detail:
+  low_entropy:
+    skip: researcher, scout
+    use: surgeon directly (tier 1 behavior even for tier 2 file counts)
+    rationale: known territory, don't waste tokens on research
+
+  medium_entropy:
+    standard: researcher → surgeon → validator
+    skip: adversary (unless security-sensitive)
+    rationale: some unknowns but manageable risk
+
+  high_entropy:
+    full: researcher + scout → triage → understudier → surgeon → adversary → reviewer
+    add: coroner on failure (automatic post-mortem)
+    rationale: maximum coverage, expect failures, learn from them
+
+integration:
+- triage agent outputs entropy estimate alongside complexity
+- forge heat phase measures entropy before choosing approach count
+- ingest classify step uses entropy to decide research depth
+
+rule: entropy decreases as learnings accumulate. Reward the system for learning.
+
+---
+
+## Checkpoint Schema (moved from SKILL.md 2026-05-28)
+
+checkpoint_schema:
+  agent_id: which agent was working
+  step: last completed step number
+  state: JSON blob of current progress
+  files_modified: list of files changed so far
+  tests_passing: count of passing tests at this point
+  timestamp: when checkpoint was written
+
+integration:
+- surgeon writes checkpoint after each file modification
+- forge checks for checkpoint before each heat cycle
+- orchestrator reads checkpoint to determine resume point
+
+---
+
+## Budget Tracking Detail (moved from SKILL.md 2026-05-28)
+
+tracking:
+- agentdb emit tracks token usage per agent per session
+- orchestrator monitors cumulative cost across spawned agents
+- budget injected into agent context: "Remaining budget: ~{N} tokens"
+
+self_regulation:
+- agent sees remaining budget in injected context
+- high budget: explore multiple approaches
+- low budget: pick simplest viable approach
+- exhausted: checkpoint and report to human

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -60,4 +60,8 @@ After optimizing:
 - Premature parallelization
 </anti_patterns>
 
+<on_complete>
+agentdb write-end '{"skill":"performance","bottleneck":"X","measured_before":true,"improvement":"Xms|none"}'
+</on_complete>
+
 </skill>

--- a/skills/quality/SKILL.md
+++ b/skills/quality/SKILL.md
@@ -73,22 +73,9 @@ Fix before commit. No exceptions.
     >= 0.50: acceptable (ship with caveats)
     < 0.50: not ready (fix before shipping)
 
-  measurement:
-    test_pass_rate: passing tests / total tests
-    acceptance_rate: acceptance criteria met / total criteria
-    scope_accuracy: files in contract / files actually changed (1.0 = perfect scope)
-    security_clean_rate: 1.0 if no security findings, 0.0 otherwise
-    budget_compliance: 1.0 if within budget, decreases proportionally over budget
-    first_try_rate: 1.0 if merged without revision, decreases per revision round
-
-  usage:
-    - Validator reports R-factor in verdict
-    - /kernel:forge uses R-factor in quench phase (>= 0.8 = survived)
-    - /kernel:metrics displays R-factor trend
-    - agentdb verdict stores R-factor in evidence JSON
-
   rule: R-factor is informational, not a hard gate. Use thresholds as guidelines.
   rule: Track R-factor over time to measure improvement, not as a one-time score.
+  reference: skills/quality/reference/quality-research.md (measurement definitions, usage notes)
 </r_factor>
 <adsr>
   Proactive deviation detection. Don't wait for bugs — detect behavioral anomalies.
@@ -99,23 +86,14 @@ Fix before commit. No exceptions.
     suppression: block progression, alert human, quarantine work
     recovery:    critical = human review required. medium = auto-retry after fix
 
-  baselines:
-    tokens_per_tier: avg from agentdb execution_traces
-    files_per_contract: avg from agentdb contracts
-    duration_per_task: avg from agentdb events
-
   thresholds:
     warning: > 1.5x baseline
     anomaly: > 2x baseline
     critical: > 3x baseline
 
-  integration:
-    - validator checks baselines during quench phase
-    - forge loop checks between iterations
-    - orchestrator checks after each agent completes
-
   rule: anomaly = pause and ask, not auto-abort.
   rule: build baselines from at least 10 historical data points before enforcing.
+  reference: skills/quality/reference/quality-research.md (baselines, integration points)
 </adsr>
 
 </skill>

--- a/skills/quality/SKILL.md
+++ b/skills/quality/SKILL.md
@@ -96,4 +96,8 @@ Fix before commit. No exceptions.
   reference: skills/quality/reference/quality-research.md (baselines, integration points)
 </adsr>
 
+<on_complete>
+agentdb write-end '{"skill":"quality","big5_checked":true,"violations":N,"r_factor":0.00}'
+</on_complete>
+
 </skill>

--- a/skills/quality/reference/quality-research.md
+++ b/skills/quality/reference/quality-research.md
@@ -134,3 +134,45 @@ fix:
 **Why:** Time saved generating < time lost reviewing, debugging, fixing.
 
 **Fix:** 50-70% planning, 30-50% coding. Quality gates before review.
+
+---
+
+## R-Factor: Measurement Definitions
+
+Per-component measurement for the composite quality score:
+
+```
+test_pass_rate:      passing tests / total tests
+acceptance_rate:     acceptance criteria met / total criteria
+scope_accuracy:      files in contract / files actually changed (1.0 = perfect scope)
+security_clean_rate: 1.0 if no security findings, 0.0 otherwise
+budget_compliance:   1.0 if within budget, decreases proportionally over budget
+first_try_rate:      1.0 if merged without revision, decreases per revision round
+```
+
+### Usage integration
+
+- Validator reports R-factor in verdict
+- /kernel:forge uses R-factor in quench phase (>= 0.8 = survived)
+- /kernel:metrics displays R-factor trend
+- agentdb verdict stores R-factor in evidence JSON
+
+---
+
+## ADSR: Baselines and Integration
+
+### Baselines (computed from AgentDB history)
+
+```
+tokens_per_tier:     avg from agentdb execution_traces
+files_per_contract:  avg from agentdb contracts
+duration_per_task:   avg from agentdb events
+```
+
+Require at least 10 historical data points before enforcing thresholds.
+
+### Integration points
+
+- validator checks baselines during quench phase
+- forge loop checks between iterations
+- orchestrator checks after each agent completes

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -6,12 +6,6 @@ allowed-tools: Read, Edit, Bash, Grep, Glob
 
 <skill id="refactor">
 
-<purpose>
-Refactoring changes structure, not behavior. If behavior changes, it's not refactoring.
-Tests must pass before AND after. If tests don't exist, write them FIRST.
-The goal is clarity, not cleverness. Three similar lines beats a premature abstraction.
-</purpose>
-
 <prerequisite>
 AgentDB read-start has run. Check for prior refactor attempts on same code.
 </prerequisite>
@@ -21,34 +15,31 @@ Skill-specific: skills/refactor/reference/refactor-research.md
 General: reference/architecture-research.md
 </reference>
 
-<core_principles>
-1. TESTS FIRST: Run tests before refactoring. Green → refactor → green. Red at any point = stop.
-2. SMALL STEPS: One transformation per commit. Easier to revert, easier to review.
-3. BEHAVIOR PRESERVATION: Observable behavior unchanged. Internal structure changes only.
-4. NO FEATURE WORK: Refactoring is separate from features. Never combine in same commit.
-5. SIMPLIFY, DON'T ABSTRACT: Remove complexity before adding abstraction. Delete > refactor > add.
-</core_principles>
+<flow>
 
-<common_refactors>
-- Extract function: repeated code → named function (only if 3+ repetitions).
-- Inline: wrapper that adds nothing → remove the indirection.
-- Rename: unclear name → intention-revealing name.
-- Move: code in wrong module → move to where it belongs.
-- Simplify conditional: nested if/else → guard clauses or early return.
-- Remove dead code: unused code → delete (no "just in case").
-</common_refactors>
+1. **Baseline** — run full test suite. (gate: all tests green before touching anything)
+2. **Scope audit** — grep/glob every instance of the target symbol/pattern across the codebase. List them ALL before changing ANY.
+3. **Count files** → determine tier. 1-2 files: execute directly. 3-5 files: write one-paragraph plan. 6+ files: CONFIRM handshake.
+4. **Define success** — write down EXACTLY what changes. Anything outside that list is scope creep → separate contract.
+5. **Check coverage** — if target code has no tests: generate JiT behavioral tests FIRST (see step 6), run them green, then proceed.
+6. **JiT tests (when needed)** — ask Claude to generate behavioral tests for current code (what it *does*, not how). Run green. These are disposable; delete after if not worth keeping. (gate: JiT tests pass before refactor starts)
+7. **Execute — one transformation per commit:**
+   - Extract function: only at 3+ repetitions (Rule of Three)
+   - Inline: wrapper with exactly one call site → inline it
+   - Rename: state full scope explicitly — ALL files, imports, tests, docs (Opus follows literally; ambiguous scope = partial refactor)
+   - Move: code in wrong module → move to correct location
+   - Simplify conditional: nested if/else → guard clauses / early return
+   - Remove dead code: unused code → delete (no "just in case")
+8. **Agentic safety checks** (after each transformation):
+   - Phantom abstraction: abstraction with one call site → inline, wait for second use
+   - Comment drift: audit every comment for accuracy — stale comments worse than none
+   - Parallel agent artifacts: if multiple agents touched the file, check `git log` for overlapping changes
+   - Scope creep: diff changes against the defined list from step 4; extras → revert + new task
+9. **Verify** — run full test suite. (gate: all tests green after each commit; red = stop, revert last change)
+10. **Metrics** — measure before/after: cyclomatic complexity, function length, duplication. Successful refactor reduces complexity 15-25%. No improvement = shuffled, not simplified.
+11. **Commit** — one logical change per commit. Format: `refactor(scope): description`. File must end shorter or justify growth in commit body.
 
-<ai_code_cleanup>
-AI-generated code has specific patterns that need cleanup (GitClear 2026):
-- Code cloning: 4x more duplication. Extract shared logic.
-- Unused constructs: Imports, variables, functions never called. Delete.
-- Hardcoded debugging: console.log, print statements left behind. Remove.
-- Missing modularization: Long functions doing multiple things. Extract.
-- Copy-paste over abstraction: Duplicate blocks that should be functions.
-
-The verification bottleneck: AI generates faster than humans can review.
-Refactoring must be reviewable—small, atomic, tested.
-</ai_code_cleanup>
+</flow>
 
 <anti_patterns>
 <block id="big_bang">Large refactors in one commit. Impossible to review or revert.</block>
@@ -57,70 +48,6 @@ Refactoring must be reviewable—small, atomic, tested.
 <block id="premature_abstraction">Abstracting before you have 3 concrete examples. Wait for patterns to emerge.</block>
 <block id="refactor_while_there">"While I'm here, I'll also..." No. Separate contract.</block>
 </anti_patterns>
-
-<vibe_coding_crisis>
-From research (2026): developers accept AI output without understanding.
-60% decline in refactored code—velocity over health.
-Copy-paste has overtaken abstraction for first time.
-
-Refactoring is the antidote: systematically improve what AI generates.
-But it requires understanding the code. No understanding = no safe refactor.
-</vibe_coding_crisis>
-
-<!-- Updated 2026-03-30: AI code review best practices, Claude Code best practices -->
-<agentic_refactor_safety>
-When refactoring AI-generated code, additional risks apply:
-
-**Phantom abstraction**: AI frequently creates abstractions that look useful but are used
-in only one place. Rule: if an abstraction has exactly one call site, inline it. Wait for
-a second use case before abstracting.
-
-**Comment drift**: AI comments often describe what the code WAS doing before an edit, not
-what it does now. Audit every comment for accuracy during refactor — stale comments are
-worse than no comments.
-
-**Parallel agent conflicts**: If multiple agents touched the same file, check git log for
-overlapping changes. The "final" file may be a merge artifact, not intentional code.
-
-**Scope creep detection**: Before starting, write down EXACTLY what you're changing.
-After finishing, diff your changes against that list. Any extras are scope creep — revert
-them and open a separate task.
-
-<!-- Updated 2026-04-19: Anthropic Opus 4.7 migration guide (literal instruction following) -->
-**Explicit scope for refactor agents (Opus 4.7)**: Opus 4.7 follows instructions literally — it won't
-generalize "rename this function" to all call sites. State full scope explicitly:
-- Wrong: "Rename `getUserData` to `fetchUser`"
-- Right: "Rename `getUserData` to `fetchUser` in ALL files across the codebase, including imports, tests, and docs"
-When spawning a surgeon for a refactor, enumerate the specific files in the contract. Ambiguous scope = partial refactor.
-</agentic_refactor_safety>
-
-<!-- Updated 2026-04-25: https://www.infoq.com/news/2026/04/meta-jit-testing-ai-detection/ -->
-<jit_refactor_verification>
-When the code being refactored lacks test coverage, use JiT (Just-in-Time) testing:
-1. Before starting: ask Claude to generate behavioral tests for the current code (what it *does*, not how).
-2. Run them: they should pass (green baseline).
-3. Refactor.
-4. Run them again: must still pass.
-
-These tests are disposable — they exist only to verify behavior preservation during this refactor.
-Delete them after if they're not worth keeping. The 4x bug-detection improvement from Meta's JiT research
-applies here: generating tests at the point of change catches regressions that pre-existing suites miss.
-</jit_refactor_verification>
-
-<!-- Updated 2026-05-06: https://getdx.com/blog/enterprise-ai-refactoring-best-practices/, https://www.augmentcode.com/tools/ai-code-refactoring-tools-tactics-and-best-practices -->
-<strategic_refactoring>
-**Target high-impact components**: Teams targeting critical high-ROI components see 4x better results than comprehensive refactoring sweeps. Identify by: change frequency, bug density, review time. Start there, not at the edges.
-
-**Atomic transformations under 200 lines**: Keeping each change under 200 lines reduces code review time by 60% and lowers regression risk. Anything larger is a separate task.
-
-**Document before refactoring**: Before starting, create an architectural diagram and document any complex business logic the AI is unlikely to understand. AI frequently mishandles domain-specific constraints and niche patterns. Organizations that prepare this context see 3x faster modernization cycles.
-
-**Success metrics**: A successful refactor measurably reduces cyclomatic complexity by 15-25%. If it doesn't, the refactor didn't simplify — it shuffled. Organizations with systematic pre/post testing see 70% fewer post-deployment issues.
-
-**Embed into regular development**: Refactoring as a periodic "cleanup project" fails from adoption friction. Integrate into normal PR workflow: every merge includes a small cleanup. Don't batch technical debt.
-
-**Rollback procedure required**: Establish a clear rollback path (git SHA or stash) before every refactor. Subtle behavioral changes hide in refactored code. Never merge without the ability to undo.
-</strategic_refactoring>
 
 <on_complete>
 agentdb write-end '{"skill":"refactor","type":"<extract|inline|rename|simplify>","files_touched":<N>,"tests_status":"green","behavior_changed":false}'

--- a/skills/refactor/reference/refactor-research.md
+++ b/skills/refactor/reference/refactor-research.md
@@ -374,3 +374,92 @@ Refactoring in KERNEL follows the standard flow with specific rules:
 - The "almost right" defense: after any AI-assisted refactoring,
   run the full 8-pass checklist above. AI refactoring introduces
   the same defect categories as AI generation.
+
+---
+
+## Moved from SKILL.md (2026-05-28)
+
+### Core Principles (background)
+
+Refactoring changes structure, not behavior. If behavior changes, it's not refactoring.
+The goal is clarity, not cleverness. Three similar lines beats a premature abstraction.
+
+### Vibe Coding Crisis (stats)
+
+From research (2026): developers accept AI output without understanding.
+60% decline in refactored code — velocity over health.
+Copy-paste has overtaken abstraction for first time.
+
+Refactoring is the antidote: systematically improve what AI generates.
+But it requires understanding the code. No understanding = no safe refactor.
+
+### AI Code Cleanup Patterns (GitClear 2026)
+
+AI-generated code has specific patterns that need cleanup:
+- Code cloning: 4x more duplication. Extract shared logic.
+- Unused constructs: Imports, variables, functions never called. Delete.
+- Hardcoded debugging: console.log, print statements left behind. Remove.
+- Missing modularization: Long functions doing multiple things. Extract.
+- Copy-paste over abstraction: Duplicate blocks that should be functions.
+
+The verification bottleneck: AI generates faster than humans can review.
+Refactoring must be reviewable — small, atomic, tested.
+
+### Agentic Refactor Safety (background context)
+
+**Phantom abstraction**: AI frequently creates abstractions used in only one place.
+Rule: if an abstraction has exactly one call site, inline it. Wait for a second use
+case before abstracting. (Executable rule retained in SKILL.md step 8.)
+
+**Comment drift**: AI comments often describe what the code WAS doing before an edit.
+Audit every comment for accuracy during refactor — stale comments are worse than none.
+(Executable rule retained in SKILL.md step 8.)
+
+**Parallel agent conflicts**: If multiple agents touched the same file, check git log
+for overlapping changes. The "final" file may be a merge artifact, not intentional code.
+(Executable rule retained in SKILL.md step 8.)
+
+**Scope creep detection**: Before starting, write down EXACTLY what you're changing.
+After finishing, diff changes against that list. Any extras are scope creep — revert
+and open a separate task. (Executable rule retained in SKILL.md step 8.)
+
+**Explicit scope for refactor agents (Opus 4.7)**: Opus 4.7 follows instructions literally.
+- Wrong: "Rename `getUserData` to `fetchUser`"
+- Right: "Rename `getUserData` to `fetchUser` in ALL files across the codebase, including imports, tests, and docs"
+When spawning a surgeon for a refactor, enumerate the specific files in the contract.
+Ambiguous scope = partial refactor. (Executable rule retained in SKILL.md step 7.)
+
+### JiT Refactor Verification (background)
+
+From Meta's JiT research: generating tests at the point of change catches regressions
+that pre-existing suites miss — 4x bug-detection improvement. Tests generated JiT are
+disposable; they exist only to verify behavior preservation during this refactor.
+Delete them after if they're not worth keeping. Source: infoq.com/news/2026/04/meta-jit-testing-ai-detection/
+
+### Strategic Refactoring (stats and context)
+
+**Target high-impact components**: Teams targeting critical high-ROI components see 4x
+better results than comprehensive refactoring sweeps. Identify by: change frequency, bug
+density, review time.
+
+**Atomic transformations under 200 lines**: Keeping each change under 200 lines reduces
+code review time by 60% and lowers regression risk. Anything larger is a separate task.
+
+**Document before refactoring**: Before starting, create an architectural diagram and
+document any complex business logic the AI is unlikely to understand. AI frequently
+mishandles domain-specific constraints. Organizations that prepare context see 3x faster
+modernization cycles.
+
+**Success metrics**: A successful refactor measurably reduces cyclomatic complexity by
+15-25%. Organizations with systematic pre/post testing see 70% fewer post-deployment
+issues.
+
+**Embed into regular development**: Refactoring as a periodic "cleanup project" fails
+from adoption friction. Integrate into normal PR workflow: every merge includes a small
+cleanup.
+
+**Rollback procedure required**: Establish a clear rollback path (git SHA or stash)
+before every refactor. Never merge without the ability to undo.
+
+Sources: getdx.com/blog/enterprise-ai-refactoring-best-practices/,
+augmentcode.com/tools/ai-code-refactoring-tools-tactics-and-best-practices (2026-05-06)

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -101,4 +101,8 @@ Before ANY production deployment:
 - Giving agents more tools or file access than their task requires
 </anti_patterns>
 
+<on_complete>
+agentdb write-end '{"skill":"security","vectors_checked":["injection","xss","authz","secrets"],"findings":N}'
+</on_complete>
+
 </skill>

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -29,217 +29,48 @@ Skill-specific: skills/security/reference/security-research.md
 5. FAIL SECURE: Errors should deny access, not grant it.
 </core_principles>
 
-<secrets_management>
-```typescript
-// BAD: Hardcoded secrets
-const apiKey = "sk-proj-xxxxx"  // NEVER
+<flow>
 
-// GOOD: Environment variables
-const apiKey = process.env.OPENAI_API_KEY
-if (!apiKey) throw new Error('OPENAI_API_KEY not configured')
-```
+  1. **Secrets check** — grep for hardcoded keys/passwords/tokens before any commit.
+     (gate: `git grep -E "(api_key|apiKey|password|secret|token)\s*=\s*['\"][^'\"]{8,}"` returns empty)
 
-Checklist before commit:
-- [ ] No API keys in code
-- [ ] No passwords in code
-- [ ] No connection strings with credentials
-- [ ] .env files in .gitignore
-- [ ] Secrets in environment variables or vault
-</secrets_management>
+  2. **Input validation** — all user input validated at API boundary with schema (Zod/Pydantic).
+     (gate: every public endpoint parses input through schema before use; see code patterns in reference)
 
-<input_validation>
-```typescript
-import { z } from 'zod'
+  3. **SQL injection** — all queries parameterized; no string concatenation with user data.
+     (gate: grep for template literal SQL with user variables returns empty)
 
-const CreateUserSchema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1).max(100),
-  age: z.number().int().min(0).max(150)
-})
+  4. **XSS prevention** — user-provided HTML sanitized (DOMPurify); CSP headers configured.
+     (gate: `dangerouslySetInnerHTML` only appears with DOMPurify wrapping)
 
-export async function createUser(input: unknown) {
-  const validated = CreateUserSchema.parse(input)
-  return await db.users.create(validated)
-}
-```
+  5. **Authentication** — tokens in httpOnly cookies, not localStorage; auth checked per-request.
+     (gate: no `localStorage.setItem('token'`; every protected route has auth check)
 
-```typescript
-// File upload validation
-function validateFileUpload(file: File) {
-  const maxSize = 5 * 1024 * 1024  // 5MB
-  if (file.size > maxSize) throw new Error('File too large')
+  6. **Authorization** — role/ownership check before every sensitive operation.
+     (gate: no delete/update/admin endpoint without requester role verification)
 
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif']
-  if (!allowedTypes.includes(file.type)) throw new Error('Invalid file type')
+  7. **CSRF protection** — tokens on state-changing requests; SameSite=Strict on session cookies.
+     (gate: POST/PUT/DELETE endpoints verify X-CSRF-Token or use SameSite cookie)
 
-  const allowedExtensions = ['.jpg', '.jpeg', '.png', '.gif']
-  const ext = file.name.toLowerCase().match(/\.[^.]+$/)?.[0]
-  if (!ext || !allowedExtensions.includes(ext)) throw new Error('Invalid extension')
-}
-```
-</input_validation>
+  8. **Rate limiting** — enabled on all public endpoints; stricter on expensive ops.
+     (gate: every `/api/` route has rate limit middleware)
 
-<sql_injection>
-```typescript
-// BAD: String concatenation
-const query = `SELECT * FROM users WHERE email = '${userEmail}'`  // NEVER
+  9. **Error handling** — generic messages in responses; stack traces only in server logs.
+     (gate: no `error.stack` or internal paths in HTTP response bodies)
 
-// GOOD: Parameterized queries
-const { data } = await supabase
-  .from('users')
-  .select('*')
-  .eq('email', userEmail)
+  10. **Dependency audit** — `npm audit` / `pip-audit` clean; lockfile committed.
+      (gate: audit exits 0 or all findings are acknowledged with justification)
 
-// Or with raw SQL
-await db.query('SELECT * FROM users WHERE email = $1', [userEmail])
-```
-</sql_injection>
+  11. **Supply chain** — verify package existence + download counts before installing AI-suggested packages.
+      (gate: no packages added without explicit npm/pypi verification; see supply chain patterns in reference)
 
-<xss_prevention>
-```typescript
-import DOMPurify from 'isomorphic-dompurify'
+  12. **Prompt injection** (AI-integrated features) — user text never interpolated into system prompts; LLM output validated before use.
+      (gate: no f-string/template system prompt with raw user input; see prompt injection patterns in reference)
 
-// ALWAYS sanitize user-provided HTML
-function renderUserContent(html: string) {
-  const clean = DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'p'],
-    ALLOWED_ATTR: []
-  })
-  return <div dangerouslySetInnerHTML={{ __html: clean }} />
-}
-```
+  13. **Agent permissions** — every spawned agent has explicit tool allowlist + file scope; no admin-by-default.
+      (gate: spawn contract lists allowed tools ≤5; sensitive scopes named explicitly)
 
-```typescript
-// Content Security Policy
-const securityHeaders = [
-  {
-    key: 'Content-Security-Policy',
-    value: `
-      default-src 'self';
-      script-src 'self' 'unsafe-eval' 'unsafe-inline';
-      style-src 'self' 'unsafe-inline';
-      img-src 'self' data: https:;
-      connect-src 'self' https://api.example.com;
-    `.replace(/\s{2,}/g, ' ').trim()
-  }
-]
-```
-</xss_prevention>
-
-<authentication>
-```typescript
-// BAD: localStorage (vulnerable to XSS)
-localStorage.setItem('token', token)  // NEVER
-
-// GOOD: httpOnly cookies
-res.setHeader('Set-Cookie',
-  `token=${token}; HttpOnly; Secure; SameSite=Strict; Max-Age=3600`)
-```
-
-```typescript
-// Authorization check
-export async function deleteUser(userId: string, requesterId: string) {
-  const requester = await db.users.findUnique({ where: { id: requesterId } })
-
-  if (requester.role !== 'admin') {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
-  }
-
-  await db.users.delete({ where: { id: userId } })
-}
-```
-
-```sql
--- Row Level Security (Supabase)
-ALTER TABLE users ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY "Users view own data"
-  ON users FOR SELECT
-  USING (auth.uid() = id);
-```
-</authentication>
-
-<csrf_protection>
-```typescript
-import { csrf } from '@/lib/csrf'
-
-export async function POST(request: Request) {
-  const token = request.headers.get('X-CSRF-Token')
-
-  if (!csrf.verify(token)) {
-    return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 })
-  }
-
-  // Process request
-}
-```
-
-```typescript
-// SameSite cookies prevent CSRF
-res.setHeader('Set-Cookie',
-  `session=${sessionId}; HttpOnly; Secure; SameSite=Strict`)
-```
-</csrf_protection>
-
-<rate_limiting>
-```typescript
-import rateLimit from 'express-rate-limit'
-
-// General API rate limit
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,  // 15 minutes
-  max: 100,                   // 100 requests per window
-  message: 'Too many requests'
-})
-
-// Stricter limit for expensive operations
-const searchLimiter = rateLimit({
-  windowMs: 60 * 1000,  // 1 minute
-  max: 10,              // 10 requests per minute
-})
-
-app.use('/api/', limiter)
-app.use('/api/search', searchLimiter)
-```
-</rate_limiting>
-
-<error_handling>
-```typescript
-// BAD: Exposing internals
-catch (error) {
-  return NextResponse.json({
-    error: error.message,
-    stack: error.stack  // NEVER
-  }, { status: 500 })
-}
-
-// GOOD: Generic messages
-catch (error) {
-  console.error('Internal error:', error)  // Log for debugging
-  return NextResponse.json({
-    error: 'An error occurred. Please try again.'
-  }, { status: 500 })
-}
-```
-
-```typescript
-// BAD: Logging sensitive data
-console.log('User login:', { email, password })  // NEVER
-
-// GOOD: Redact sensitive fields
-console.log('User login:', { email, userId })
-```
-</error_handling>
-
-<owasp_awareness>
-Top vulnerabilities to prevent:
-- Injection (SQL, command, LDAP) - parameterized queries, never string concat
-- Broken auth - secure session management, MFA where possible
-- Sensitive data exposure - encrypt at rest and in transit
-- XSS - output encoding, CSP headers
-- CSRF - tokens for state-changing requests
-- Security misconfiguration - secure defaults, minimal exposure
-</owasp_awareness>
+</flow>
 
 <pre_deployment_checklist>
 Before ANY production deployment:
@@ -258,67 +89,6 @@ Before ANY production deployment:
 - [ ] **RLS**: Row Level Security enabled (Supabase)
 - [ ] **File Uploads**: Validated (size, type, extension)
 </pre_deployment_checklist>
-
-<supply_chain>
-<!-- Updated 2026-03-30: Claude Code best practices, OWASP supply chain guidance -->
-AI-generated code introduces supply chain risks beyond traditional OWASP top 10:
-
-- **Hallucinated packages**: AI may reference packages that don't exist or have been
-  name-squatted. Always verify package existence and download counts before installing.
-- **Version pinning**: Pin exact versions in package.json/requirements.txt for production.
-  Floating versions allow silent breaking changes on redeploy.
-- **Dependency audit cadence**: Run `npm audit` / `pip audit` / `cargo audit` on every PR,
-  not just on release. CI gate should block merge on HIGH/CRITICAL findings.
-- **Lockfile integrity**: Commit lockfiles. Verify lockfile wasn't modified unexpectedly
-  before merging PRs (lockfile tampering is a supply chain attack vector).
-</supply_chain>
-
-<prompt_injection>
-<!-- Updated 2026-03-30: Anthropic prompt engineering guide, agentic security research -->
-When building AI-integrated features, prevent prompt injection:
-
-- **Untrusted content isolation**: Never interpolate user-provided text directly into
-  system prompts. Use structured data formats (JSON tool calls) instead of free-text.
-- **Output validation**: Treat LLM output as untrusted input. Validate and sanitize before
-  rendering or executing.
-- **Capability scoping**: AI agents should have only the permissions needed for their task.
-  An agent that reads files shouldn't be able to write to disk unless explicitly required.
-- **Indirect injection**: User-provided data can contain injections that activate when
-  processed by an AI (e.g., "Ignore previous instructions and..."). Sanitize on ingestion,
-  not just on display.
-</prompt_injection>
-
-<!-- Updated 2026-04-29: https://javaworldmag.com/evolving-code-reviews-with-ai-in-2026/, https://codeintelligently.com/blog/ai-code-quality-guide-2026 -->
-<cautionary_pattern_library>
-AI code reviewers miss security issues that require system context humans possess.
-Maintain a living doc at `_meta/security/cautionary-patterns.md` capturing:
-- AI hallucinations that produced plausible but insecure code (non-existent APIs called, wrong auth flows)
-- Patterns where AI bypassed validation "for simplicity" that later became vulnerabilities
-- Successful security prompts that caught real issues (promote to skills)
-
-Review this doc before any security-sensitive implementation. Institutional memory beats repeated audits.
-</cautionary_pattern_library>
-
-<!-- Updated 2026-05-12: https://www.coderabbit.ai/blog/claude-opus-4-7-for-ai-code-review -->
-<agentic_security_scanning>
-**In-agent dependency scanning**: Use Snyk MCP (or equivalent) to run vulnerability checks inside the agent rather than as a separate CI step. Agent sees results inline, can fix issues before committing. Install once, invoke via MCP tool calls.
-
-**Tool count limit**: Give each security-review agent ≤5 tools. Each tool adds context overhead; beyond 5, agents lose focus and tool selection degrades. For security review: Read + Grep + Bash (run audit) + one MCP scanner. That's it.
-
-**Agent permission audit**: Before spawning any agent that touches auth, payments, or PII, explicitly list its allowed tools and file scope in the contract. An agent scoped to read `src/api/` should never touch `src/auth/` or `.env`. Least-privilege applies to agents, not just users.
-</agentic_security_scanning>
-
-<!-- Updated 2026-05-17: web research — https://brightsec.com/blog/ai-code-review-best-practices-2-0-2026-toolchain/, https://www.kluster.ai/blog/best-code-review-practices -->
-<risk_based_review_config>
-Configure AI code review tools with risk-based rules — not blanket "review everything" settings. Default-enable scanning for:
-- Deleted input validations (highest risk: silent regression)
-- Auth flow changes (any modification to authentication/authorization logic)
-- Query changes touching user-scoped data (RLS bypass risk)
-- SQLi / XSS / unsafe API patterns
-- Functions exceeding complexity threshold (complexity correlates with audit misses)
-
-Turn off style and formatting rules in security scanning — noise drowns signal. Security reviewers should see zero false-positive noise to avoid alert fatigue.
-</risk_based_review_config>
 
 <anti_patterns>
 - "We'll add security later" (you won't)

--- a/skills/security/reference/security-research.md
+++ b/skills/security/reference/security-research.md
@@ -163,3 +163,292 @@ jailbreak success climbs from 4.3% baseline to 78.5% in multi-turn scenarios.
 - Invariants in kernel.md: no hardcoded secrets, no irreversible operations
   without confirmation.
 - tearitapart: security review is a dedicated phase in architecture assessment.
+
+---
+
+## Code Patterns: Secrets Management
+
+```typescript
+// BAD: Hardcoded secrets
+const apiKey = "sk-proj-xxxxx"  // NEVER
+
+// GOOD: Environment variables
+const apiKey = process.env.OPENAI_API_KEY
+if (!apiKey) throw new Error('OPENAI_API_KEY not configured')
+```
+
+Checklist before commit:
+- [ ] No API keys in code
+- [ ] No passwords in code
+- [ ] No connection strings with credentials
+- [ ] .env files in .gitignore
+- [ ] Secrets in environment variables or vault
+
+---
+
+## Code Patterns: Input Validation
+
+```typescript
+import { z } from 'zod'
+
+const CreateUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1).max(100),
+  age: z.number().int().min(0).max(150)
+})
+
+export async function createUser(input: unknown) {
+  const validated = CreateUserSchema.parse(input)
+  return await db.users.create(validated)
+}
+```
+
+```typescript
+// File upload validation
+function validateFileUpload(file: File) {
+  const maxSize = 5 * 1024 * 1024  // 5MB
+  if (file.size > maxSize) throw new Error('File too large')
+
+  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif']
+  if (!allowedTypes.includes(file.type)) throw new Error('Invalid file type')
+
+  const allowedExtensions = ['.jpg', '.jpeg', '.png', '.gif']
+  const ext = file.name.toLowerCase().match(/\.[^.]+$/)?.[0]
+  if (!ext || !allowedExtensions.includes(ext)) throw new Error('Invalid extension')
+}
+```
+
+---
+
+## Code Patterns: SQL Injection
+
+```typescript
+// BAD: String concatenation
+const query = `SELECT * FROM users WHERE email = '${userEmail}'`  // NEVER
+
+// GOOD: Parameterized queries
+const { data } = await supabase
+  .from('users')
+  .select('*')
+  .eq('email', userEmail)
+
+// Or with raw SQL
+await db.query('SELECT * FROM users WHERE email = $1', [userEmail])
+```
+
+---
+
+## Code Patterns: XSS Prevention
+
+```typescript
+import DOMPurify from 'isomorphic-dompurify'
+
+// ALWAYS sanitize user-provided HTML
+function renderUserContent(html: string) {
+  const clean = DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'p'],
+    ALLOWED_ATTR: []
+  })
+  return <div dangerouslySetInnerHTML={{ __html: clean }} />
+}
+```
+
+```typescript
+// Content Security Policy
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: `
+      default-src 'self';
+      script-src 'self' 'unsafe-eval' 'unsafe-inline';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' data: https:;
+      connect-src 'self' https://api.example.com;
+    `.replace(/\s{2,}/g, ' ').trim()
+  }
+]
+```
+
+---
+
+## Code Patterns: Authentication
+
+```typescript
+// BAD: localStorage (vulnerable to XSS)
+localStorage.setItem('token', token)  // NEVER
+
+// GOOD: httpOnly cookies
+res.setHeader('Set-Cookie',
+  `token=${token}; HttpOnly; Secure; SameSite=Strict; Max-Age=3600`)
+```
+
+```typescript
+// Authorization check
+export async function deleteUser(userId: string, requesterId: string) {
+  const requester = await db.users.findUnique({ where: { id: requesterId } })
+
+  if (requester.role !== 'admin') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
+  }
+
+  await db.users.delete({ where: { id: userId } })
+}
+```
+
+```sql
+-- Row Level Security (Supabase)
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users view own data"
+  ON users FOR SELECT
+  USING (auth.uid() = id);
+```
+
+---
+
+## Code Patterns: CSRF Protection
+
+```typescript
+import { csrf } from '@/lib/csrf'
+
+export async function POST(request: Request) {
+  const token = request.headers.get('X-CSRF-Token')
+
+  if (!csrf.verify(token)) {
+    return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 })
+  }
+
+  // Process request
+}
+```
+
+```typescript
+// SameSite cookies prevent CSRF
+res.setHeader('Set-Cookie',
+  `session=${sessionId}; HttpOnly; Secure; SameSite=Strict`)
+```
+
+---
+
+## Code Patterns: Rate Limiting
+
+```typescript
+import rateLimit from 'express-rate-limit'
+
+// General API rate limit
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,  // 15 minutes
+  max: 100,                   // 100 requests per window
+  message: 'Too many requests'
+})
+
+// Stricter limit for expensive operations
+const searchLimiter = rateLimit({
+  windowMs: 60 * 1000,  // 1 minute
+  max: 10,              // 10 requests per minute
+})
+
+app.use('/api/', limiter)
+app.use('/api/search', searchLimiter)
+```
+
+---
+
+## Code Patterns: Error Handling
+
+```typescript
+// BAD: Exposing internals
+catch (error) {
+  return NextResponse.json({
+    error: error.message,
+    stack: error.stack  // NEVER
+  }, { status: 500 })
+}
+
+// GOOD: Generic messages
+catch (error) {
+  console.error('Internal error:', error)  // Log for debugging
+  return NextResponse.json({
+    error: 'An error occurred. Please try again.'
+  }, { status: 500 })
+}
+```
+
+```typescript
+// BAD: Logging sensitive data
+console.log('User login:', { email, password })  // NEVER
+
+// GOOD: Redact sensitive fields
+console.log('User login:', { email, userId })
+```
+
+---
+
+## Supply Chain Security (Updated 2026-03-30)
+<!-- Sources: Claude Code best practices, OWASP supply chain guidance -->
+
+AI-generated code introduces supply chain risks beyond traditional OWASP top 10:
+
+- **Hallucinated packages**: AI may reference packages that don't exist or have been
+  name-squatted. Always verify package existence and download counts before installing.
+- **Version pinning**: Pin exact versions in package.json/requirements.txt for production.
+  Floating versions allow silent breaking changes on redeploy.
+- **Dependency audit cadence**: Run `npm audit` / `pip audit` / `cargo audit` on every PR,
+  not just on release. CI gate should block merge on HIGH/CRITICAL findings.
+- **Lockfile integrity**: Commit lockfiles. Verify lockfile wasn't modified unexpectedly
+  before merging PRs (lockfile tampering is a supply chain attack vector).
+
+---
+
+## Prompt Injection Patterns (Updated 2026-03-30)
+<!-- Sources: Anthropic prompt engineering guide, agentic security research -->
+
+When building AI-integrated features, prevent prompt injection:
+
+- **Untrusted content isolation**: Never interpolate user-provided text directly into
+  system prompts. Use structured data formats (JSON tool calls) instead of free-text.
+- **Output validation**: Treat LLM output as untrusted input. Validate and sanitize before
+  rendering or executing.
+- **Capability scoping**: AI agents should have only the permissions needed for their task.
+  An agent that reads files shouldn't be able to write to disk unless explicitly required.
+- **Indirect injection**: User-provided data can contain injections that activate when
+  processed by an AI (e.g., "Ignore previous instructions and..."). Sanitize on ingestion,
+  not just on display.
+
+---
+
+## Cautionary Pattern Library (Updated 2026-04-29)
+<!-- Sources: https://javaworldmag.com/evolving-code-reviews-with-ai-in-2026/, https://codeintelligently.com/blog/ai-code-quality-guide-2026 -->
+
+AI code reviewers miss security issues that require system context humans possess.
+Maintain a living doc at `_meta/security/cautionary-patterns.md` capturing:
+- AI hallucinations that produced plausible but insecure code (non-existent APIs called, wrong auth flows)
+- Patterns where AI bypassed validation "for simplicity" that later became vulnerabilities
+- Successful security prompts that caught real issues (promote to skills)
+
+Review this doc before any security-sensitive implementation. Institutional memory beats repeated audits.
+
+---
+
+## Agentic Security Scanning (Updated 2026-05-12)
+<!-- Source: https://www.coderabbit.ai/blog/claude-opus-4-7-for-ai-code-review -->
+
+**In-agent dependency scanning**: Use Snyk MCP (or equivalent) to run vulnerability checks inside the agent rather than as a separate CI step. Agent sees results inline, can fix issues before committing. Install once, invoke via MCP tool calls.
+
+**Tool count limit**: Give each security-review agent ≤5 tools. Each tool adds context overhead; beyond 5, agents lose focus and tool selection degrades. For security review: Read + Grep + Bash (run audit) + one MCP scanner. That's it.
+
+**Agent permission audit**: Before spawning any agent that touches auth, payments, or PII, explicitly list its allowed tools and file scope in the contract. An agent scoped to read `src/api/` should never touch `src/auth/` or `.env`. Least-privilege applies to agents, not just users.
+
+---
+
+## Risk-Based Review Configuration (Updated 2026-05-17)
+<!-- Sources: https://brightsec.com/blog/ai-code-review-best-practices-2-0-2026-toolchain/, https://www.kluster.ai/blog/best-code-review-practices -->
+
+Configure AI code review tools with risk-based rules — not blanket "review everything" settings. Default-enable scanning for:
+- Deleted input validations (highest risk: silent regression)
+- Auth flow changes (any modification to authentication/authorization logic)
+- Query changes touching user-scoped data (RLS bypass risk)
+- SQLi / XSS / unsafe API patterns
+- Functions exceeding complexity threshold (complexity correlates with audit misses)
+
+Turn off style and formatting rules in security scanning — noise drowns signal. Security reviewers should see zero false-positive noise to avoid alert fatigue.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: kernel:ship
+name: ship
 description: "Release-gate sequence: validate → review → push → tag. Wraps kernel:git mechanics with the pre-ship safety chain. Triggers: ship, release, push to main, ready to merge, deploy."
 allowed-tools: Read, Bash, Task, Edit
 ---

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -6,115 +6,65 @@ allowed-tools: Read, Bash, Task, Edit
 
 <skill id="ship">
 
-<purpose>
-Shipping is not committing. Committing is one step of shipping.
-Ship = the full sequence: validate gates → review → push → optionally tag.
-Each step has a fail-fast verdict; the chain stops on first failure.
-</purpose>
+## Sequence
 
-<prerequisite>
-agentdb read-start has run. Working tree is clean OR all uncommitted work is intentional and named.
-You know what you are shipping: branch name, commit range, the thing this release changes.
-</prerequisite>
+1. **Preflight**
+   - `git status --porcelain` — clean? If not: ask user to commit, stash, or abandon.
+   - `git branch --show-current` — matches intent? Wrong branch → stop.
+   - `git log --oneline {main}..HEAD` — commit range matches what you think you're shipping?
+   - (gate: any mismatch → AskUserQuestion before continuing)
 
-<reference>
-Pairs with skills/git/SKILL.md (commit mechanics) and skills/quality/SKILL.md (Big 5).
-Invokes /kernel:validate (gates) and /kernel:review (PR review). Spawns agents/pre-ship.md
-for tier 2+ work.
-</reference>
+2. **Validate**
+   - Invoke `/kernel:validate` (spawns validator agent, full 9-gate safety chain).
+   - If unavailable: run project's nearest configured command (see reference/ship-research.md for equivalents).
+   - (gate: any FAIL → stop; report which gate; do NOT push)
 
-<core_principles>
-1. **Validate before review, review before push, push before tag.** The order is fail-fast.
-2. **Push to `main` requires explicit user say-so.** Feature branch push is fine after gates pass.
-3. **The release is the artifact, not the intent.** Verify by file/diff, not by what you meant to ship.
-4. **Tag only when explicitly releasing.** Casual pushes don't get tags.
-5. **Hook carve-outs apply to hooks only.** User and agent commits in this skill go through the full gate chain.
-</core_principles>
+3. **Review**
+   - Tier 1 (1–2 file changes, low risk): self-review via Big 5 from skills/quality/SKILL.md.
+   - Tier 2+: invoke `/kernel:review` (spawns reviewer agent, >80% confidence threshold).
+   - (gate: REQUEST CHANGES → stop; address feedback; restart from step 2)
+   - (gate: COMMENT → AskUserQuestion: "Address now, ship anyway, or hold?")
+   - (gate: APPROVE → continue)
 
-<sequence>
+4. **Push**
+   - Feature branch (`feat/*`, `fix/*`, `chore/*`, etc.): `git push` (or `git push -u origin {branch}` if upstream not set).
+   - `main` / `master`: **STOP. AskUserQuestion required.** (NEXUS I0.8)
+   - Detached HEAD or unexpected state: stop; investigate.
+   - (gate: push rejected / non-fast-forward → surface to user; do NOT force-push)
 
-  <phase id="preflight">
-    Before anything else:
-    - `git status --porcelain` clean? If not: ask user to commit, stash, or abandon.
-    - `git branch --show-current` matches the intent? If user said "ship the auth fix" but you're on `main`, stop.
-    - Commit range: `git log --oneline {main}..HEAD` — does it match what you think you're shipping?
-    - If anything looks wrong, AskUserQuestion before continuing.
-  </phase>
+5. **Tag** *(only if user explicitly requested a tagged release)*
+   - Check: `git tag -l` — confirm tag doesn't already exist.
+   - Semver: read version from manifest, confirm next version with user.
+   - `git tag -a v{X.Y.Z} -m "{release notes summary}"` → `git push origin v{X.Y.Z}`.
+   - Non-versioned: timestamp tag if requested; otherwise skip.
 
-  <phase id="validate">
-    Invoke /kernel:validate (spawns validator agent with full 9-gate safety chain).
-    Block on any FAIL. Do not soft-skip a gate.
+6. **Checkpoint**
+   - `agentdb learn pattern "ship: {branch} {commit_range} {sha_pushed}" "validate=pass review=pass push=ok"`
+   - Profile-gated: github-oss/github-production → post PR or release note via gh CLI.
 
-    Quick local equivalents if /kernel:validate is unavailable:
-    - Tests: project's nearest configured command (`npm test`, `pytest`, `cargo test`, etc.)
-    - Types: `tsc --noEmit` / `mypy` / `cargo check`
-    - Lint: `eslint` / `ruff` / `cargo clippy`
-    - Security: `npm audit` / `pip-audit` / project's configured scanner
-    - Diff sanity: `git diff --stat {main}..HEAD` — no unrelated changes, no leaked secrets
+## Ask-user gates (mandatory pause points)
 
-    On FAIL: stop. Report which gate failed and why. Do not push.
-  </phase>
+| Point | Condition | Question |
+|---|---|---|
+| Preflight | Branch or commit range is ambiguous | "Shipping {N} commits on {branch}. Confirm?" |
+| Review | COMMENT verdict | "Review returned {N} comments. Address now, ship anyway, or hold?" |
+| Push | Target is main/master | "About to push to main. NEXUS I0.8 requires explicit say-so. Confirm?" |
 
-  <phase id="review">
-    Tier 1 (1-2 file changes, low risk): self-review via Big 5 from skills/quality/SKILL.md.
-    Tier 2+: invoke /kernel:review (spawns reviewer agent at >80% confidence threshold).
+## Failure modes
 
-    If review returns REQUEST CHANGES: stop. Address feedback. Re-run from validate.
-    If review returns COMMENT: surface the comments to user; ask if they want to proceed or address.
-    If review returns APPROVE: continue.
-  </phase>
+1. `validate FAIL` → block; report which gate; do not loop silently
+2. `review REQUEST_CHANGES` → block; address comments; restart from step 2
+3. `push rejected (non-fast-forward)` → ask user; never auto-rebase or force-push
+4. `tag conflict` → check `git tag -l` first; suggest next version; never overwrite existing tag
 
-  <phase id="push">
-    Branch detection:
-    - Feature branch (`feat/*`, `fix/*`, `chore/*`, etc.): push without further confirmation.
-    - `main` / `master`: **STOP. AskUserQuestion before pushing.** Push to main requires explicit user say-so (NEXUS I0.8).
-    - Detached HEAD or weird state: stop. Investigate.
+## Anti-patterns
 
-    Push command: `git push` (or `git push -u origin {branch}` if upstream not set).
-    On rejection (non-fast-forward, hook block, auth fail): surface to user. Do NOT force-push.
-  </phase>
-
-  <phase id="tag" optional="true">
-    Only if the user explicitly asked to tag a release.
-
-    For semver projects: read current version from manifest (`package.json`, `Cargo.toml`,
-    `pyproject.toml`, etc.), confirm next version with user, then:
-    `git tag -a v{X.Y.Z} -m "{release notes summary}"` and `git push origin v{X.Y.Z}`.
-
-    For non-versioned projects: timestamp tag if requested, otherwise skip.
-  </phase>
-
-  <phase id="checkpoint">
-    agentdb learn pattern "ship: {branch} {commit_range} {sha_pushed}" "validate=pass review=pass push=ok"
-    Profile-gated:
-    - github-oss / github-production: post PR or release note via gh CLI / GitHub integration hooks.
-    - local: nothing further.
-  </phase>
-
-</sequence>
-
-<ask_user>
-  Use AskUserQuestion at three points:
-  1. Preflight, if branch or commit range is ambiguous: "Shipping {N} commits on {branch}. Confirm?"
-  2. Review COMMENT verdict (not REQUEST CHANGES): "Review returned {N} comments. Address now, ship anyway, or hold?"
-  3. Push to main: "About to push to main. NEXUS I0.8 requires explicit say-so. Confirm?"
-</ask_user>
-
-<failure_modes>
-1. validate FAIL → block; report which gate; do not loop silently into "try again"
-2. review REQUEST CHANGES → block; address comments; restart from validate (changes invalidate prior gates)
-3. push rejected (non-fast-forward) → ask user; never auto-rebase or force-push
-4. tag conflict → check `git tag -l` first; suggest next version; never overwrite an existing tag
-</failure_modes>
-
-<anti_patterns>
-- ship_without_validate: every step depends on the previous; skipping validate skips type/test/security
-- silent_skip_review: review FAIL with no surfacing to user = trust violation
-- auto_push_to_main: NEXUS I0.8 — main requires explicit user confirmation
-- force_push_on_rejection: rejection means the remote has work you don't; investigate before overwriting
-- tag_without_release_intent: tags are durable; casual pushes get no tag
-- skip_checkpoint: shipped-but-unrecorded work breaks retrospective and learning loops
-</anti_patterns>
+- `ship_without_validate` — every step depends on the previous; skipping validate skips type/test/security
+- `silent_skip_review` — review FAIL with no surfacing to user = trust violation
+- `auto_push_to_main` — NEXUS I0.8; main requires explicit user confirmation
+- `force_push_on_rejection` — rejection means remote has work you don't; investigate before overwriting
+- `tag_without_release_intent` — tags are durable; casual pushes get no tag
+- `skip_checkpoint` — shipped-but-unrecorded work breaks retrospective and learning loops
 
 <on_complete>
 agentdb write-end '{"skill":"ship","branch":"X","commits":N,"validate":"pass","review":"approve|comment|skip","pushed":true,"tagged":"X.Y.Z|none"}'

--- a/skills/ship/reference/ship-research.md
+++ b/skills/ship/reference/ship-research.md
@@ -1,0 +1,59 @@
+---
+date: 2026-05-28
+topic: ship skill — background, rationale, tooling survey
+---
+
+# Ship Skill — Reference
+
+## Purpose and mental model
+
+Shipping is not committing. Committing is one step of shipping.
+Ship = the full sequence: validate gates → review → push → optionally tag.
+Each step has a fail-fast verdict; the chain stops on first failure.
+
+## Skill relationships
+
+- skills/git/SKILL.md — commit mechanics
+- skills/quality/SKILL.md — Big 5 self-review checklist
+- /kernel:validate — invokes validator agent (full 9-gate safety chain)
+- /kernel:review — invokes reviewer agent (>80% confidence threshold)
+- agents/pre-ship.md — composite release gate for tier 2+ work (spawns 4 parallel validators)
+
+## Core principles (the "why" behind the sequence)
+
+1. **Validate before review, review before push, push before tag.** The order is fail-fast.
+2. **Push to `main` requires explicit user say-so.** Feature branch push is fine after gates pass.
+3. **The release is the artifact, not the intent.** Verify by file/diff, not by what you meant to ship.
+4. **Tag only when explicitly releasing.** Casual pushes don't get tags.
+5. **Hook carve-outs apply to hooks only.** User and agent commits in this skill go through the full gate chain.
+
+## Local gate equivalents (when /kernel:validate unavailable)
+
+Use the project's nearest configured command first (`package.json` scripts, `Makefile`, `pyproject.toml`, `justfile`).
+
+| Gate | Command |
+|---|---|
+| Tests | `npm test` / `pytest` / `cargo test` |
+| Types | `tsc --noEmit` / `mypy` / `cargo check` |
+| Lint | `eslint` / `ruff` / `cargo clippy` |
+| Security | `npm audit` / `pip-audit` / project scanner |
+| Diff sanity | `git diff --stat {main}..HEAD` — no unrelated changes, no leaked secrets |
+
+## Tag format details
+
+- Semver projects: read version from manifest (`package.json`, `Cargo.toml`, `pyproject.toml`), confirm next version with user.
+- Command: `git tag -a v{X.Y.Z} -m "{release notes summary}"` then `git push origin v{X.Y.Z}`.
+- Non-versioned projects: timestamp tag if requested, otherwise skip.
+- Check before tagging: `git tag -l` to avoid overwriting existing tags.
+
+## Profile-gated post-ship actions
+
+- `github-oss` / `github-production`: post PR or release note via `gh` CLI / GitHub integration hooks.
+- `local`: nothing further beyond agentdb checkpoint.
+
+## Why the ask_user gates exist
+
+Three mandatory pause points prevent autonomy overreach:
+1. **Preflight ambiguity** — wrong branch or unexpected commit range is a pre-condition failure, not a recoverable error.
+2. **Review COMMENT (not REQUEST CHANGES)** — comments are advisory; the human decides if they block.
+3. **Push to main** — NEXUS I0.8 is non-negotiable; explicit confirmation is the external hook equivalent for this gate.

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -6,20 +6,28 @@ allowed-tools: Read, Bash, Write, Edit, Grep, Glob
 
 <skill id="tdd">
 
-<purpose>
-Tests first, code second. No exceptions. The test defines the contract; the code fulfills it.
-Red (failing test) -> Green (minimal code to pass) -> Refactor (clean up while green).
-If you write code before tests, you're testing your bugs, not your requirements.
-</purpose>
-
 <prerequisite>
-AgentDB read-start has run. Check for existing test patterns in codebase.
-Identify test framework in use (Jest, Vitest, pytest, etc.).
+1. agentdb read-start — check for existing test patterns in codebase.
+2. Identify test framework in use (Jest, Vitest, pytest).
+3. Check _meta/research/ for prior TDD work.
 </prerequisite>
 
 <reference>
-Skill-specific: skills/tdd/reference/tdd-research.md
+skills/tdd/reference/tdd-research.md — mocking patterns, framework examples, coverage config, organization strategies
 </reference>
+
+<workflow>
+1. Write user journey: "As a [role], I want [action], so that [benefit]"
+2. Generate test cases from journey (happy path, edge cases, errors)
+3. Write tests first.
+   (gate: `npm test` / `pytest` exits non-zero — tests must FAIL red before proceeding)
+4. Implement MINIMAL code to pass — no anticipatory features.
+   (gate: `npm test` / `pytest` exits zero — all tests GREEN)
+5. Refactor while keeping tests green.
+   (gate: tests still pass after every change; file ends same length or shorter)
+6. Verify coverage >= 80% branches/functions/lines/statements.
+   (gate: coverage report shows >= 80% on all axes)
+</workflow>
 
 <core_principles>
 1. TESTS DEFINE BEHAVIOR: Write tests from requirements, not implementation. Test what SHOULD happen.
@@ -29,71 +37,6 @@ Skill-specific: skills/tdd/reference/tdd-research.md
 5. ONE ASSERT PER TEST: Test names are specifications. Split if "and" appears.
 </core_principles>
 
-<workflow>
-1. Write user journey: "As a [role], I want [action], so that [benefit]"
-2. Generate test cases from journey (happy path, edge cases, errors)
-3. Run tests - they MUST fail (red)
-4. Implement minimal code to pass
-5. Run tests - they MUST pass (green)
-6. Refactor while keeping tests green
-7. Verify coverage >= 80%
-</workflow>
-
-<mocking_patterns>
-<!-- Supabase -->
-```typescript
-jest.mock('@/lib/supabase', () => ({
-  supabase: {
-    from: jest.fn(() => ({
-      select: jest.fn(() => ({
-        eq: jest.fn(() => Promise.resolve({
-          data: [{ id: 1, name: 'Test' }],
-          error: null
-        }))
-      }))
-    }))
-  }
-}))
-```
-
-<!-- Redis -->
-```typescript
-jest.mock('@/lib/redis', () => ({
-  searchByVector: jest.fn(() => Promise.resolve([
-    { slug: 'test', similarity_score: 0.95 }
-  ])),
-  checkHealth: jest.fn(() => Promise.resolve({ connected: true }))
-}))
-```
-
-<!-- OpenAI -->
-```typescript
-jest.mock('@/lib/openai', () => ({
-  generateEmbedding: jest.fn(() => Promise.resolve(
-    new Array(1536).fill(0.1)
-  ))
-}))
-```
-</mocking_patterns>
-
-<test_organization>
-```
-src/
-  components/
-    Button/
-      Button.tsx
-      Button.test.tsx      # Unit tests colocated
-  app/
-    api/
-      users/
-        route.ts
-        route.test.ts      # Integration tests colocated
-e2e/
-  auth.spec.ts             # E2E tests separate
-  checkout.spec.ts
-```
-</test_organization>
-
 <anti_patterns>
 <block id="code_before_test">Writing code then tests validates bugs. Test first or not at all.</block>
 <block id="testing_implementation">Test behavior, not structure. Refactoring should not break tests.</block>
@@ -101,23 +44,6 @@ e2e/
 <block id="brittle_selectors">Use semantic selectors ([data-testid], role), not CSS classes.</block>
 <block id="test_dependency">Each test must be independent. No shared state between tests.</block>
 </anti_patterns>
-
-<coverage_config>
-```json
-{
-  "jest": {
-    "coverageThreshold": {
-      "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": 80
-      }
-    }
-  }
-}
-```
-</coverage_config>
 
 <on_complete>
 agentdb write-end '{"skill":"tdd","tests_written":<N>,"coverage":"<X%>","cycle":"red->green->refactor","failures_caught":["<list>"]}'

--- a/skills/tdd/reference/tdd-research.md
+++ b/skills/tdd/reference/tdd-research.md
@@ -1,3 +1,7 @@
+---
+date: 2026-05-28
+---
+
 # TDD Research
 
 Deep reference for Test-Driven Development methodology.
@@ -197,6 +201,78 @@ def test_create_user_hashes_password(user_service):
         user_service.create(email='test@example.com', password='secret')
 
         mock_hash.assert_called_once_with('secret')
+```
+
+## Project-Specific Mock Patterns
+
+### Supabase
+```typescript
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => Promise.resolve({
+          data: [{ id: 1, name: 'Test' }],
+          error: null
+        }))
+      }))
+    }))
+  }
+}))
+```
+
+### Redis
+```typescript
+jest.mock('@/lib/redis', () => ({
+  searchByVector: jest.fn(() => Promise.resolve([
+    { slug: 'test', similarity_score: 0.95 }
+  ])),
+  checkHealth: jest.fn(() => Promise.resolve({ connected: true }))
+}))
+```
+
+### OpenAI
+```typescript
+jest.mock('@/lib/openai', () => ({
+  generateEmbedding: jest.fn(() => Promise.resolve(
+    new Array(1536).fill(0.1)
+  ))
+}))
+```
+
+## Test Organization Layout (Colocated + E2E Separate)
+
+```
+src/
+  components/
+    Button/
+      Button.tsx
+      Button.test.tsx      # Unit tests colocated
+  app/
+    api/
+      users/
+        route.ts
+        route.test.ts      # Integration tests colocated
+e2e/
+  auth.spec.ts             # E2E tests separate
+  checkout.spec.ts
+```
+
+## Coverage Config (Jest)
+
+```json
+{
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
+      }
+    }
+  }
+}
 ```
 
 ## Resources

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -6,236 +6,112 @@ allowed-tools: Read, Bash, Grep, Glob
 
 <skill id="testing">
 
-<purpose>
-Tests prove behavior, not implementation. A test that passes with buggy code is worse than no test.
-Edge cases over happy paths. Boundary conditions reveal bugs; normal inputs rarely do.
-If you can't explain what the test verifies, the test is worthless.
-</purpose>
+<on_start>
+agentdb read-start — check past test failures, patterns repeat.
+Load: skills/testing/reference/testing-research.md on demand.
+</on_start>
 
-<prerequisite>
-AgentDB read-start has run. Check past test failures—patterns repeat.
-</prerequisite>
+## Core Laws (non-negotiable)
 
-<reference>
-Skill-specific: skills/testing/reference/testing-research.md
-</reference>
+1. TEST REQUIREMENTS, NOT CODE. AI generates tests from code — this validates bugs. Test what SHOULD happen.
+2. EDGE CASES FIRST. Empty, null, boundary, concurrent, error paths. Happy path is least valuable.
+3. STRONG ASSERTIONS ONLY. `.toBeTruthy()` catches nothing. Assert specific values.
+4. ONE BEHAVIOR PER TEST. If "and" appears in the test name, split the test.
+5. REGRESSION OVER COVERAGE. One test that catches a real bug beats 10 that pad metrics.
+6. NEVER use `.skip()` or `.only()` — Claude rewrites tests to pass buggy code rather than fix the bug.
 
-<core_principles>
-1. TEST REQUIREMENTS, NOT CODE: AI generates tests from code. This validates bugs. Test what SHOULD happen.
-2. EDGE CASES FIRST: Empty, null, boundary, concurrent, error paths. Happy path is least valuable.
-3. ASSERTION STRENGTH: Weak assertions (truthy, not-null) catch nothing. Assert specific values.
-4. ONE BEHAVIOR PER TEST: Test names should read like specifications. If "and" appears, split.
-5. REGRESSION OVER COVERAGE: One test that catches a real bug beats 10 tests that pad metrics.
-</core_principles>
+---
 
-<!-- Updated 2026-04-27: https://medium.com/ngconf/create-reliable-unit-tests-with-claude-code-9147d050d557, https://code.claude.com/docs/en/best-practices -->
-<naming_convention>
-BDD format: GIVEN/WHEN/SHOULD. Reads as specification, not code description.
+## Flow
 
-```javascript
-// POOR: describes implementation
-test('validateEmail regex check')
+### Step 1 — Specify before writing
+1. Write test case descriptions (inputs + expected outputs) BEFORE requesting implementation.
+2. For AI-generated code: provide spec, then ask for tests, then ask for implementation.
+   (gate: spec exists as comments or descriptions before any test code is written)
+3. If a test name cannot be written in GIVEN/WHEN/SHOULD form, the test is ambiguous — clarify first.
 
-// GOOD: describes behavior
-test('GIVEN an email without domain WHEN validated SHOULD return false')
-test('GIVEN a valid email WHEN validated SHOULD return true')
+### Step 2 — Prioritize by risk
+Order of testing priority:
+1. Business logic (core correctness rules)
+2. Error handling (what fails gracefully vs. crashes)
+3. Boundary conditions (edges of valid input ranges)
+4. State transitions (auth flows, multi-step workflows)
+5. Integration points (external systems, DB, APIs)
+6. Regression cases (every bug fix gets a test that would have caught it)
+
+### Step 3 — Write edge cases explicitly
+For every function, enumerate:
+- Empty / null / undefined inputs
+- Boundary values (0, -1, MAX_INT, empty string, oversized input)
+- Invalid type/shape → error, not corrupted result
+- Security inputs (injection payloads, newline injection) → rejected at entry
+- Concurrent access or race conditions where applicable
+(gate: minimum 3 edge cases per non-trivial function)
+
+### Step 4 — Name tests as specifications
+Format: `GIVEN <state> WHEN <action> SHOULD <expected>`
 ```
-
-If a test name can't be written in GIVEN/WHEN/SHOULD form, the test is ambiguous.
-Also applies to test suites: describe() should be the subject, it()/test() should be the scenario.
-
-**"Don't modify the tests" instruction**: When asking Claude to fix failing tests, include
-"Do not modify the tests — fix the implementation to pass them." Without this, Claude takes
-the fastest path to green: weakening assertions or skipping edge cases rather than fixing the bug.
-</naming_convention>
-
-<test_hierarchy>
-1. Unit tests: isolated functions, fast, many.
-2. Integration tests: component boundaries, medium speed, focused.
-3. E2E tests: critical paths only, slow, few.
-
-Invert the pyramid at your peril. More E2E = slower feedback = less testing.
-</test_hierarchy>
-
-<anti_patterns>
-<block id="coverage_theater">High coverage, weak assertions. 100% coverage with .toBeTruthy() catches nothing.</block>
-<block id="implementation_coupling">Test breaks when refactoring. Test behavior, not structure.</block>
-<block id="happy_path_only">Normal inputs rarely fail. Test edges, nulls, boundaries, concurrent access.</block>
-<block id="ai_test_trust">AI generates tests that validate bugs. Review AI tests for what they ACTUALLY assert.</block>
-<block id="flaky_tolerance">Flaky test = broken test. Fix or delete. Never ignore.</block>
-<!-- Updated 2026-04-07: https://www.ontestautomation.com/writing-tests-with-claude-code-part-1-initial-results/ -->
-<block id="skip_or_only">Never use .skip() or .only() — Claude will rewrite tests to pass against buggy code rather than fix the bug. Disabled tests become permanent. Fix or delete.</block>
-</anti_patterns>
-
-<verification_gate>
-<!-- Updated 2026-03-28: https://code.claude.com/docs/en/best-practices -->
-Always provide verification. If you can't verify it, don't ship it.
-AI writes tests prolifically — but tends to test where the code IS, not where it matters most.
-Review AI-generated tests for: do they test the actual risk area, or just the happy path it already handles?
-</verification_gate>
-
-<jit_testing>
-<!-- Updated 2026-04-25: https://www.infoq.com/news/2026/04/meta-jit-testing-ai-detection/ -->
-From Meta: Just-in-Time (JiT) testing generates tests *during code review* instead of relying on static suites.
-Result: **~4x bug detection improvement** in AI-assisted development (InfoQ, April 2026).
-No maintenance burden (tests don't persist). Mutation-based fault injection.
-Consider for high-churn code where traditional test suites rot faster than they help.
-Also useful during refactoring: generate behavioral tests for the code being refactored *before* making changes,
-run them after to confirm behavior preservation without a pre-existing test suite.
-</jit_testing>
-
-<!-- Updated 2026-03-30: Claude Code best practices, AI code review research -->
-<golden_ratio_principle>
-Test coverage follows diminishing returns past ~80%. Beyond that, invest in:
-- Mutation testing (verify your tests actually catch real mutations)
-- Property-based testing for complex logic (fast-check, hypothesis)
-- Contract tests at service boundaries (Pact, schema mocks)
-
-Coverage % is a vanity metric without mutation score.
-</golden_ratio_principle>
-
-<ai_generated_test_review>
-When reviewing AI-generated tests, specifically check:
-1. Does the assertion verify the RIGHT thing? (.toBe(true) catches nothing meaningful)
-2. Is the test coupled to implementation? (mocking internals → brittle)
-3. Is the test isolated? (shared state between tests → order-dependent failures)
-4. Does it test requirements or code? (test what SHOULD happen, not what code does)
-
-AI-generated tests frequently validate bugs because they're synthesized FROM the code.
-Read them as if the implementation might be wrong — because it might be.
-
-<!-- Updated 2026-04-10: https://code.claude.com/docs/en/best-practices, https://utofa.com/blogs/ai-code-review-2026-best-practices/ -->
-**Pre-generation test descriptions**: When asking Claude to generate code, provide at minimum
-the test case descriptions (inputs and expected outputs) BEFORE requesting implementation.
-This forces behavioral specification first and prevents tautological tests that just validate
-what the code does rather than what it should do. Example:
-> "Write validateEmail. Test cases: user@example.com → true, invalid → false, user@.com → false.
-> Write the tests first, then implement the function to pass them."
-
-**40-70% of production code is now AI-generated** (industry estimate, 2026). The proportion
-of tautological tests in codebases is rising proportionally. Manual review of AI-generated
-tests for behavioral correctness is non-optional.
-</ai_generated_test_review>
-
-<!-- Updated 2026-04-02: https://code.claude.com/docs/en/best-practices, https://testdino.com/blog/claude-code-with-playwright/ -->
-<multi_agent_test_patterns>
-**Writer/Reviewer split**: Have one agent write tests, a separate agent write code to pass them.
-This prevents the common failure where AI writes tests FROM the code (validating bugs, not behavior).
-The test-writing agent must only see the SPECIFICATION, not the implementation.
-
-**Parallel hypothesis testing**: When coverage gaps exist across multiple modules, spawn agents
-per module boundary. Each agent tests its domain independently. Prevents agents from stepping
-on each other's test state or sharing fixtures incorrectly.
-
-**Test-before-code in agentic context**: When issuing a contract to a surgeon agent, include
-acceptance criteria as executable test cases. The surgeon's done-when is tests passing, not
-code written. This forces behavioral specification before implementation.
-
-**Verification criteria = highest leverage**: Claude performs dramatically better when it can
-verify its own work by running tests. Always give agents runnable verification — a test
-suite they can execute — not just a written description of done.
-
-<!-- Updated 2026-04-19: Anthropic Opus 4.7 migration guide -->
-**Effort levels for test agents (Opus 4.7)**: Use `effort: high` when spawning test-generation agents.
-Opus 4.7 at default effort under-generates edge cases. At `high`, it produces fuller coverage with
-more boundary conditions. At `xhigh`, test generation is exhaustive — use for security-critical code.
-Pair with "Report ALL issues" framing: avoid "be conservative" prompts that cause under-reporting.
-Opus 4.7 has 11pp better recall on issues — don't filter it out at the prompt level.
-</multi_agent_test_patterns>
-
-<!-- Updated 2026-04-23: https://code.claude.com/docs/en/best-practices, https://www.tech-reader.blog/2026/04/the-secret-life-of-claude-code-testing.html -->
-<behavior_vs_implementation>
-AI tends to write tests that validate implementation details, not behavior. These break on refactoring.
-Test WHAT the code does, not HOW it does it.
-
-```javascript
-// POOR: Tests implementation (breaks on refactor)
-test('validateEmail uses regex pattern', () => {
-  expect(validateEmail).toHaveBeenCalledWith(expect.stringMatching(/\w+@\w+/));
-});
-
-// GOOD: Tests behavior (survives refactor)
-test('validateEmail rejects invalid formats', () => {
-  expect(validateEmail('user@.com')).toBe(false);
-  expect(validateEmail('user@example.com')).toBe(true);
-  expect(validateEmail('invalid')).toBe(false);
-});
+GOOD: test('GIVEN email without domain WHEN validated SHOULD return false')
+POOR: test('validateEmail regex check')
 ```
-</behavior_vs_implementation>
+Pattern for file/function naming: `test_{function}_{scenario}_{expected}`
 
-<!-- Updated 2026-04-23: https://code.claude.com/docs/en/best-practices (QA automation section) -->
-<edge_case_discovery>
-Claude's testing strength is edge case discovery, not boilerplate unit tests.
-Prompt explicitly for edge cases rather than asking for generic coverage.
+### Step 5 — Layer by pyramid
+1. Unit tests — isolated functions, fast, many. (primary layer)
+2. Integration tests — component boundaries, DB/API calls, medium speed.
+3. E2E / browser — critical user-visible flows only, slow, few.
+(gate: E2E count stays low; flaky tests fixed or deleted immediately)
 
-Effective prompt structure:
-1. "What edge cases exist for [function]?"
-2. Show 2–3 expected edge cases to anchor thinking.
-3. "What boundary conditions or interaction effects might break this?"
-4. "Generate N test cases covering these scenarios."
+### Step 6 — Review AI-generated tests
+Before accepting any AI-generated test, verify:
+1. Does the assertion verify the RIGHT thing? (not just `.toBe(true)`)
+2. Is the test coupled to implementation? (mocks of internals → brittle)
+3. Is state shared between tests? (order-dependent failures)
+4. Does it test requirements or does it mirror code that may be buggy?
+(gate: at least one negative/rejection case per test file)
 
-Example for validateEmail:
-```
-"Write tests covering:
-- Invalid formats (missing @, missing domain, invalid chars)
-- Boundary cases (empty string, very long email, null/undefined)
-- Interaction effects (uppercase, spaces, international domains)
-- Security cases (SQL injection payloads, newline injection)
-Generate 15 cases that would catch a developer who forgot one category."
-```
-</edge_case_discovery>
+### Step 7 — Multi-agent test patterns (tier 2+)
+- **Writer/Reviewer split**: one agent writes tests (spec only, no implementation), separate agent writes code to pass them.
+- **Parallel per module**: when coverage gaps span multiple modules, spawn one agent per module boundary.
+- **Surgeon done-when**: acceptance criteria = runnable tests passing, not "code written."
+- **Effort level**: use `effort: high` for test-generation agents; default under-generates edge cases.
 
-<!-- Updated 2026-05-06: https://medium.com/@karkeralathesh/the-complete-guide-to-testing-claude-code-skills-with-the-skill-creator-1ae3821bd7b8 -->
-<negative_case_testing>
-Test what code should NOT do. In AI-assisted development, positive-case tests dominate and negative-case behavior is routinely untested.
+### Step 8 — Grader pattern (complex features)
+1. Define success rubric (expected behaviors, edge handling, perf bounds) BEFORE tests or code.
+2. After implementation, spawn a grader agent in fresh context (no knowledge of implementation).
+3. Grader evaluates output against rubric. Failure → specific issues → surgeon takes another pass.
+(gate: grader verdict is PASS before declaring done on complex features)
 
-Negative cases to add to every test suite:
-- Rejection of out-of-scope inputs (tool/function declines gracefully, not crashes)
-- Invalid type/shape returns an error, not a corrupted result
-- Empty/null/undefined handled at boundary, not propagated
-- Security inputs (injection payloads, oversized strings) rejected at entry, not silently processed
+### Step 9 — JiT testing for high-churn code
+Generate tests during code review, not into the static suite, when:
+- Code changes faster than test suites can track
+- Refactoring: generate behavioral tests BEFORE changes, run AFTER to confirm preservation
+(reference: testing-research.md § Just-in-Time Testing)
 
-**The rejection quality test**: A function that correctly declines invalid input is more production-grade than one that accepts everything. Test this explicitly — it's not covered by happy-path suites.
-</negative_case_testing>
+---
 
-<!-- Updated 2026-05-12: https://code.claude.com/docs/en/best-practices, https://testdino.com/blog/claude-code-with-playwright/ -->
-<browser_verification>
-Use browser automation (Playwright + MCP browser tools) to verify UI features before declaring done. Claude runs the browser, sees console errors, iterates until the feature works end-to-end. Not a substitute for unit tests — complements them by catching integration failures that unit tests can't.
+## Anti-Patterns (block on sight)
 
-Effective sequence: unit tests (fast feedback) → integration tests (component boundaries) → browser automation (real user path). Browser tests are slow — reserve for critical user-visible flows only.
-</browser_verification>
+| Pattern | Block |
+|---|---|
+| `coverage_theater` | High coverage, weak assertions. 100% + `.toBeTruthy()` = nothing caught. |
+| `implementation_coupling` | Tests break on refactor. Test behavior, not structure. |
+| `happy_path_only` | Normal inputs rarely fail. Test edges, nulls, boundaries, concurrent access. |
+| `ai_test_trust` | AI synthesizes tests FROM code → validates bugs. Review what assertions ACTUALLY check. |
+| `flaky_tolerance` | Flaky test = broken test. Fix or delete. Never ignore. |
+| `skip_or_only` | `.skip()` / `.only()` become permanent. Fix or delete. |
+| `print_over_assert` | Print statements are not assertions. Require formal `expect`/`assert` calls. |
 
-<!-- Updated 2026-05-12: https://www.mindstudio.ai/blog/code-w-claude-2026-new-agent-features -->
-<grader_pattern>
-For complex features where "all tests pass" isn't sufficient: define a success rubric (expected behaviors, edge case handling, performance bounds) BEFORE writing tests or code. After implementation, spawn a grader agent in a fresh context — no knowledge of how the code was written — to evaluate output against the rubric.
+---
 
-Grader failure returns specific, addressable issues. Implementing agent takes another pass. This outer loop catches the "tautological test" failure mode (tests pass, rubric fails) by separating evaluation context from implementation context.
-</grader_pattern>
+## Verification Gate
 
-<!-- Updated 2026-05-14: https://www.infoq.com/news/2026/04/claude-code-review/, https://www.coderabbit.ai/blog/claude-opus-4-7-for-ai-code-review -->
-<native_code_review_stats>
-Anthropic's Code Review feature (launched March 2026) integrates with GitHub and leaves inline comments automatically on PRs.
-Production stats:
-- Large PRs (>1000 lines): 84% get findings, avg 7.5 issues flagged
-- Small PRs (<50 lines): 31% get findings, avg 0.5 issues
-- Average review time: ~20 minutes. Average cost: $15–25/review (token-based)
-- Focus: logical errors over style. Opus 4.7 has stronger cross-file reasoning for multi-module issues.
+Always provide runnable verification. If you can't verify it, don't ship it.
+AI writes tests prolifically — review for: does it test the actual risk area, or just the happy path it already handles?
 
-Best ROI: large PRs where human reviewers are most likely to miss cross-file interactions.
-Use small PRs strategically to reduce both review time and cost.
-</native_code_review_stats>
+When reviewing AI-generated code in 2026 (40–70% of production is AI-generated), check for **intent drift**: AI correctly implements what it inferred from the prompt, not what was actually needed. Verify against the original spec, not just the code structure.
 
-<!-- Updated 2026-05-17: web research — https://www.kluster.ai/blog/best-code-review-practices, https://brightsec.com/blog/ai-code-review-best-practices-2-0-2026-toolchain/ -->
-<intent_verification>
-In 2026 codebases where 40–70% of production code is AI-generated, the failure mode is **intent drift**: AI correctly implements what it inferred from the prompt, not what the developer actually needed.
-
-When reviewing AI-generated tests or code, verify against the ORIGINAL intent:
-- What prompt or spec drove this generation?
-- Does the output match the business requirement, not just the code structure?
-- Are edge cases from the spec covered, or only edges visible in the code?
-
-Practical check: read the generation prompt (or ask the author for it), then read the output. Discrepancies between intent and output are specification bugs, not implementation bugs — fix the spec before the test.
-</intent_verification>
+---
 
 <on_complete>
 agentdb write-end '{"skill":"testing","tests_added":<N>,"coverage_delta":"<+X%>","edge_cases":["<list>"],"assertions":"<strong|weak>"}'

--- a/skills/testing/reference/testing-research.md
+++ b/skills/testing/reference/testing-research.md
@@ -173,3 +173,171 @@ understand what you're testing.
   (65% vs lower). Missing context is the root cause; hallucinations are symptom.
 - **Self-healing tests**: 95% maintenance reduction claimed, but caution:
   may mask genuine product bugs. Use with transparent logging.
+
+---
+
+## Naming Convention — Extended (from SKILL.md 2026-04-27)
+
+Source: https://medium.com/ngconf/create-reliable-unit-tests-with-claude-code-9147d050d557
+
+BDD format: GIVEN/WHEN/SHOULD. Reads as specification, not code description.
+
+```javascript
+// POOR: describes implementation
+test('validateEmail regex check')
+
+// GOOD: describes behavior
+test('GIVEN an email without domain WHEN validated SHOULD return false')
+test('GIVEN a valid email WHEN validated SHOULD return true')
+```
+
+If a test name can't be written in GIVEN/WHEN/SHOULD form, the test is ambiguous.
+`describe()` should be the subject; `it()`/`test()` should be the scenario.
+
+**"Don't modify the tests" instruction**: When asking Claude to fix failing tests, include
+"Do not modify the tests — fix the implementation to pass them." Without this, Claude takes
+the fastest path to green: weakening assertions or skipping edge cases rather than fixing the bug.
+
+---
+
+## Behavior vs. Implementation — Code Examples (from SKILL.md 2026-04-23)
+
+Source: https://code.claude.com/docs/en/best-practices, https://www.tech-reader.blog/2026/04/the-secret-life-of-claude-code-testing.html
+
+```javascript
+// POOR: Tests implementation (breaks on refactor)
+test('validateEmail uses regex pattern', () => {
+  expect(validateEmail).toHaveBeenCalledWith(expect.stringMatching(/\w+@\w+/));
+});
+
+// GOOD: Tests behavior (survives refactor)
+test('validateEmail rejects invalid formats', () => {
+  expect(validateEmail('user@.com')).toBe(false);
+  expect(validateEmail('user@example.com')).toBe(true);
+  expect(validateEmail('invalid')).toBe(false);
+});
+```
+
+---
+
+## Edge Case Discovery — Prompting Patterns (from SKILL.md 2026-04-23)
+
+Source: https://code.claude.com/docs/en/best-practices (QA automation section)
+
+Claude's testing strength is edge case discovery, not boilerplate unit tests.
+Prompt explicitly for edge cases rather than asking for generic coverage.
+
+Effective prompt structure:
+1. "What edge cases exist for [function]?"
+2. Show 2–3 expected edge cases to anchor thinking.
+3. "What boundary conditions or interaction effects might break this?"
+4. "Generate N test cases covering these scenarios."
+
+Example for validateEmail:
+```
+"Write tests covering:
+- Invalid formats (missing @, missing domain, invalid chars)
+- Boundary cases (empty string, very long email, null/undefined)
+- Interaction effects (uppercase, spaces, international domains)
+- Security cases (SQL injection payloads, newline injection)
+Generate 15 cases that would catch a developer who forgot one category."
+```
+
+---
+
+## Negative Case Testing (from SKILL.md 2026-05-06)
+
+Source: https://medium.com/@karkeralathesh/the-complete-guide-to-testing-claude-code-skills-with-the-skill-creator-1ae3821bd7b8
+
+Test what code should NOT do. In AI-assisted development, positive-case tests dominate and
+negative-case behavior is routinely untested.
+
+Negative cases to add to every test suite:
+- Rejection of out-of-scope inputs (tool/function declines gracefully, not crashes)
+- Invalid type/shape returns an error, not a corrupted result
+- Empty/null/undefined handled at boundary, not propagated
+- Security inputs (injection payloads, oversized strings) rejected at entry, not silently processed
+
+**The rejection quality test**: A function that correctly declines invalid input is more
+production-grade than one that accepts everything. Test this explicitly.
+
+---
+
+## Browser Verification (from SKILL.md 2026-05-12)
+
+Source: https://code.claude.com/docs/en/best-practices, https://testdino.com/blog/claude-code-with-playwright/
+
+Use browser automation (Playwright + MCP browser tools) to verify UI features before declaring done.
+Claude runs the browser, sees console errors, iterates until the feature works end-to-end.
+Not a substitute for unit tests — complements them by catching integration failures unit tests can't.
+
+Effective sequence: unit tests (fast feedback) → integration tests (component boundaries) →
+browser automation (real user path). Browser tests are slow — reserve for critical user-visible flows only.
+
+---
+
+## Native Code Review Stats — Anthropic (from SKILL.md 2026-05-14)
+
+Source: https://www.infoq.com/news/2026/04/claude-code-review/, https://www.coderabbit.ai/blog/claude-opus-4-7-for-ai-code-review
+
+Anthropic's Code Review feature (launched March 2026) integrates with GitHub and leaves inline
+comments automatically on PRs.
+
+Production stats:
+- Large PRs (>1000 lines): 84% get findings, avg 7.5 issues flagged
+- Small PRs (<50 lines): 31% get findings, avg 0.5 issues
+- Average review time: ~20 minutes. Average cost: $15–25/review (token-based)
+- Focus: logical errors over style. Opus 4.7 has stronger cross-file reasoning for multi-module issues.
+
+Best ROI: large PRs where human reviewers are most likely to miss cross-file interactions.
+Use small PRs strategically to reduce both review time and cost.
+
+---
+
+## Golden Ratio Principle — Coverage Diminishing Returns (from SKILL.md 2026-03-30)
+
+Source: https://code.claude.com/docs/en/best-practices, AI code review research
+
+Test coverage follows diminishing returns past ~80%. Beyond that, invest in:
+- Mutation testing (verify your tests actually catch real mutations)
+- Property-based testing for complex logic (fast-check, hypothesis)
+- Contract tests at service boundaries (Pact, schema mocks)
+
+Coverage % is a vanity metric without mutation score.
+
+---
+
+## Pre-Generation Test Descriptions (from SKILL.md 2026-04-10)
+
+Source: https://code.claude.com/docs/en/best-practices, https://utofa.com/blogs/ai-code-review-2026-best-practices/
+
+When asking Claude to generate code, provide at minimum the test case descriptions (inputs and
+expected outputs) BEFORE requesting implementation. This forces behavioral specification first
+and prevents tautological tests that just validate what the code does rather than what it should do.
+
+Example:
+> "Write validateEmail. Test cases: user@example.com → true, invalid → false, user@.com → false.
+> Write the tests first, then implement the function to pass them."
+
+**40-70% of production code is now AI-generated** (industry estimate, 2026). The proportion
+of tautological tests in codebases is rising proportionally. Manual review of AI-generated
+tests for behavioral correctness is non-optional.
+
+---
+
+## Intent Drift — Verification Checklist (from SKILL.md 2026-05-17)
+
+Source: https://www.kluster.ai/blog/best-code-review-practices, https://brightsec.com/blog/ai-code-review-best-practices-2-0-2026-toolchain/
+
+In 2026 codebases where 40–70% of production code is AI-generated, the failure mode is
+**intent drift**: AI correctly implements what it inferred from the prompt, not what the
+developer actually needed.
+
+When reviewing AI-generated tests or code, verify against the ORIGINAL intent:
+- What prompt or spec drove this generation?
+- Does the output match the business requirement, not just the code structure?
+- Are edge cases from the spec covered, or only edges visible in the code?
+
+Practical check: read the generation prompt (or ask the author for it), then read the output.
+Discrepancies between intent and output are specification bugs, not implementation bugs —
+fix the spec before the test.


### PR DESCRIPTION
## What

Two layered changes to the plugin's nondeterministic instruction docs (read by the agent at runtime, not humans). Headed here for review rather than straight to main, per request.

**1. `refactor(skills)` — blob → numbered executable flows (f949273)**
18 over-cap `SKILL.md` files converted from prose "blobs to remember" into terse, numbered, ordered, gated step-flows. Deep context (rationale, long examples, tooling surveys) relocated to each skill's `reference/<id>-research.md`, consulted on demand instead of loaded every time.

Representative line drops (SKILL.md): build 340→156, security 338→~150, api 325→114, eval 155→86. Net ~half the per-load tokens; full fidelity preserved in `reference/`.

**2. `chore(kernel)` — consistency layer (4fafeed)**
Every skill flow now ends with the `agentdb write-end` bookend the root CLAUDE.md marks non-negotiable; `read-start` added to diagnose/dream; stale refs fixed (help `v7.6.1→v7.13.0`, handoff dead path); `dreamer` name fix that resolves a `kernel:kernel:dreamer` double-prefix registration; ship/context-mgmt/reviewer label fixes.

## Invariant held

**No information deleted.** Every removed concept either survives condensed inline in the flow or moved to the reference file. Frontmatter byte-for-byte preserved. All test-asserted strings intact (quality `r_factor`/`adsr`/weights; orchestration `knowledge_injection`/`worktree_safety`/…; app-dev `EAS`/`store submission`).

## Verification

- `bash tests/run-tests.sh` → **242 passed, 0 failed**.
- A fresh-context opus info-loss auditor inspected the diff of every skill (reading surviving content, not line counts) → **0 confirmed losses**. Report: `_meta/reports/skill-flow-rewrite-audit.md`.
- Plan + rationale: `_meta/plans/md-philosophy-enshrinement.md`.

## Note

The DB migration-drift self-heal and security/lifecycle hook hardening from the same session already landed on `main` (commits 7140e8e, 1db6c42, c771891) — those were verified + adversary-passed and not part of this review.