### PR TITLE
feat(agentdb): memory observatory repairs PR1-4

### DIFF
--- a/agents/triage.md
+++ b/agents/triage.md
@@ -17,7 +17,7 @@ agentdb read-start
 
 <input>
 - Task description (natural language)
-- File count (estimated or exact)
+- Estimated files, if known
 - Current learnings from AgentDB (patterns, failures)
 </input>
 
@@ -25,10 +25,10 @@ agentdb read-start
 <phase id="classify">
 Analyze task against classification matrix:
 
-  low:    1-2 files, familiar pattern, existing tests       -> tier 1
-  medium: 3-5 files, some unknowns, partial test coverage   -> tier 2
-  high:   6+ files, unfamiliar tech, cross-cutting concerns  -> tier 3
-  epic:   architecture change, schema migration, breaking changes -> tier 3 + human review
+  low:    easy to undo, loud if wrong, narrow blast radius -> tier 1
+  medium: persistent or moderately quiet failure           -> tier 2
+  high:   hard to undo, quiet if wrong, or wide blast      -> tier 3
+  epic:   architecture, schema, security, policy, or breaking change -> tier 3 + human review
 
 Signals that increase complexity:
 - Multiple modules touched
@@ -36,6 +36,7 @@ Signals that increase complexity:
 - New dependency required
 - Schema or API contract changes
 - Auth/payment/migration involvement
+- Failure would be silent or hard to notice
 </phase>
 
 <phase id="risk_scan">
@@ -69,7 +70,7 @@ surface the ambiguity and ask:
 
 <integration>
 Called at start of /kernel:ingest CLASSIFY step, before tier determination.
-Replaces manual file counting with structured assessment.
+Replaces manual file counting with structured risk assessment. File count is only a weak hint.
 </integration>
 
 <anti_patterns>

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -116,11 +116,11 @@ Or type `/kernel:ingest` first, then describe your task on the next line.
 
 **Why this matters:** `/kernel:ingest` reads memory, classifies your request, and routes to the right approach. Without it, Claude Code skips the memory system entirely.
 
-Behind the scenes, it classifies your request (bug, feature, refactor, question), decides scope by file count (1–2 files = Tier 1 direct, 3–5 = Tier 2 surgeon, 6+ = Tier 3 surgeon + adversary), reads what's been tried before, checks what broke last time, and picks up where you left off.
+Behind the scenes, it classifies your request (bug, feature, refactor, question), decides scope by risk (how hard it is to undo, how quietly it can fail, and how far it reaches), reads what's been tried before, checks what broke last time, and picks up where you left off.
 
 ### Doing Work
 
-Claude Code builds what you asked for. For small changes (Tier 1), it executes directly. For bigger projects (Tier 2+: contract → surgeon → adversary), it breaks the work into steps, gets it done, and verifies everything works. In plain terms: you just describe what you want.
+Claude Code builds what you asked for. For low-risk changes (Tier 1), it executes directly. For durable or high-risk projects (Tier 2+: contract → surgeon → adversary), it breaks the work into steps, gets it done, and verifies everything works. In plain terms: you just describe what you want.
 
 ### Checking Work
 

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -90,6 +90,76 @@ $1
 EOF
 }
 
+# Ensure the soft-delete cache columns exist on the LOCAL learnings table
+# (migration 014, design 3.7). SQLite has no ADD COLUMN IF NOT EXISTS, so this
+# PRAGMA-gates the add. Single source of truth for the archived_at/archived_reason
+# columns: cmd_preflight, cmd_read_start, cmd_recall, and cmd_decay all call this
+# so the "WHERE archived_at IS NULL" filter is safe regardless of preflight timing.
+# Idempotent + cheap (one PRAGMA select), best-effort (never fails the caller).
+_ensure_softdelete_cols() {
+  [ -f "$DB" ] || return 0
+  local has
+  has=$(db_exec "SELECT 1 FROM pragma_table_info('learnings') WHERE name='archived_at' LIMIT 1;" 2>/dev/null || echo "")
+  if [ -z "$has" ]; then
+    db_exec "ALTER TABLE learnings ADD COLUMN archived_at TEXT;" 2>/dev/null || true
+    db_exec "ALTER TABLE learnings ADD COLUMN archived_reason TEXT;" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# Return a SQL literal for a text value: '<escaped>' for a non-empty string, or
+# bare NULL for an empty one (absence = UNKNOWN, never an empty-string fact; the
+# null-semantics contract, design 5.2).
+_sql_text() {
+  if [ -z "${1:-}" ]; then printf 'NULL'; else printf "'%s'" "$(sql_escape "$1")"; fi
+}
+
+# Append one row to the memory-lifecycle event spine (memory_events, design 2.1).
+# BEST-EFFORT BY CONTRACT: a failed emit prints a LOUD warning to stderr and
+# returns 0, so instrumentation can never break a learn/recall/decay/read-start.
+# Never UPDATEs or DELETEs (append-only). event_id is globally unique across dbs.
+# Args (positional; empty = SQL NULL):
+#   1 kind (required)   2 subject_id   3 reason   4 payload_json
+#   5 actor             6 object_id    7 inference_method
+#   8 source_db         9 source_row_id  10 import_batch_id
+emit_memory_event() {
+  local kind="${1:-}" subject_id="${2:-}" reason="${3:-}" payload="${4:-}"
+  local actor="${5:-}" object_id="${6:-}" inference_method="${7:-}"
+  local source_db="${8:-}" source_row_id="${9:-}" import_batch_id="${10:-}"
+
+  if [ -z "$kind" ]; then
+    echo "[agentdb] emit_memory_event: kind is required; event NOT recorded" >&2
+    return 0
+  fi
+  # Advisory known-verb validation (open vocabulary: a new verb is accepted, a
+  # typo in a known verb is surfaced). Never a hard reject (design 2.2).
+  case "$kind" in
+    created|updated|imported|merged|retrieved|surfaced|used|ignored|reinforced|graduated|archived|resurrected|domain_changed|superseded) ;;
+    *) echo "[agentdb] emit_memory_event: '$kind' is not a known memory verb (recording anyway; open vocabulary)" >&2 ;;
+  esac
+
+  # actor defaults to the session id if the caller left it empty.
+  [ -z "$actor" ] && actor="${AGENTDB_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+
+  local db_short eid
+  db_short=$(basename "$PROJECT_ROOT" 2>/dev/null | tr -cs 'a-zA-Z0-9' '-' | cut -c1-16)
+  [ -z "$db_short" ] && db_short="db"
+  eid="${db_short}-$(date -u +%Y%m%d%H%M%S)-$$-${RANDOM}${RANDOM}"
+
+  if db_exec "INSERT INTO memory_events
+      (event_id, kind, actor, source_db, source_row_id, import_batch_id,
+       subject_id, object_id, reason, inference_method, payload)
+      VALUES ('$eid', '$(sql_escape "$kind")', $(_sql_text "$actor"),
+        $(_sql_text "$source_db"), $(_sql_text "$source_row_id"), $(_sql_text "$import_batch_id"),
+        $(_sql_text "$subject_id"), $(_sql_text "$object_id"), $(_sql_text "$reason"),
+        $(_sql_text "$inference_method"), $(_sql_text "$payload"));" 2>/dev/null; then
+    return 0
+  else
+    echo "[agentdb] WARNING: failed to record memory_event (kind=$kind subject=${subject_id:-none}); memory path unaffected, but this observation was LOST. Run 'agentdb preflight' to self-heal the memory_events table." >&2
+    return 0
+  fi
+}
+
 # === COMMANDS ===
 
 # Apply every migration not yet recorded in _migrations, in filename order.
@@ -183,7 +253,7 @@ cmd_preflight() {
   fi
 
   # Check 2: Required tables exist
-  local required_tables="learnings context errors _migrations events"
+  local required_tables="learnings context errors _migrations events memory_events"
   for table in $required_tables; do
     local exists
     exists=$(db_exec "SELECT 1 FROM sqlite_master WHERE type='table' AND name='$table' LIMIT 1;" 2>/dev/null || echo "")
@@ -234,6 +304,18 @@ cmd_preflight() {
   if [ -z "$has_errors_domain" ]; then
     echo "preflight:missing_column — errors.domain not found, adding"
     db_exec "ALTER TABLE errors ADD COLUMN domain TEXT;" 2>/dev/null || true
+    repairs=$((repairs + 1))
+  fi
+
+  # Check 3c: learnings has the soft-delete cache columns (migration 014,
+  # design 3.7). Delegated to a single guarded helper (SQLite has no ADD COLUMN
+  # IF NOT EXISTS), shared with read-start/recall/decay so the archived filter is
+  # always safe. Silent + idempotent: only ALTERs when the column is absent.
+  local has_archived
+  has_archived=$(db_exec "SELECT 1 FROM pragma_table_info('learnings') WHERE name='archived_at' LIMIT 1;" 2>/dev/null || echo "")
+  if [ -z "$has_archived" ]; then
+    echo "preflight:missing_column learnings.archived_at not found, adding (migration 014)"
+    _ensure_softdelete_cols
     repairs=$((repairs + 1))
   fi
 

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -135,6 +135,7 @@ emit_memory_event() {
   # typo in a known verb is surfaced). Never a hard reject (design 2.2).
   case "$kind" in
     created|updated|imported|merged|retrieved|surfaced|used|ignored|reinforced|graduated|archived|resurrected|domain_changed|superseded) ;;
+    session_outcome) ;;  # phase-4 causal anchor (design 5.1 weak session association): a session's QA outcome, joined to surfaced events by actor
     *) echo "[agentdb] emit_memory_event: '$kind' is not a known memory verb (recording anyway; open vocabulary)" >&2 ;;
   esac
 
@@ -392,6 +393,9 @@ cmd_preflight() {
 cmd_read_start() {
   local mode="${1:---weighted}"
   [ ! -f "$DB" ] && cmd_init >/dev/null
+  # D9 fix (design 5.1): the ids this preamble surfaces + a label, captured per
+  # mode below and emitted as `surfaced` observations after the case.
+  local loaded_ids="" sf_mode=""
 
   echo "# AgentDB Context"
 
@@ -411,6 +415,7 @@ cmd_read_start() {
       # Telemetry only: bump load_count (NOT hit_count — read-start dumps are not
       # relevance feedback; only recall earns a hit_count bump). See migration 013.
       db_exec "UPDATE learnings SET load_count = load_count + 1;" 2>/dev/null
+      loaded_ids=$(db_exec "SELECT id FROM learnings;" 2>/dev/null); sf_mode="full"
       ;;
 
     --summary)
@@ -437,6 +442,13 @@ cmd_read_start() {
           FROM learnings ORDER BY score DESC LIMIT 10
         )
       );" 2>/dev/null
+      loaded_ids=$(db_exec "SELECT id FROM (
+          SELECT id,
+            (hit_count * 10) + (CASE WHEN type IN ('failure','gotcha') THEN 50 ELSE 0 END)
+            + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
+            + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END) AS score
+          FROM learnings ORDER BY score DESC LIMIT 10
+        );" 2>/dev/null); sf_mode="summary"
       ;;
 
     --tiered)
@@ -453,6 +465,7 @@ cmd_read_start() {
       db_exec "SELECT '- ' || insight FROM learnings WHERE hit_count <= 5 AND type NOT IN ('failure','gotcha') AND julianday('now') - julianday(ts) < 7 ORDER BY ts DESC;" 2>/dev/null || echo "None"
       # Telemetry only: bump load_count for the dumped tier set (see migration 013).
       db_exec "UPDATE learnings SET load_count = load_count + 1 WHERE hit_count > 5 OR type IN ('failure','gotcha') OR julianday('now') - julianday(ts) < 7;" 2>/dev/null
+      loaded_ids=$(db_exec "SELECT id FROM learnings WHERE hit_count > 5 OR type IN ('failure','gotcha') OR julianday('now') - julianday(ts) < 7;" 2>/dev/null); sf_mode="tiered"
       ;;
 
     --weighted|*)
@@ -481,8 +494,35 @@ cmd_read_start() {
           FROM learnings ORDER BY score DESC LIMIT 75
         )
       );" 2>/dev/null
+      loaded_ids=$(db_exec "SELECT id FROM (
+          SELECT id,
+            (hit_count * 10) + (CASE WHEN type IN ('failure','gotcha') THEN 50 ELSE 0 END)
+            + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
+            + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END) AS score
+          FROM learnings ORDER BY score DESC LIMIT 75
+        );" 2>/dev/null); sf_mode="weighted-75"
       ;;
   esac
+
+  # D9 fix (design 5.1): emit one `surfaced` observation per loaded id, so the
+  # memory spine records what a session preamble actually put in front of the
+  # agent (distinct from recall's task-driven surface). One batched INSERT keeps
+  # this session-start hot path fast (no per-row process spawn). Best-effort.
+  if [ -n "$loaded_ids" ]; then
+    local sf_actor sf_short sf_values="" sf_n=0 lid
+    sf_actor=$(_sql_text "${AGENTDB_SESSION_ID:-${CLAUDE_SESSION_ID:-}}")
+    sf_short=$(basename "$PROJECT_ROOT" 2>/dev/null | tr -cs 'a-zA-Z0-9' '-' | cut -c1-16)
+    [ -z "$sf_short" ] && sf_short="db"
+    while IFS= read -r lid; do
+      [ -z "$lid" ] && continue
+      sf_values="${sf_values:+$sf_values,}('${sf_short}-$(date -u +%Y%m%d%H%M%S)-$$-${RANDOM}-${sf_n}', 'surfaced', $sf_actor, '$(sql_escape "$lid")', 'read-start session preamble', '{\"mode\":\"$sf_mode\"}')"
+      sf_n=$((sf_n + 1))
+    done <<< "$loaded_ids"
+    if [ -n "$sf_values" ]; then
+      db_exec "INSERT INTO memory_events (event_id, kind, actor, subject_id, reason, payload) VALUES $sf_values;" 2>/dev/null \
+        || echo "[agentdb] WARNING: read-start surfaced emit failed for $sf_n ids (memory path unaffected)" >&2
+    fi
+  fi
 
   echo ""
   echo "## Recent Errors"
@@ -598,6 +638,9 @@ cmd_learn() {
   existing=$(db_exec "SELECT id FROM learnings WHERE insight LIKE '%${safe_substr}%' AND type='$safe_type' LIMIT 1;" 2>/dev/null || echo "")
   if [ -n "$existing" ]; then
     db_exec "UPDATE learnings SET hit_count = hit_count + 1 WHERE id='$existing';"
+    # Observation: a near-identical insight recurred and reinforced an existing row.
+    emit_memory_event reinforced "$existing" "learn dedup: near-identical insight recurred" \
+      "{\"type\":\"$(json_escape "$type")\",\"domain\":\"$(json_escape "$domain")\"}"
     echo "Reinforced: [$type] (existing: $existing)"
     return
   fi
@@ -605,6 +648,9 @@ cmd_learn() {
   local id="LRN-$(date +%Y%m%d%H%M%S)-$$-$RANDOM"
   db_exec "INSERT INTO learnings (id, type, insight, evidence, domain, visibility, sensitivity)
     VALUES ('$id', '$safe_type', '$safe_insight', '$safe_evidence', '$safe_domain', '$safe_visibility', '$safe_sensitivity');"
+  # Observation: a new insight was recorded (origin event for this learning).
+  emit_memory_event created "$id" "learn: new insight recorded" \
+    "{\"type\":\"$(json_escape "$type")\",\"domain\":\"$(json_escape "$domain")\"}"
   echo "Learned: [$type] $insight"
 }
 
@@ -747,6 +793,13 @@ cmd_verdict() {
   local safe_content
   safe_content=$(sql_escape "$content")
   db_exec "INSERT INTO context (id, type, agent, content, contract_id) VALUES ('$id', 'verdict', 'adversary', '$safe_content', '$safe_contract_id');"
+  # Phase-4 causal anchor (design 5.1): record the session's QA outcome so a future
+  # decision-leverage metric can join it to the memories surfaced in the same
+  # session (weak association by actor). NOT a per-memory signal, so subject_id is
+  # NULL and inference_method says so. Best-effort; never blocks the verdict.
+  emit_memory_event session_outcome "" "verdict: $result" \
+    "{\"result\":\"$(json_escape "$result")\",\"contract_id\":\"$(json_escape "$contract_id")\"}" \
+    "" "" "weak: session-level QA outcome, not a per-memory observation"
   echo "Verdict: $result"
 }
 
@@ -1659,8 +1712,11 @@ find_global_db() {
 # global brain — its FTS is refreshed by the nightly consolidation job, never here).
 # Always visibility-filtered (never surfaces human_only/operational to an agent).
 _recall_emit() {
-  local db="$1" fts_query="$2" like_clause="$3" tag="$4" limit="$5" writable="$6"
+  local db="$1" fts_query="$2" like_clause="$3" tag="$4" limit="$5" writable="$6" origin="${7:-local}"
   [ -f "$db" ] || return 0
+  # Each row is: <dedup-key>@@US@@<display>@@US@@<row id>@@US@@<origin>. The id +
+  # origin let cmd_recall emit/reinforce the ACTUALLY-displayed rows (design 5.1),
+  # not the raw match set. Older callers that pass no origin default to 'local'.
   local has_fts
   has_fts=$(sqlite3 "$db" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='learnings_fts' LIMIT 1;" 2>/dev/null || echo "")
   if [ -n "$has_fts" ]; then
@@ -1670,6 +1726,7 @@ _recall_emit() {
              '- [' || l.type || '] ' || l.insight || '$tag' ||
              CASE WHEN l.evidence IS NOT NULL AND l.evidence != ''
                   THEN '  ↳ ' || substr(l.evidence,1,90) ELSE '' END
+             || '@@US@@' || l.id || '@@US@@' || '$origin'
       FROM learnings l JOIN learnings_fts f ON f.rowid = l.rowid
       WHERE learnings_fts MATCH '$fts_query'
         AND (l.visibility = 'agent' OR l.visibility IS NULL)
@@ -1686,6 +1743,7 @@ _recall_emit() {
              '- [' || type || '] ' || insight || '$tag' ||
              CASE WHEN evidence IS NOT NULL AND evidence != ''
                   THEN '  ↳ ' || substr(evidence,1,90) ELSE '' END
+             || '@@US@@' || id || '@@US@@' || '$origin'
       FROM learnings
       WHERE ($like_clause)
         AND (visibility = 'agent' OR visibility IS NULL)
@@ -1729,9 +1787,12 @@ cmd_recall() {
 
   # Self-heal local FTS (build it if this DB predates migration 012 / hasn't run
   # preflight this session) so the local path uses bm25 ranking, not LIKE.
-  local has_fts
+  local has_fts has_mevents
   has_fts=$(db_exec "SELECT 1 FROM sqlite_master WHERE type='table' AND name='learnings_fts' LIMIT 1;" 2>/dev/null || echo "")
-  if [ -z "$has_fts" ]; then
+  has_mevents=$(db_exec "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_events' LIMIT 1;" 2>/dev/null || echo "")
+  # Self-heal on recall (the design's "migrations self-heal on cmd_recall"): build
+  # the FTS index and/or the memory_events spine if this DB predates migration 012/014.
+  if [ -z "$has_fts" ] || [ -z "$has_mevents" ]; then
     run_pending_migrations "recall:applied_migration" >/dev/null 2>&1 || true
   fi
 
@@ -1746,35 +1807,65 @@ cmd_recall() {
   echo ""
 
   # Collect local first (so a lesson present in both wins as the local copy), then
-  # global, then dedup by 200-char insight key and cut to the limit. bm25() can't
-  # live inside GROUP BY/an aggregate (the optimizer flattens the subquery →
+  # global, then dedup by 200-char insight key and cut to the limit. bm25() cannot
+  # live inside GROUP BY / an aggregate (the optimizer flattens the subquery into
   # "unable to use function bm25 in the requested context"), so dedup is post-query
-  # in awk (printable @@US@@ delimiter — sqlite3 escapes control chars on output,
-  # so a raw \037 byte never survives the shell; see _recall_emit note).
-  local raw_local raw_global out
-  raw_local=$(_recall_emit "$DB" "$fts_query" "$like_clause" "" "$limit" 1)
+  # in awk. Printable @@US@@ delimiter (sqlite3 escapes control chars on output, so
+  # a raw \037 byte never survives the shell; see _recall_emit note). Each row now
+  # carries trailing @@US@@<id>@@US@@<origin> fields so events + reinforcement target
+  # the ACTUALLY-displayed rows, not the raw match set (the D9 / 5.1 bump-vs-display fix).
+  local raw_local raw_global dedup out
+  raw_local=$(_recall_emit "$DB" "$fts_query" "$like_clause" "" "$limit" 1 "local")
   raw_global=""
-  [ -n "$global_db" ] && raw_global=$(_recall_emit "$global_db" "$fts_query" "$like_clause" " [global]" "$limit" 0)
-  out=$(printf '%s\n%s\n' "$raw_local" "$raw_global" | grep -v '^[[:space:]]*$' \
-        | awk -F'@@US@@' '!seen[$1]++{print $2}' | head -n "$limit")
+  [ -n "$global_db" ] && raw_global=$(_recall_emit "$global_db" "$fts_query" "$like_clause" " [global]" "$limit" 0 "global")
+  dedup=$(printf '%s\n%s\n' "$raw_local" "$raw_global" | grep -v '^[[:space:]]*$' \
+        | awk -F'@@US@@' '!seen[$1]++' | head -n "$limit")
+  out=$(printf '%s\n' "$dedup" | awk -F'@@US@@' 'NF{print $2}')
 
   if [ -n "$out" ]; then
     echo "$out"
-    # Relevance feedback: bump only the (agent-visible) LOCAL rows this query
-    # surfaced. hit_count is exclusively recall-earned (read-start uses load_count),
-    # so it's a trustworthy "answered a real task" signal. Never write to the global
-    # brain from recall (the consolidation job owns it).
-    if [ -n "$has_fts" ] || db_exec "SELECT 1 FROM sqlite_master WHERE type='table' AND name='learnings_fts' LIMIT 1;" 2>/dev/null | grep -q 1; then
+
+    local q_json
+    q_json=$(json_escape "$query")
+
+    # retrieved: one query-level observation carrying the local candidate set
+    # (design 5.1). subject_id is NULL (this is about the query, not one learning).
+    local cand_ids cand_json
+    cand_ids=$(printf '%s\n' "$raw_local" | awk -F'@@US@@' 'NF>=4{print $3}')
+    if command -v jq >/dev/null 2>&1; then
+      cand_json=$(printf '%s\n' "$cand_ids" | grep -v '^[[:space:]]*$' | jq -R . | jq -cs .)
+    fi
+    [ -z "${cand_json:-}" ] && cand_json="[]"
+    emit_memory_event retrieved "" "recall query ran" \
+      "{\"query\":\"$q_json\",\"candidate_ids\":$cand_json}"
+
+    # The ids actually SHOWN (post-dedup, post-limit), split by origin: $3=id, $4=origin.
+    local surfaced_local surfaced_global lid in_list=""
+    surfaced_local=$(printf '%s\n' "$dedup" | awk -F'@@US@@' 'NF>=4 && $4=="local"{print $3}')
+    surfaced_global=$(printf '%s\n' "$dedup" | awk -F'@@US@@' 'NF>=4 && $4=="global"{print $3}')
+
+    # LOCAL displayed rows: emit surfaced + reinforced, and bump hit_count on exactly
+    # these ids. This is the fix: pre-repair the bump hit the raw FTS match set up to
+    # `limit` (agentdb old :1686-1694), NOT the deduped display set, so the counter
+    # never matched what was shown. Never reinforce the global brain (job owns it).
+    while IFS= read -r lid; do
+      [ -z "$lid" ] && continue
+      emit_memory_event surfaced   "$lid" "recall displayed (local)" "{\"query\":\"$q_json\"}"
+      emit_memory_event reinforced "$lid" "recall hit: displayed for a task query" "{\"query\":\"$q_json\"}"
+      in_list="${in_list:+$in_list,}'$(sql_escape "$lid")'"
+    done <<< "$surfaced_local"
+    if [ -n "$in_list" ]; then
       db_exec "UPDATE learnings SET hit_count = hit_count + 1,
                  last_hit = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-               WHERE rowid IN (
-                 SELECT f.rowid FROM learnings_fts f
-                 JOIN learnings l ON l.rowid = f.rowid
-                 WHERE learnings_fts MATCH '$fts_query'
-                   AND (l.visibility = 'agent' OR l.visibility IS NULL)
-                 LIMIT $limit
-               );" 2>/dev/null
+               WHERE id IN ($in_list);" 2>/dev/null || true
     fi
+
+    # GLOBAL displayed rows: a surfaced observation (source-stamped), NO reinforcement.
+    while IFS= read -r lid; do
+      [ -z "$lid" ] && continue
+      emit_memory_event surfaced "$lid" "recall displayed (global brain)" \
+        "{\"query\":\"$q_json\",\"origin\":\"global\"}" "" "" "" "$global_db"
+    done <<< "$surfaced_global"
   else
     echo "(no matching learnings)"
   fi

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -393,6 +393,7 @@ cmd_preflight() {
 cmd_read_start() {
   local mode="${1:---weighted}"
   [ ! -f "$DB" ] && cmd_init >/dev/null
+  _ensure_softdelete_cols  # guarantee the archived_at filter below is valid (design 3.7)
   # D9 fix (design 5.1): the ids this preamble surfaces + a label, captured per
   # mode below and emitted as `surfaced` observations after the case.
   local loaded_ids="" sf_mode=""
@@ -405,17 +406,17 @@ cmd_read_start() {
       echo "## Mode: full (all learnings)"
       echo ""
       echo "## Failures (AVOID THESE)"
-      db_exec "SELECT '- [' || type || '] ' || insight FROM learnings WHERE type IN ('failure','gotcha') ORDER BY hit_count DESC, ts DESC;" 2>/dev/null || echo "None"
+      db_exec "SELECT '- [' || type || '] ' || insight FROM learnings WHERE type IN ('failure','gotcha') AND archived_at IS NULL ORDER BY hit_count DESC, ts DESC;" 2>/dev/null || echo "None"
       echo ""
       echo "## Patterns"
-      db_exec "SELECT '- ' || insight FROM learnings WHERE type='pattern' ORDER BY hit_count DESC, ts DESC;" 2>/dev/null || echo "None"
+      db_exec "SELECT '- ' || insight FROM learnings WHERE type='pattern' AND archived_at IS NULL ORDER BY hit_count DESC, ts DESC;" 2>/dev/null || echo "None"
       echo ""
       echo "## Preferences"
-      db_exec "SELECT '- ' || insight FROM learnings WHERE type='preference' ORDER BY ts DESC;" 2>/dev/null || echo "None"
-      # Telemetry only: bump load_count (NOT hit_count — read-start dumps are not
+      db_exec "SELECT '- ' || insight FROM learnings WHERE type='preference' AND archived_at IS NULL ORDER BY ts DESC;" 2>/dev/null || echo "None"
+      # Telemetry only: bump load_count (NOT hit_count: read-start dumps are not
       # relevance feedback; only recall earns a hit_count bump). See migration 013.
-      db_exec "UPDATE learnings SET load_count = load_count + 1;" 2>/dev/null
-      loaded_ids=$(db_exec "SELECT id FROM learnings;" 2>/dev/null); sf_mode="full"
+      db_exec "UPDATE learnings SET load_count = load_count + 1 WHERE archived_at IS NULL;" 2>/dev/null
+      loaded_ids=$(db_exec "SELECT id FROM learnings WHERE archived_at IS NULL;" 2>/dev/null); sf_mode="full"
       ;;
 
     --summary)
@@ -430,7 +431,7 @@ cmd_read_start() {
             + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END)
             AS score
-          FROM learnings ORDER BY score DESC LIMIT 10
+          FROM learnings WHERE archived_at IS NULL ORDER BY score DESC LIMIT 10
         );
       " 2>/dev/null || echo "None"
       db_exec "UPDATE learnings SET load_count = load_count + 1 WHERE id IN (
@@ -439,7 +440,7 @@ cmd_read_start() {
             (hit_count * 10) + (CASE WHEN type IN ('failure','gotcha') THEN 50 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END) AS score
-          FROM learnings ORDER BY score DESC LIMIT 10
+          FROM learnings WHERE archived_at IS NULL ORDER BY score DESC LIMIT 10
         )
       );" 2>/dev/null
       loaded_ids=$(db_exec "SELECT id FROM (
@@ -447,7 +448,7 @@ cmd_read_start() {
             (hit_count * 10) + (CASE WHEN type IN ('failure','gotcha') THEN 50 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END) AS score
-          FROM learnings ORDER BY score DESC LIMIT 10
+          FROM learnings WHERE archived_at IS NULL ORDER BY score DESC LIMIT 10
         );" 2>/dev/null); sf_mode="summary"
       ;;
 
@@ -456,16 +457,16 @@ cmd_read_start() {
       echo "## Mode: tiered (hot + warm + cold)"
       echo ""
       echo "### Hot (high-hit, proven valuable)"
-      db_exec "SELECT '- ' || insight FROM learnings WHERE hit_count > 5 ORDER BY hit_count DESC;" 2>/dev/null || echo "None"
+      db_exec "SELECT '- ' || insight FROM learnings WHERE hit_count > 5 AND archived_at IS NULL ORDER BY hit_count DESC;" 2>/dev/null || echo "None"
       echo ""
       echo "### Warm (all failures + gotchas)"
-      db_exec "SELECT '- [' || type || '] ' || insight FROM learnings WHERE type IN ('failure','gotcha') AND hit_count <= 5 ORDER BY hit_count DESC, ts DESC;" 2>/dev/null || echo "None"
+      db_exec "SELECT '- [' || type || '] ' || insight FROM learnings WHERE type IN ('failure','gotcha') AND hit_count <= 5 AND archived_at IS NULL ORDER BY hit_count DESC, ts DESC;" 2>/dev/null || echo "None"
       echo ""
       echo "### Cold (last 7 days)"
-      db_exec "SELECT '- ' || insight FROM learnings WHERE hit_count <= 5 AND type NOT IN ('failure','gotcha') AND julianday('now') - julianday(ts) < 7 ORDER BY ts DESC;" 2>/dev/null || echo "None"
+      db_exec "SELECT '- ' || insight FROM learnings WHERE hit_count <= 5 AND type NOT IN ('failure','gotcha') AND julianday('now') - julianday(ts) < 7 AND archived_at IS NULL ORDER BY ts DESC;" 2>/dev/null || echo "None"
       # Telemetry only: bump load_count for the dumped tier set (see migration 013).
-      db_exec "UPDATE learnings SET load_count = load_count + 1 WHERE hit_count > 5 OR type IN ('failure','gotcha') OR julianday('now') - julianday(ts) < 7;" 2>/dev/null
-      loaded_ids=$(db_exec "SELECT id FROM learnings WHERE hit_count > 5 OR type IN ('failure','gotcha') OR julianday('now') - julianday(ts) < 7;" 2>/dev/null); sf_mode="tiered"
+      db_exec "UPDATE learnings SET load_count = load_count + 1 WHERE (hit_count > 5 OR type IN ('failure','gotcha') OR julianday('now') - julianday(ts) < 7) AND archived_at IS NULL;" 2>/dev/null
+      loaded_ids=$(db_exec "SELECT id FROM learnings WHERE (hit_count > 5 OR type IN ('failure','gotcha') OR julianday('now') - julianday(ts) < 7) AND archived_at IS NULL;" 2>/dev/null); sf_mode="tiered"
       ;;
 
     --weighted|*)
@@ -481,7 +482,7 @@ cmd_read_start() {
             + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END)
             AS score
-          FROM learnings ORDER BY score DESC LIMIT 75
+          FROM learnings WHERE archived_at IS NULL ORDER BY score DESC LIMIT 75
         );
       " 2>/dev/null || echo "None"
       # Telemetry only: bump load_count for the dumped set (see migration 013).
@@ -491,7 +492,7 @@ cmd_read_start() {
             (hit_count * 10) + (CASE WHEN type IN ('failure','gotcha') THEN 50 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END) AS score
-          FROM learnings ORDER BY score DESC LIMIT 75
+          FROM learnings WHERE archived_at IS NULL ORDER BY score DESC LIMIT 75
         )
       );" 2>/dev/null
       loaded_ids=$(db_exec "SELECT id FROM (
@@ -499,7 +500,7 @@ cmd_read_start() {
             (hit_count * 10) + (CASE WHEN type IN ('failure','gotcha') THEN 50 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 7 THEN 10 ELSE 0 END)
             + (CASE WHEN julianday('now') - julianday(ts) < 14 THEN 5 ELSE 0 END) AS score
-          FROM learnings ORDER BY score DESC LIMIT 75
+          FROM learnings WHERE archived_at IS NULL ORDER BY score DESC LIMIT 75
         );" 2>/dev/null); sf_mode="weighted-75"
       ;;
   esac
@@ -1628,24 +1629,39 @@ cmd_trace() {
 
 cmd_decay() {
   [ ! -f "$DB" ] && { echo "No DB"; exit 1; }
+  _ensure_softdelete_cols  # archived_at/archived_reason are the soft-delete cache (design 3.10)
 
-  # Delete learnings that are TRULY untouched: never recalled (hit_count=0) AND
-  # never even loaded into a session preamble (load_count=0) AND >46 days old.
-  # Since v7.15, hit_count is recall-only — a still-loaded-but-never-recalled
-  # learning keeps hit_count=0, so requiring load_count=0 too prevents deleting
-  # learnings that read-start is actively surfacing. COALESCE handles pre-013 DBs.
-  local cond="hit_count = 0 AND COALESCE(load_count,0) = 0 AND ts < datetime('now', '-46 days')"
-  local archived
-  archived=$(db_exec "SELECT COUNT(*) FROM learnings WHERE $cond;")
+  # SOFT-DELETE (never DELETE) learnings that are TRULY untouched: never recalled
+  # (hit_count=0) AND never even loaded into a session preamble (load_count=0) AND
+  # >46 days old. Since v7.15 hit_count is recall-only (a still-loaded-but-never-
+  # recalled learning keeps hit_count=0), so requiring load_count=0 too prevents
+  # archiving learnings that read-start is actively surfacing. COALESCE handles
+  # pre-013 DBs. The `archived_at IS NULL` guard makes a re-run idempotent.
+  # This replaces the pre-repair HARD DELETE that destroyed reinforcement history
+  # (the boundary violation the commission exists to prevent; design 3.10).
+  local cond="hit_count = 0 AND COALESCE(load_count,0) = 0 AND ts < datetime('now', '-46 days') AND archived_at IS NULL"
+  local ids n=0 lid
+  ids=$(db_exec "SELECT id FROM learnings WHERE $cond;" 2>/dev/null)
 
-  if [ "$archived" -gt 0 ]; then
-    db_exec "DELETE FROM learnings WHERE $cond;"
-    echo "Archived $archived stale learnings (0 hits, 0 loads, >46 days)"
+  if [ -n "$ids" ]; then
+    # Emit an `archived` observation per row: every disappearance from the working
+    # set is a recorded event with a reason, never a silent destroy (design 3.7).
+    while IFS= read -r lid; do
+      [ -z "$lid" ] && continue
+      emit_memory_event archived "$lid" "decay: 0 hits, 0 loads, >46 days" '{"policy":"decay-46d"}'
+      n=$((n + 1))
+    done <<< "$ids"
+    # Refresh the derived cache columns from that same policy (the cache is a
+    # function of the archived event; recall/read-start filter archived_at IS NULL).
+    db_exec "UPDATE learnings SET archived_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+               archived_reason = 'decay: 0 hits, 0 loads, >46 days'
+             WHERE $cond;" 2>/dev/null
+    echo "Archived $n stale learnings (soft-delete: 0 hits, 0 loads, >46 days). Reverse with: agentdb resurrect <id>"
   else
     echo "No stale learnings to archive"
   fi
 
-  # Report freshness distribution
+  # Report freshness distribution (live rows only; archived rows are excluded).
   echo ""
   echo "Freshness distribution:"
   db_exec "SELECT
@@ -1654,8 +1670,30 @@ cmd_decay() {
       WHEN hit_count >= 1 THEN 'reinforced (' || COUNT(*) || ')'
       ELSE 'unvalidated (' || COUNT(*) || ')'
     END as status
-  FROM learnings GROUP BY
+  FROM learnings WHERE archived_at IS NULL GROUP BY
     CASE WHEN hit_count >= 3 THEN 1 WHEN hit_count >= 1 THEN 2 ELSE 3 END;"
+}
+
+cmd_resurrect() {
+  # Reverse a soft-delete: emit a `resurrected` observation (which clears the
+  # archived cache per the design 1.1 derivation), then null the cache columns.
+  local id="${1:-}"
+  [ -z "$id" ] && { echo "Usage: agentdb resurrect <learning_id>"; exit 1; }
+  [ ! -f "$DB" ] && { echo "No DB"; exit 1; }
+  _ensure_softdelete_cols
+
+  local safe_id exists archived
+  safe_id=$(sql_escape "$id")
+  exists=$(db_exec "SELECT 1 FROM learnings WHERE id='$safe_id' LIMIT 1;" 2>/dev/null || echo "")
+  [ -z "$exists" ] && { echo "No learning with id: $id" >&2; exit 1; }
+  archived=$(db_exec "SELECT 1 FROM learnings WHERE id='$safe_id' AND archived_at IS NOT NULL LIMIT 1;" 2>/dev/null || echo "")
+  if [ -z "$archived" ]; then
+    echo "Not archived (nothing to resurrect): $id"
+    return 0
+  fi
+  emit_memory_event resurrected "$id" "manual resurrect" '{"via":"agentdb resurrect"}'
+  db_exec "UPDATE learnings SET archived_at = NULL, archived_reason = NULL WHERE id='$safe_id';" 2>/dev/null
+  echo "Resurrected: $id"
 }
 
 cmd_antibody() {
@@ -1717,6 +1755,14 @@ _recall_emit() {
   # Each row is: <dedup-key>@@US@@<display>@@US@@<row id>@@US@@<origin>. The id +
   # origin let cmd_recall emit/reinforce the ACTUALLY-displayed rows (design 5.1),
   # not the raw match set. Older callers that pass no origin default to 'local'.
+  # Archived rows (soft-deleted, design 3.7/3.10) are excluded, but ONLY when the
+  # column exists in THIS db: the global brain may not have migrated yet, so the
+  # filter is column-gated to keep global recall working mid-migration.
+  local arch_fts="" arch_like=""
+  if sqlite3 "$db" "SELECT 1 FROM pragma_table_info('learnings') WHERE name='archived_at' LIMIT 1;" 2>/dev/null | grep -q 1; then
+    arch_fts="AND l.archived_at IS NULL"
+    arch_like="AND archived_at IS NULL"
+  fi
   local has_fts
   has_fts=$(sqlite3 "$db" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='learnings_fts' LIMIT 1;" 2>/dev/null || echo "")
   if [ -n "$has_fts" ]; then
@@ -1730,6 +1776,7 @@ _recall_emit() {
       FROM learnings l JOIN learnings_fts f ON f.rowid = l.rowid
       WHERE learnings_fts MATCH '$fts_query'
         AND (l.visibility = 'agent' OR l.visibility IS NULL)
+        $arch_fts
       ORDER BY (
         bm25(learnings_fts)
         - (CASE WHEN l.type IN ('failure','gotcha') THEN 1.5 ELSE 0 END)
@@ -1747,6 +1794,7 @@ _recall_emit() {
       FROM learnings
       WHERE ($like_clause)
         AND (visibility = 'agent' OR visibility IS NULL)
+        $arch_like
       ORDER BY hit_count DESC, ts DESC
       LIMIT $((limit * 5));" 2>/dev/null || true
   fi
@@ -1795,6 +1843,7 @@ cmd_recall() {
   if [ -z "$has_fts" ] || [ -z "$has_mevents" ]; then
     run_pending_migrations "recall:applied_migration" >/dev/null 2>&1 || true
   fi
+  _ensure_softdelete_cols  # guarantee the local archived_at filter is valid (design 3.7)
 
   # Resolve the global brain only if requested.
   local global_db=""
@@ -2226,6 +2275,7 @@ case "${1:-help}" in
   schema)      shift; cmd_schema "$@" ;;
   trace)       shift; cmd_trace "$@" ;;
   decay)       cmd_decay ;;
+  resurrect)   shift; cmd_resurrect "$@" ;;
   antibody)    shift; cmd_antibody "$@" ;;
   recall)      shift; cmd_recall "$@" ;;
   export)      cmd_export ;;
@@ -2269,7 +2319,8 @@ case "${1:-help}" in
     echo "  inject-context <type>   Build agent-specific context slice"
     echo "LEARNING SYSTEM (after migration 005):"
     echo "  trace <json>            Record GEPA execution trace"
-    echo "  decay                   Archive stale learnings, show freshness"
+    echo "  decay                   Soft-delete stale learnings (archived event + cache), show freshness"
+    echo "  resurrect <id>          Reverse a soft-delete (emits a resurrected event)"
     echo "  antibody <text>         Search learnings for pattern matches"
     echo "HYPOTHESIS TESTING (after migration 006):"
     echo "  hypothesis add <stmt> [--domain X] [--source Y]  Create hypothesis"

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -28,23 +28,41 @@ command -v sqlite3 >/dev/null 2>&1 || { echo "Error: sqlite3 required but not fo
 
 # Find project root (where .claude/ or _meta/ exists)
 find_project_root() {
-  # Explicit override wins — pin the DB location to dodge the PWD-walk foot-gun
+  # Explicit override wins: pin the DB location to dodge the PWD-walk foot-gun
   # when agents run from sub-dirs or temp dirs (D9/R7).
   if [ -n "${AGENTDB_ROOT:-}" ]; then
     echo "$AGENTDB_ROOT"
     return
   fi
+  # KERNEL_VAULTS (if set) is the privileged vault root. A "nested vault" (a
+  # direct child of it that carries its own _meta/.claude, e.g. CollabVault or
+  # CodingVault) must NOT shadow it for a root-scoped command: walk THROUGH such a
+  # match up to KERNEL_VAULTS and return the root, with a one-line shadow warning.
+  # Genuine projects (deeper than a direct child) still win via the nearest-ancestor
+  # rule. This whole block is gated on KERNEL_VAULTS being set, so the walk is
+  # byte-for-byte unchanged when it is unset (design 3.9).
+  local kv="${KERNEL_VAULTS:-}"; kv="${kv%/}"
   local dir="$PWD"
+  local shadow=""
   while [ "$dir" != "/" ]; do
     if [ -d "$dir/_meta" ] || [ -d "$dir/.claude" ]; then
+      if [ -n "$kv" ] && [ "$dir" != "$kv" ] && [ "$(dirname "$dir")" = "$kv" ]; then
+        # A nested vault sitting directly under KERNEL_VAULTS: record it, keep climbing.
+        [ -z "$shadow" ] && shadow="$dir"
+        dir=$(dirname "$dir")
+        continue
+      fi
+      if [ -n "$shadow" ] && [ "$dir" = "$kv" ]; then
+        echo "agentdb: warning: nested vault $shadow shadows KERNEL_VAULTS root $kv; routing to $kv (set AGENTDB_ROOT to pin a different db)" >&2
+      fi
       echo "$dir"
       return
     fi
     dir=$(dirname "$dir")
   done
-  # Fallback: nothing found on the walk up. Warn — this is how orphan DBs get
+  # Fallback: nothing found on the walk up. Warn: this is how orphan DBs get
   # created in whatever PWD happened to be (the "VaultsS" typo orphan, etc.).
-  echo "agentdb: warning — no _meta/ or .claude/ above $PWD; using PWD (set AGENTDB_ROOT to pin)" >&2
+  echo "agentdb: warning: no _meta/ or .claude/ above $PWD; using PWD (set AGENTDB_ROOT to pin)" >&2
   echo "$PWD"
 }
 

--- a/orchestration/agentdb/migrations/014_memory_events_and_softdelete.sql
+++ b/orchestration/agentdb/migrations/014_memory_events_and_softdelete.sql
@@ -1,0 +1,45 @@
+-- Migration 014: memory-lifecycle event spine + soft-delete columns.
+--
+-- WHY (memory observatory, design 2.1 / 3.7 / 6.2): the pre-existing `events`
+-- table (migration 003) is hook/session/command telemetry only, with a closed
+-- CHECK enum that structurally cannot record a memory verb (created / imported /
+-- merged / retrieved / surfaced / reinforced / archived / ...). This migration
+-- adds a dedicated APPEND-ONLY `memory_events` table that IS the observation
+-- ground truth for the memory lifecycle. Derived caches (hit_count, archived_at)
+-- are reconciled against it; interpretations never enter it.
+--
+-- APPEND-ONLY CONTRACT: never UPDATE, never DELETE a row here. A correction is a
+-- new event (kind='superseded', object_id pointing at the corrected row). The
+-- `kind` column is deliberately OPEN vocabulary (no CHECK): live data already
+-- carries out-of-vocabulary verbs and a closed enum would force a schema
+-- migration for every new verb. Known verbs are validated advisory-only in code.
+CREATE TABLE IF NOT EXISTS memory_events (
+  event_id         TEXT PRIMARY KEY,           -- <db-short>-<ts>-<pid>-<rand>, globally unique across dbs
+  ts               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  schema_version   INTEGER NOT NULL DEFAULT 1, -- bump only on shape change; old rows keep their number
+  kind             TEXT NOT NULL,              -- OPEN vocabulary, no CHECK (advisory validation in code)
+  actor            TEXT,                       -- session id | script name | hook name | 'human' | import name
+  -- provenance (immutable observation of origin):
+  source_db        TEXT,                       -- logical name or realpath of the db the action touched
+  source_row_id    TEXT,                       -- id of the row in its ORIGIN db (survives import)
+  import_batch_id  TEXT,                       -- set on imported/merged events; null for in-place events
+  -- affected records:
+  subject_id       TEXT,                       -- the learning/hypothesis this event is about
+  object_id        TEXT,                       -- the OTHER row, for merged/superseded/graduated
+  -- the why + the rest:
+  reason           TEXT,                       -- why this happened (required by convention)
+  inference_method TEXT,                       -- null = directly observed; set = derived/inferred/seed
+  payload          TEXT                        -- JSON: query text, candidate/surfaced ids, observed_hit_count, domain from/to, etc.
+);
+CREATE INDEX IF NOT EXISTS idx_mevents_subject ON memory_events(subject_id);
+CREATE INDEX IF NOT EXISTS idx_mevents_kind    ON memory_events(kind);
+CREATE INDEX IF NOT EXISTS idx_mevents_ts      ON memory_events(ts);
+
+-- Soft-delete columns on learnings (design 3.7 / 3.10). These are DERIVED CACHES
+-- of the latest archived/resurrected memory_event, not authoritative state. Like
+-- migrations 004 / 009 / 013, the ADD COLUMN is delegated to cmd_preflight
+-- (_ensure_softdelete_cols) and defined in schema.sql for fresh DBs: a raw ALTER
+-- here would throw "duplicate column name" when preflight force-re-reads every
+-- migration to repair a dropped table. Record the marker only; let the code own
+-- the column so this file stays idempotent under a force re-read.
+INSERT OR IGNORE INTO _migrations (name) VALUES ('014_memory_events_and_softdelete');

--- a/orchestration/agentdb/schema.sql
+++ b/orchestration/agentdb/schema.sql
@@ -19,7 +19,9 @@ CREATE TABLE IF NOT EXISTS learnings (
   load_count INTEGER DEFAULT 0,        -- bumped by read-start (session-open telemetry, never ranked)
   last_hit TEXT,
   visibility TEXT DEFAULT 'agent',     -- agent | human_only | operational
-  sensitivity TEXT DEFAULT 'low'       -- low | medium | high
+  sensitivity TEXT DEFAULT 'low',      -- low | medium | high
+  archived_at TEXT,                    -- migration 014: derived cache of latest archived event (NULL = live)
+  archived_reason TEXT                 -- migration 014: reason from that archived event
 );
 
 CREATE INDEX IF NOT EXISTS idx_learnings_type ON learnings(type);

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1917,11 +1917,13 @@ test_decay_spares_loaded_learnings() {
   sqlite3 "$db" "INSERT INTO learnings (id,ts,type,insight,hit_count,load_count) VALUES ('OLD-LOADED','2020-01-01T00:00:00Z','pattern','old but still loaded lesson',0,3);"
   sqlite3 "$db" "INSERT INTO learnings (id,ts,type,insight,hit_count,load_count) VALUES ('OLD-DEAD','2020-01-01T00:00:00Z','pattern','old and truly untouched lesson',0,0);"
   agentdb decay >/dev/null
-  local loaded dead
-  loaded=$(sqlite3 "$db" "SELECT count(*) FROM learnings WHERE id='OLD-LOADED';")
-  dead=$(sqlite3 "$db" "SELECT count(*) FROM learnings WHERE id='OLD-DEAD';")
+  local loaded live_dead archived_dead
+  loaded=$(sqlite3 "$db" "SELECT count(*) FROM learnings WHERE id='OLD-LOADED' AND archived_at IS NULL;")
+  live_dead=$(sqlite3 "$db" "SELECT count(*) FROM learnings WHERE id='OLD-DEAD' AND archived_at IS NULL;")
+  archived_dead=$(sqlite3 "$db" "SELECT count(*) FROM learnings WHERE id='OLD-DEAD' AND archived_at IS NOT NULL;")
   [ "$loaded" -eq 1 ] || { echo "decay wrongly deleted a loaded learning"; return 1; }
-  [ "$dead" -eq 0 ] || { echo "decay failed to remove a truly-untouched learning"; return 1; }
+  [ "$live_dead" -eq 0 ] || { echo "decay failed to archive a truly-untouched learning"; return 1; }
+  [ "$archived_dead" -eq 1 ] || { echo "decay should soft-archive, not hard-delete, stale learnings"; return 1; }
 }
 
 # --- Learn Domain Auto-Population Tests ---


### PR DESCRIPTION
Kernel-claude track of the memory observatory repair (commission
`2026-07-01-repair-the-memory-observatory`). THE SPEC IS THE DESIGN:
`_meta/research/memory-observatory/design.md` (v2, adversary-revised); this PR
implements design rows PR1-PR4 (sections 2.1-2.3, 3.9, 3.10, 5.1).

All four commits are additive and verified live against throwaway copies of a
real `agent.db` (never a live one). Do not merge yet (commission still has the
metabrain + Vaults-root tracks + PR8 validation to land).

## Commits
- **PR1 `ea5fc01`** (design 2.1/3.7/6.2): migration 014 adds the append-only
  `memory_events` spine (open-vocabulary kind, provenance triple, subject/object,
  reason, inference_method, payload, schema_version) + `archived_at`/
  `archived_reason` derived-cache columns on `learnings`; a best-effort
  `emit_memory_event` helper (never crashes the caller; a lost emit warns loudly;
  advisory known-verb validation; empty fields become SQL NULL). No behavior
  change; preflight self-heals the new table + columns.
- **PR2 `037be33`** (design 5.1, the D9 fix): wires emits into
  learn/recall/read-start/verdict. Recall emits `retrieved` (query-level candidate
  set) plus `surfaced` + `reinforced` on the ACTUALLY-DISPLAYED ids, and the
  hit_count bump now targets the deduped display set (fixing the pre-repair
  bump-vs-display mismatch). Global-brain rows get a source-stamped `surfaced`
  observation but no reinforcement.
- **PR3 `848e94e`** (design 3.10/3.7): `cmd_decay` stops HARD-DELETEing; it emits
  an `archived` event + sets the derived cache. New `agentdb resurrect <id>`
  emits `resurrected` and clears the cache. recall/read-start filter
  `archived_at IS NULL` (column-gated so the not-yet-migrated global brain keeps
  working).
- **PR4 `5f877d1`** (design 3.9): `find_project_root` honors `$KERNEL_VAULTS` as
  the privileged root, rerouting a nested-vault cwd to the root with a shadow
  warning; genuine projects unchanged; byte-for-byte identical when the env is
  unset.

## Live verification highlights
- PR1: preflight creates table + columns + indexes, existing rows untouched,
  emit records known/unknown verbs and rejects empty kind, JSON mirror
  round-trips `memory_events`.
- PR2: recall's surfaced set == reinforced set == displayed rows; the hit_count
  bump hit exactly those rows and nothing else.
- PR3: a synthetic stale row is soft-deleted (present, hit_count preserved,
  archived event emitted), excluded from recall + read-start, decay re-run is a
  no-op, resurrect restores it; a global.db with no `archived_at` still recalls.
- PR4: 7 cwds byte-identical to origin/main with `KERNEL_VAULTS` unset; nested
  vault reroutes with warning, grandchild project stays local, `AGENTDB_ROOT`
  still wins.

## Notes / deviations (see design doc)
- Migration 014 delegates the `ALTER TABLE ADD COLUMN` for the archived columns
  to `_ensure_softdelete_cols`/preflight (schema.sql for fresh DBs) rather than a
  raw ALTER in the migration body, matching the existing migrations 004/009/013
  idempotency pattern (a raw ALTER throws "duplicate column" under preflight's
  force re-read). Same additive effect the design specifies.
- `cmd_decay`'s emit is bundled into PR3 (emit `archived` as part of the
  soft-delete) rather than PR2, so there is never an emit-then-DELETE transitional
  state.
- `cmd_verdict` emits a `session_outcome` phase-4 causal anchor (subject NULL,
  joined to surfaced events by actor), a small labeled extension of the 2.2 vocab
  for the phase-4 outcome capture the commission asks for.

Design doc: `_meta/research/memory-observatory/design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)