### PR TITLE
feat(retrospective): promote learnings via artifact ladder (hook > agent > skill > prose)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <block action="trust_agent_summary">Receipts describe intent. Files describe reality. Read the file before approving the checkpoint.</block>
   <block action="self_score_high_stakes_eval">Spawn blind-evaluator for any user-facing or high-stakes eval. Self-scoring inflates ~36% structurally.</block>
   <block action="autonomous_loop_without_budget_cap">/kernel:forge and tier 2+ multi-agent spawns require max_budget_usd. Stuck retries silently burn 3-4 figures.</block>
+  <block action="verify_sub_computation_only">A green sub-computation is not a green control flow. Drive the armed path end-to-end (wired hook, registered handler, fresh runtime); echo-test every wrapper param once (silently dropped params run defaults while reporting your value); name the live call site that reaches new code, built-but-unreachable is not shipped.</block>
   <block action="promote_learning_to_prose">A pattern reinforced 2+ (or once, if the failure is quiet/expensive) becomes an artifact: hook if enforceable, agent if it's a role, skill if it's methodology. CLAUDE.md prose is the last resort, not the default. Project-specific artifacts scaffold into the host project's .claude/, not the plugin.</block>
 </anti_patterns>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,10 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
     Bug mode: reproduce → trace → isolate → hypothesize → diagnose.
     Refactor mode: map → trace deps → coupling → risks → diagnose.
   </command>
-  <command id="/kernel:retrospective" purpose="Cross-session learning synthesis. Finds patterns, resolves contradictions, promotes insights." file="commands/retrospective.md">
-    Groups learnings, merges duplicates, archives stale, promotes high-confidence patterns.
+  <command id="/kernel:retrospective" purpose="Cross-session learning synthesis. Finds patterns, resolves contradictions, promotes insights into project artifacts." file="commands/retrospective.md">
+    Groups learnings, merges duplicates, archives stale, promotes via the artifact ladder
+    (hook > agent > skill > prose), scaffolds the artifact in the host project's .claude/,
+    doesn't just recommend. Audits project fit: missing artifacts created, dormant ones flagged.
   </command>
   <command id="/kernel:metrics" purpose="Observability dashboard. Sessions, agents, hooks, learnings." file="commands/metrics.md">
     Wraps agentdb metrics + health with actionable insights.
@@ -258,6 +260,7 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <block action="trust_agent_summary">Receipts describe intent. Files describe reality. Read the file before approving the checkpoint.</block>
   <block action="self_score_high_stakes_eval">Spawn blind-evaluator for any user-facing or high-stakes eval. Self-scoring inflates ~36% structurally.</block>
   <block action="autonomous_loop_without_budget_cap">/kernel:forge and tier 2+ multi-agent spawns require max_budget_usd. Stuck retries silently burn 3-4 figures.</block>
+  <block action="promote_learning_to_prose">A pattern reinforced 2+ (or once, if the failure is quiet/expensive) becomes an artifact: hook if enforceable, agent if it's a role, skill if it's methodology. CLAUDE.md prose is the last resort, not the default. Project-specific artifacts scaffold into the host project's .claude/, not the plugin.</block>
 </anti_patterns>
 
 <!-- ============================================ -->

--- a/agents/adversary.md
+++ b/agents/adversary.md
@@ -34,8 +34,8 @@ Reference: skills/quality/reference/quality-research.md
      Run BEFORE code review. If coordination fails, code review is pointless. -->
 Verify coordination integrity (tier 2+ contracts):
 - File overlap: Did multiple agents modify the same files? `git diff --name-only` per branch.
-- Claim verification: Agent claims completion — open the actual file with Read and verify the
-  claimed function/type/behavior exists. "Exists and is non-empty" is not enough — modelmind hit
+- Claim verification: Agent claims completion, open the actual file with Read and verify the
+  claimed function/type/behavior exists. "Exists and is non-empty" is not enough, modelmind hit
   a case where a surgeon claimed drag-and-drop but the file contained only type definitions.
   Read the body, not just the path.
 - Scope drift: Files changed outside contract constraints = FAIL.
@@ -64,24 +64,35 @@ Scope violation = automatic FAIL.
 Run basic happy path. If fails, FAIL immediately.
 </phase>
 
-<phase id="edge_cases" priority="5">
+<phase id="reachability" priority="5">
+Exercise the armed path, not the sub-computation:
+- Name the live call site that invokes the new code. Grep for callers; a fully
+  built system with zero call sites is NOT shipped. No live entry point = FAIL.
+- Drive the real wired path end-to-end once (the installed hook, the registered
+  handler, the fresh-checkout runtime), not the extracted function in isolation.
+- Echo-test any wrapper/tool params the change relies on: confirm the value
+  arrives, not the default. A green isolated test over an unwired path = FAIL.
+</phase>
+
+<phase id="edge_cases" priority="6">
 Test: null, empty, boundary, invalid, concurrent, large input.
 At least 3 categories per review.
 </phase>
 
-<phase id="error_paths" priority="6">
-Invalid input returns useful error? Errors logged, not swallowed?
+<phase id="error_paths" priority="7">
+Invalid input returns useful error? Errors logged, not swallowed? A catch/onError
+returning a masked body without logging the cause = FAIL.
 </phase>
 
-<phase id="regression" priority="7">
+<phase id="regression" priority="8">
 Run full test suite. New failures = FAIL.
 </phase>
 
-<phase id="security" priority="8">
+<phase id="security" priority="9">
 Input validated? Auth protected? No secrets exposed?
 </phase>
 
-<phase id="contract" priority="9">
+<phase id="contract" priority="10">
 All success criteria met with evidence?
 Partial = FAIL.
 </phase>
@@ -95,7 +106,7 @@ Surface to GitHub: if github-oss/production profile and issue exists, post verdi
 <ask_user>
   Use AskUserQuestion when: a finding could be intentional design (not clearly a defect)
   Ask: "Found {behavior} at {file:line}. Intentional design choice, or defect?"
-  Options: intentional — skip, defect — fail it, need more context
+  Options: intentional, skip, defect, fail it, need more context
 </ask_user>
 
 <anti_patterns>
@@ -117,6 +128,7 @@ agentdb write-end '{"agent":"adversary","result":"pass|fail","phases_completed":
 - [ ] Big 5 checked (quality skill loaded)
 - [ ] Scope verified
 - [ ] Smoke test passed
+- [ ] Reachability proven (live call site named, armed path driven end-to-end)
 - [ ] Edge cases tested (3+ categories)
 - [ ] Regression suite passed
 - [ ] Evidence is actual output

--- a/commands/help.md
+++ b/commands/help.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Bash, Grep, Glob
 
 <purpose>
 Quick reference for KERNEL v7.23.0.
-Commands, agents, workflows, philosophy — and current plugin status.
+Commands, agents, workflows, philosophy, and current plugin status.
 </purpose>
 
 <on_start>
@@ -17,7 +17,7 @@ Before showing help, check the actual state of the plugin as loaded in your cont
 1. Is the session-start hook output visible? (Look for "# KERNEL" at conversation start)
 2. Which profile is active? (local, github, github-oss, github-production)
 3. Are there active contracts or pending reviews in AgentDB?
-4. Report what you see — don't just recite docs.
+4. Report what you see, don't just recite docs.
 
 ```bash
 agentdb read-start
@@ -40,16 +40,16 @@ agentdb read-start
 
 | Command | Purpose | When to use |
 |---------|---------|-------------|
-| `/kernel:ingest` | Guided entry — classify, scope, execute | Default for any task. Human confirms each phase. |
-| `/kernel:forge` | Autonomous engine — heat/hammer/quench/anneal | Run overnight. Iterates until antifragile or reports why not. |
-| `/kernel:dream` | Creative exploration — 3 perspectives + stress test | When you need competing approaches before committing. |
+| `/kernel:ingest` | Guided entry, classify, scope, execute | Default for any task. Human confirms each phase. |
+| `/kernel:forge` | Autonomous engine, heat/hammer/quench/anneal | Run overnight. Iterates until antifragile or reports why not. |
+| `/kernel:dream` | Creative exploration, 3 perspectives + stress test | When you need competing approaches before committing. |
 | `/kernel:diagnose` | Systematic debugging + refactor analysis | Bugs, regressions, or before refactoring. Diagnosis before prescription. |
 
 ## Quality & Review
 
 | Command | Purpose | When to use |
 |---------|---------|-------------|
-| `/kernel:validate` | Pre-commit gates — build, lint, test, security | Before every commit. Blocks on failure. |
+| `/kernel:validate` | Pre-commit gates, build, lint, test, security | Before every commit. Blocks on failure. |
 | `/kernel:tearitapart` | Critical pre-implementation review | Before tier 2+ work. Verdict: PROCEED/REVISE/RETHINK. |
 | `/kernel:review` | Code review for PRs or staged changes | Before merging. >80% confidence threshold. |
 
@@ -57,7 +57,7 @@ agentdb read-start
 
 | Command | Purpose | When to use |
 |---------|---------|-------------|
-| `/kernel:retrospective` | Cross-session learning synthesis | When 5+ learnings accumulated. Clusters, deduplicates, promotes patterns. |
+| `/kernel:retrospective` | Cross-session learning synthesis | When 5+ learnings accumulated. Clusters, deduplicates, promotes patterns into project hooks/agents/skills. |
 | `/kernel:metrics` | Observability dashboard | Check session stats, agent success rates, hook health, learning utilization. |
 
 ## Session Management
@@ -70,7 +70,7 @@ agentdb read-start
 </commands>
 
 <command_flow>
-Typical workflows — commands chain together:
+Typical workflows, commands chain together:
 
 **New feature:**
   ingest → (dream if complex) → tearitapart → execute → validate → review → handoff
@@ -99,12 +99,12 @@ Tier by reversibility x silence x blast radius; file count is only a weak hint.
 | Agent | Role |
 |-------|------|
 | **Surgeon** | Minimal diff implementation. Only touches contract-listed files. |
-| **Adversary** | QA — assumes broken, finds edge cases, proves with evidence. |
+| **Adversary** | QA, assumes broken, finds edge cases, proves with evidence. |
 | **Reviewer** | Code review with APPROVE/REQUEST CHANGES/COMMENT verdict. |
 | **Researcher** | Finds proven solutions and anti-patterns before coding. |
-| **Scout** | Codebase reconnaissance — maps structure, detects tooling. |
-| **Validator** | Pre-commit quality gate — build, types, lint, tests, security. |
-| **Dreamer** | Multi-perspective debate — minimalist/maximalist/pragmatist. |
+| **Scout** | Codebase reconnaissance, maps structure, detects tooling. |
+| **Validator** | Pre-commit quality gate, build, types, lint, tests, security. |
+| **Dreamer** | Multi-perspective debate, minimalist/maximalist/pragmatist. |
 </agents>
 
 <philosophy>
@@ -119,7 +119,7 @@ Tier by reversibility x silence x blast radius; file count is only a weak hint.
 - **Be specific**: "Add rate limiting to /api/upload" > "make it more secure"
 - **Use the right command**: diagnose for bugs, dream for design, ingest for everything else
 - **Check metrics**: `/kernel:metrics` shows if learnings are being used or ignored
-- **Save often**: `/kernel:handoff` before long breaks — the next session starts faster
+- **Save often**: `/kernel:handoff` before long breaks, the next session starts faster
 - **Run retrospective**: After several sessions, synthesize what you've learned
 </tips>
 

--- a/commands/retrospective.md
+++ b/commands/retrospective.md
@@ -1,15 +1,17 @@
 ---
 name: kernel:retrospective
-description: "Cross-session learning synthesis. Finds patterns, resolves contradictions, promotes insights. Triggers: retrospective, reflect, patterns, learnings, synthesis."
+description: "Cross-session learning synthesis. Finds patterns, resolves contradictions, promotes insights into project skills, agents, and hooks. Triggers: retrospective, reflect, patterns, learnings, synthesis."
 user-invocable: true
-allowed-tools: Read, Bash, Grep, Glob
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 
 <command id="retrospective">
 
 <purpose>
 Cross-session learning synthesis. Reviews AgentDB learnings, finds patterns across sessions,
-resolves contradictions, merges duplicates, archives stale entries, promotes high-confidence insights.
+resolves contradictions, merges duplicates, archives stale entries, then promotes surviving
+patterns into ARTIFACTS (project hooks, agents, skills), not prose. A learning that stays a
+sentence in a doc is honor-system; an artifact fires on its own.
 </purpose>
 
 <execution>
@@ -23,33 +25,49 @@ resolves contradictions, merges duplicates, archives stale entries, promotes hig
    agentdb recent
    ```
 
-3. Analyze learnings across 5 dimensions:
+3. Analyze learnings across 6 dimensions:
    - **Clusters**: Group related learnings by theme (e.g., hook loading, git workflow, testing)
-   - **Duplicates**: Identify learnings that say the same thing differently — merge into strongest form
-   - **Contradictions**: Find learnings that conflict — resolve with evidence, archive the loser
+   - **Duplicates**: Identify learnings that say the same thing differently, merge into strongest form
+   - **Contradictions**: Find learnings that conflict, resolve with evidence, archive the loser
    - **Stale**: Flag learnings not reinforced in 30+ days with no recent evidence
-   - **Promotable**: Identify high-confidence patterns (reinforced 2+) worth encoding into rules
+   - **Promotable**: Identify patterns worth encoding as artifacts (reinforced 2+, OR reinforced 1x
+     when the failure mode is quiet/expensive, don't wait for a third burn on a costly lesson)
+   - **Project fit**: Audit the host project's `.claude/` against its actual work. A recurring
+     manual pattern with no skill → skill candidate. A repeated safety catch with no hook → hook
+     candidate. A skill/agent that never fires → prune candidate.
 
-4. Take action:
-   - Merge duplicates: `agentdb learn {type} "{merged}" "{combined evidence}"`
-   - Archive stale: `agentdb query "DELETE FROM learnings WHERE id = {id}"`
-   - Promote patterns: Recommend additions to CLAUDE.md or skill reference docs
-   - If non-local profile: surface promoted patterns to GitHub Discussions (Learnings category)
+4. Promote via the artifact ladder (most enforceable form that fits, never default to prose):
+   - **Hook**, the pattern is a safety property or a mechanical check (I0.15: hooks, not
+     honor-system). Scaffold a PreToolUse/PreCommit script under the project's `.claude/hooks/`.
+   - **Agent**, the pattern is a recurring role with its own judgment (a reviewer lens, a
+     domain validator). Scaffold `.claude/agents/<name>.md`.
+   - **Skill**, the pattern is methodology: a repeatable HOW for this project's work.
+     Scaffold `.claude/skills/<name>/SKILL.md` with triggers phrased the way tasks are asked.
+   - **CLAUDE.md prose**, last resort, only for context no mechanism can enforce.
+   Scaffold means WRITE THE FILE in this session, a draft artifact the human can reject beats
+   a recommendation nobody actions. Artifacts land in the host project's `.claude/`, not the
+   kernel plugin, unless the lesson is genuinely cross-project.
 
    <ask_user>
-     Use AskUserQuestion when: promotable patterns found (reinforced 2+)
-     Ask: "Found {N} promotable patterns. Which should be encoded into rules?"
-     Options: promote all, review each, skip promotion
+     Use AskUserQuestion when: promotable patterns found.
+     Ask: "Found {N} promotable patterns. Scaffolding as {hooks/agents/skills}, approve?"
+     Options: scaffold all, review each, skip promotion
+     Prune candidates (dormant skills/agents) always require explicit approval before removal.
    </ask_user>
 
-5. Write synthesis to AgentDB:
+5. Take housekeeping actions:
+   - Merge duplicates: `agentdb learn {type} "{merged}" "{combined evidence}"`
+   - Archive stale: `agentdb query "DELETE FROM learnings WHERE id = {id}"`
+   - If non-local profile: surface promoted patterns to GitHub Discussions (Learnings category)
+
+6. Write synthesis to AgentDB:
    ```bash
-   agentdb write-end '{"did":"retrospective","clusters":N,"merged":N,"archived":N,"promoted":N}'
+   agentdb write-end '{"did":"retrospective","clusters":N,"merged":N,"archived":N,"promoted":N,"artifacts":["path1","path2"]}'
    ```
 </execution>
 
 <output_format>
-## Retrospective — {date}
+## Retrospective, {date}
 
 ### Clusters
 - **{theme}** ({count} learnings): {summary}
@@ -59,9 +77,12 @@ resolves contradictions, merges duplicates, archives stale entries, promotes hig
 - Archived: {count} stale learnings
 - Contradictions resolved: {count}
 
-### Promotable Patterns
-- {pattern}: reinforced {N}x, evidence: {summary}
-  - Recommend: {where to encode}
+### Artifacts Promoted
+- {pattern} → **{hook|agent|skill|prose}** at `{path}` (reinforced {N}x, evidence: {summary})
+
+### Project Fit
+- Missing: {recurring pattern with no artifact} → {proposed artifact}
+- Dormant: {skill/agent that never fires} → prune candidate
 
 ### Health
 - Total learnings: {N}

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -22,43 +22,44 @@ Deep patterns, SQL schema, domain design templates, confidence-scoring examples:
 
 <flow>
 
-1. **Seed** — parse CLAUDE.md for imperative/assertive statements → register as hypotheses
+1. **Seed**, parse CLAUDE.md for imperative/assertive statements → register as hypotheses
    - (gate: each hypothesis has id, statement, source, domain, status=unproven, confidence=0.0)
    - Auto-assign H001, H002, … ; classify domain from <domains> list
    - `agentdb learn hypothesis "H{N}: {statement}" "{source}:{line}"`
 
-2. **Design** — for each hypothesis under test, define experiment BEFORE running anything
+2. **Design**, for each hypothesis under test, define experiment BEFORE running anything
    - method: what you will do (A/B, timed comparison, fuzz, track-and-count)
    - measurement: quantitative metric preferred (time, error count, rework frequency)
    - control condition: what happens WITHOUT the rule applied
    - pass_criteria: specific observable that supports the hypothesis
    - fail_criteria: specific observable that refutes it
-   - (gate: experiment_designed — must be falsifiable; if no outcome could refute, redesign)
+   - (gate: experiment_designed, must be falsifiable; if no outcome could refute, redesign)
 
-3. **Execute** — run the experiment; record raw observations
+3. **Execute**, run the experiment; record raw observations
    - (gate: control condition was actually tested, not just assumed)
    - minimum sample sizes: methodology/coordination/git/quality ≥ 3 comparisons; testing ≥ 5 tasks per condition; security ≥ 50 fuzz inputs
 
-4. **Score** — apply Bayesian update to confidence
+4. **Score**, apply Bayesian update to confidence
    - supports:     `confidence += (1 - confidence) * 0.25`
    - refutes:      `confidence -= confidence * 0.3`
    - inconclusive: no change (record in evidence log)
    - `agentdb learn experiment "H{N} result={supports|refutes|inconclusive}" "{evidence}"`
 
-5. **Transition** — update hypothesis status per lifecycle rules
+5. **Transition**, update hypothesis status per lifecycle rules
    - unproven → testing: first experiment registered
    - testing → supported: confidence ≥ 0.8 AND evidence_for ≥ 3 AND ratio ≥ 3:1
    - testing → refuted: confidence < 0.2 AND evidence_against ≥ 2
    - supported → graduated: human approval after sustained confidence
    - refuted → killed: human approval to remove from rules
    - any → unproven: rule is modified (resets all evidence)
-   - (gate: evidence_recorded — verdict must include specific, measurable evidence string)
+   - (gate: evidence_recorded, verdict must include specific, measurable evidence string)
 
-6. **Report** — surface verdict
+6. **Report**, surface verdict
    - verdict: SUPPORTED | REFUTED | INCONCLUSIVE
    - confidence: current 0.0–1.0 value
    - evidence: required (specific, measurable, not narrative)
-   - if GRADUATED: propose rule promotion to CLAUDE.md with human approval
+   - if GRADUATED: promote via the artifact ladder with human approval, hook if
+     enforceable, agent if a role, skill if methodology; CLAUDE.md prose only as last resort
    - if KILLED: propose rule removal from CLAUDE.md with human approval
 
 </flow>

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -27,6 +27,23 @@ Every spawned lane gets ALL of these fields; a missing field is where the lane f
    alone; a lane that returns only prose has returned nothing checkable.
 </lane_contract>
 
+<output_integrity>
+Structured long-report lanes degrade silently to placeholders under load. Validate
+every lane return mechanically before using it: minimum-length check on required
+sections, placeholder detection ("TBD", "...", repeated boilerplate), counts match
+the claimed work. Reject-and-retry a degraded return; never synthesize over it.
+Pass large input pools to lanes by FILE PATH, never as an inline slice (silent
+truncation reads as full coverage). Each lane keeps a per-lane journal/checkpoint
+so a degraded final message is not the only record of what it did.
+</output_integrity>
+
+<single_coordinator>
+One coordinator per repo at a time. Before coordinating, check for a live second
+session on the same working directory (stale sessions can survive as background
+daemons and produce split-brain: two coordinators mutating one repo in parallel).
+When killing a stuck session, kill its whole process pool, not just the visible pid.
+</single_coordinator>
+
 <worker_model_doctrine>
 Cheap models (haiku/codex-tier) are safe ONLY for total-spec execution and mechanical
 evidence-only verification: zero delegated decisions, a pre-verified guide, every step
@@ -66,7 +83,9 @@ Holding context in memory instead of AgentDB · assuming a lane finished without
 reading the deliverable file (receipts describe intent; files describe reality) ·
 parallel lanes touching shared files (N-way merge conflicts) · serial execution when
 parallel is genuinely safe · retrying without new information from the failure ·
-autonomous loops without a budget cap (`max_budget_usd` on the contract).
+autonomous loops without a budget cap (`max_budget_usd` on the contract) ·
+accepting a lane return without the output-integrity check (placeholder degradation
+is silent) · two coordinators on one repo.
 </anti_patterns>
 
 </skill>

--- a/skills/quality/SKILL.md
+++ b/skills/quality/SKILL.md
@@ -26,6 +26,11 @@ Handle: null, empty array, zero-length string, timeout, unicode.
 
 <check id="3" name="error_handling" detection="grep -r 'catch.*{}'">
 No empty catch. Errors logged with context. User messages generic.
+Silent swallowing is the worst variant: a catch/onError that returns a masked or
+generic body without first logging method/path/cause hides the root failure behind
+a 500 and costs a full re-diagnosis per incident. Every handler logs the cause
+before it masks. Missing config/dependency is a NAMED condition in the response
+(which var, which service), never a generic error.
 </check>
 
 <check id="4" name="duplication" detection="jscpd or manual review">
@@ -49,6 +54,19 @@ grep -r "catch.*{}" --include="*.ts" --include="*.js" | head -5
 grep -rE "SELECT.*\$\{|INSERT.*\$\{" --include="*.ts" --include="*.js" | head -5
 ```
 </quick_checks>
+
+<data_correctness>
+For any pipeline that extracts or transforms figures (financial, metrics, counts):
+- Parse deterministically (a real parser, regex, typed loader). The LLM never
+  generates, transforms, or "fixes" numeric values.
+- Units are explicit at parse time (percent vs fraction, counts vs currency);
+  a value never crosses unit categories through arithmetic.
+- Tie-out gate: derived aggregates must reproduce the source's own totals before
+  any output is shown downstream. A delta between your output and the source is
+  assumed to be YOUR normalization bug until proven otherwise.
+- Silent-empty guard: "no findings" produced from an empty parse is a failure of
+  the parse, not a finding.
+</data_correctness>
 
 <verdict>
 Any Big 5 violation = NOT READY

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -64,6 +64,22 @@ Before accepting any AI-written test: does the assertion check the right thing, 
 coupled to internals, is state shared between tests, does it test the requirement or
 mirror possibly-buggy code? At least one negative/rejection case per test file.
 
+## Exercise the armed path
+
+A green sub-computation is not a green control flow. The recurring failure shape:
+the logic passes in isolation while the bug lives in how it is wired (the armed
+hook path, the exit code under `set -e`, the runtime type check, setup only the
+test harness performs).
+- Drive the REAL entry point end-to-end at least once: the wired handler, the
+  installed hook, the fresh-checkout runtime, not just the extracted function.
+- Echo-test every wrapper/tool parameter once before relying on it: a silently
+  dropped param runs defaults while reporting your value.
+- Verify reachability, not just correctness: name the live call site that invokes
+  the new code. A fully built system with zero call sites is not shipped.
+- Test-environment parity: anything the harness sets up (migrations, bindings,
+  seeded state), the real runtime must also get, or its absence must be a named,
+  loud condition.
+
 ## Verification Gate
 
 Always provide runnable verification: if you can't verify it, don't ship it. Any


### PR DESCRIPTION
## What

Shifts the kernel's learning-promotion pathway from prose recommendations to scaffolded artifacts.

- **commands/retrospective.md**: promotion step rewritten around the artifact ladder — hook if enforceable, agent if a role, skill if methodology, CLAUDE.md prose only as last resort. Scaffolds the file in-session (human approves/rejects the draft) instead of recommending. New sixth analysis dimension: project fit — recurring patterns with no artifact become candidates, dormant skills/agents get flagged for pruning. Added Write/Edit to allowed-tools. Threshold loosened: reinforced 2+, or 1x when the failure mode is quiet/expensive.
- **CLAUDE.md**: updated retrospective command entry; new anti-pattern block `promote_learning_to_prose` making the ladder the default across sessions.
- **skills/experiment/SKILL.md**: graduated hypotheses follow the same ladder.
- **commands/help.md**: description sync.

## Why

I0.15 already says safety lives in hooks, not honor-system prose — but the promotion pathway defaulted to CLAUDE.md sentences. Learnings that stay prose don't fire; artifacts do.