### PR TITLE
fix: run advisory hooks in Codex (8.0.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code. KERNEL 8 includes 33 skills and 15 specialized agent definitions.",
-      "version": "8.0.1"
+      "version": "8.0.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code. KERNEL 8 includes 33 skills and 15 specialized agent definitions.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<kernel version="8.0.1">
+<kernel version="8.0.2">
 
 <!-- ============================================ -->
 <!-- CONTEXT DELIVERY: READ THIS FIRST            -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.0.2] - 2026-07-11
+
+KERNEL 8.0.2 fixes cross-client advisory hooks that Codex skipped whenever the shared
+manifest marked them `async`. Upgrade and restart Codex so its installed cache loads
+the corrected manifest.
+
+### Fixed
+- Removed exactly six unsupported `async` keys while preserving every hook command,
+  matcher, order, and timeout. The advisory checks now run synchronously in both Claude
+  Code and Codex and still exit successfully when their own downstream work fails.
+- Normalized valid Claude Write/Edit and Codex `apply_patch` payloads for structure,
+  hardcoded-value, JSON-schema, write-log, and error-capture advisory hooks, so inspected
+  paths, added content, and errors are no longer silently empty.
+- Made `log-write.sh` wait for its AgentDB timing emit and tolerate emit failure instead
+  of leaving a detached child after the hook process exits.
+- Added armed cross-loader payload, failure, false-positive, command-retention,
+  no-child, and critical-guard-integrity regressions. The blocking guards remain
+  unchanged.
+
 ## [8.0.1] - 2026-07-11
 
 KERNEL 8.0.1 is the corrected KERNEL 8 release. An incomplete 8.0.0 candidate reached

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<kernel version="8.0.1">
+<kernel version="8.0.2">
 
 <!-- ============================================ -->
 <!-- CONTEXT DELIVERY: READ THIS FIRST            -->

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ claude --plugin-dir "$HOME/kernel-claude-7.23"
 To deliberately select a validated local or cached runtime for the helper links:
 
 ```bash
-"$HOME/.claude/plugins/cache/kernel-marketplace/kernel/8.0.1/scripts/select-runtime.sh" /path/to/kernel-claude-7.23
+"$HOME/.claude/plugins/cache/kernel-marketplace/kernel/8.0.2/scripts/select-runtime.sh" /path/to/kernel-claude-7.23
 ```
 
 That explicit selection may move `current` backward; normal old sessions cannot. It does not convert KERNEL 8 JSON state to KERNEL 7 YAML. Do not delete the plugin cache or remove the marketplace as a normal rollback step.
@@ -163,6 +163,11 @@ must be invoked explicitly with `$kernel:handoff`. Some workflows can use GitHub
 the project profile enables it. KERNEL does not promise that all processing stays
 local when you invoke a workflow that uses external tools. Review host permissions
 and the repository's own instructions before granting access.
+
+KERNEL 8.0.2 declares its six advisory hooks as synchronous so Codex executes them
+instead of skipping them. They remain non-blocking in outcome: an internal logging or
+validation failure returns success and cannot reject the tool operation. The critical
+secret, configuration, command, and context guards remain separate blocking gates.
 
 When the active project root exactly matches the Vaults root and the shared continuity
 engine plus an executable Claude or Codex adapter are present, that Vaults service owns

--- a/_meta/reviews/codex-async-hooks-8.0.2-teardown.md
+++ b/_meta/reviews/codex-async-hooks-8.0.2-teardown.md
@@ -1,0 +1,111 @@
+# Tear Down: Codex async hooks compatibility for 8.0.2
+
+reviewed: 2026-07-11T10:02:00-07:00
+tier: 3
+contract: CR-20260711092844-32094-8833
+scope: 3 required implementation files, release metadata handled by parent contract
+
+## Evidence
+
+- Codex CLI `0.144.1` emits one startup warning for every hook object containing
+  `"async": true` and skips that hook entirely.
+- Claude Code `2.1.207` accepts the same shared `hooks/hooks.json` format.
+- A disposable local marketplace was installed into an isolated `CODEX_HOME` with
+  all `async` keys removed. A real interactive Codex startup loaded and trusted all
+  13 hooks without any async warning.
+- Direct 20-run timings on macOS:
+  - `validate-structure.sh`: 0.19 s total (~10 ms/call)
+  - `warn-hardcoded.sh`: 0.32 s total (~16 ms/call)
+  - `log-write.sh`: 1.06 s total (~53 ms/call, including its current detached emit)
+  - `validate-json-schema.sh`: 0.18 s total (~9 ms/call)
+  - `capture-error.sh`: 7.12 s total (~356 ms/call; failure path only)
+  - synchronous AgentDB hook emit alone: 0.31 s/10 (~31 ms/call)
+- The six affected scripts already consume stdin themselves. Adding a dispatch
+  wrapper would require buffering and replaying the exact payload and would create
+  the child-lifetime/temporary-file race this change is supposed to eliminate.
+
+## Approaches considered
+
+### A. Remove `async` and execute the existing scripts synchronously (recommended)
+
+One shared manifest, no wrapper, no temporary payload, no detached hook process.
+The common Write/Edit path adds roughly 100 ms for all advisory checks together.
+`capture-error` is slower but runs only after a failed tool. `autopush install` is
+normally an immediate no-op because it is opt-in.
+
+Required hardening: remove the inner `&` from `log-write.sh` so the hook really has
+one lifetime, and make the AgentDB timing emit explicitly advisory (`|| true`).
+Keep each hook script unconditionally exiting zero. Preserve critical synchronous
+guards byte-for-byte.
+
+### B. Remove `async` and add a generic detach/background wrapper
+
+Rejected. The wrapper must read all stdin before returning, store or pipe it to a
+child, detach file descriptors, survive parent cleanup, clean temporary files, and
+still surface warnings. `nohup`, `disown`, or `setsid` availability differs across
+macOS/Linux, and success would only prove launch, not completion. It is substantially
+more code and directly conflicts with the no-child-race requirement.
+
+### C. Maintain separate Claude and Codex hook manifests
+
+Rejected for 8.0.2. Both clients currently discover the same plugin hook component;
+there is no validated client selector in the shared marketplace metadata. Two files
+would add a drift-prone release surface without a proven loader path.
+
+## Big 5
+
+input_validation: pass with required dual-loader payload tests
+edge_cases: pass with required empty/malformed payload and missing dependency tests
+error_handling: pass only if all six advisory paths always exit zero
+duplication: pass; no wrapper or duplicate manifest
+complexity: pass; deletion plus one background-removal change
+
+## Security and architecture
+
+- Critical synchronous guards (`guard-bash`, `guard-config`, `detect-secrets`,
+  `guard-context`) must not change.
+- Synchronous advisory checks cannot be allowed to become accidental denial gates.
+- Existing payload inconsistency is a latent cross-client bug: `log-write.sh` reads
+  `.tool_input.file_path`, while three other scripts prefer only top-level
+  `.file_path`. Tests must use one real Claude-shaped fixture and one real
+  Codex-shaped fixture and assert non-empty inspected values, not merely exit zero.
+- No new dependency is justified.
+
+## Verdict: PROCEED
+
+Proceed with Approach A. This is the smallest design, actually runs every behavior
+in Codex, keeps Claude latency bounded, preserves stdin naturally, and eliminates
+rather than relocates hook-child cleanup races.
+
+## Exact bounded implementation files
+
+1. `hooks/hooks.json`
+   - remove exactly six `async` keys; do not alter critical hook commands/matchers.
+2. `hooks/scripts/log-write.sh`
+   - update stale async comments; execute timing emit synchronously and tolerate its
+     failure; leave the primary actions log append advisory.
+3. `tests/run-tests.sh`
+   - regression: no `async` key anywhere in shared hook manifest.
+   - regression: all six commands remain registered and execute.
+   - Claude- and Codex-shaped stdin fixtures assert file/tool/content/error values
+     are actually consumed.
+   - every advisory script returns zero for valid, empty, malformed, missing-file,
+     missing-AgentDB, and unwritable-log scenarios.
+   - process check: no descendant remains after `log-write.sh` exits.
+   - real disposable Codex marketplace smoke (bounded/optional when binary absent)
+     confirms startup output contains no `skipping async hook`.
+
+Release-only metadata/version/docs may be changed by the parent release contract,
+not by this implementation lane.
+
+## Failure conditions
+
+1. Any `async` key remains in the shipped shared manifest.
+2. Any of the six behaviors is removed or skipped rather than executed.
+3. Payload data is empty under either client fixture.
+4. An advisory hook exits nonzero, times out, or blocks the tool operation.
+5. A child process survives hook exit or a temporary stdin payload is raced/removed.
+6. Critical guard definitions change.
+7. Normal Write/Edit advisory latency exceeds 250 ms p95 on the release machine, or
+   the failure-only hook exceeds its five-second timeout.
+8. Actual Codex 0.144.1 startup still prints an async-hook warning.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,8 +13,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopush.sh install",
-            "timeout": 15,
-            "async": true
+          "timeout": 15
           }
         ]
       }
@@ -46,14 +45,12 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-structure.sh",
-            "timeout": 5,
-            "async": true
+          "timeout": 5
           },
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
-            "timeout": 5,
-            "async": true
+          "timeout": 5
           }
         ]
       },
@@ -87,14 +84,12 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/log-write.sh",
-            "timeout": 5,
-            "async": true
+          "timeout": 5
           },
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-json-schema.sh",
-            "timeout": 5,
-            "async": true
+          "timeout": 5
           }
         ]
       }
@@ -106,8 +101,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/capture-error.sh",
-            "timeout": 5,
-            "async": true
+          "timeout": 5
           }
         ]
       }

--- a/hooks/scripts/capture-error.sh
+++ b/hooks/scripts/capture-error.sh
@@ -13,11 +13,13 @@ AGENTDB=$(get_agentdb "$VAULTS")
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // .tool // "unknown"' 2>/dev/null)
 ERROR=$(kernel_hook_error "$INPUT")
-FILE=$(kernel_hook_file_path "$INPUT")
 
 # Only log if agentdb is initialized
 if [ -f "$VAULTS/_meta/agentdb/agent.db" ]; then
-  "$AGENTDB" error "$TOOL" "$ERROR" "$FILE" 2>/dev/null
+  while IFS= read -r RECORD; do
+    FILE=$(printf '%s' "$RECORD" | jq -r '.path // empty' 2>/dev/null)
+    "$AGENTDB" error "$TOOL" "$ERROR" "$FILE" 2>/dev/null || true
+  done < <(kernel_hook_file_records "$INPUT")
 fi
 
 _kernel_hook_end "capture-error" 0

--- a/hooks/scripts/capture-error.sh
+++ b/hooks/scripts/capture-error.sh
@@ -12,8 +12,8 @@ AGENTDB=$(get_agentdb "$VAULTS")
 # Read from stdin (same as all other hooks)
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // .tool // "unknown"' 2>/dev/null)
-ERROR=$(echo "$INPUT" | jq -r '.error // .message // "unknown error"' 2>/dev/null)
-FILE=$(echo "$INPUT" | jq -r '.file_path // .path // ""' 2>/dev/null)
+ERROR=$(kernel_hook_error "$INPUT")
+FILE=$(kernel_hook_file_path "$INPUT")
 
 # Only log if agentdb is initialized
 if [ -f "$VAULTS/_meta/agentdb/agent.db" ]; then

--- a/hooks/scripts/common.sh
+++ b/hooks/scripts/common.sh
@@ -247,26 +247,41 @@ get_project_root() {
   echo "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 }
 
-# Normalize the two loader payload shapes used by advisory hooks. Claude sends
-# Write/Edit fields under tool_input; Codex sends an apply_patch document.
-kernel_hook_file_path() {
-  printf '%s' "$1" | jq -r '
-    .tool_input.file_path // .tool_input.path // .file_path // .path //
-    (if (.tool_input.patch | type) == "string" then
-       [.tool_input.patch | split("\n")[]
-        | select(test("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "))
-        | sub("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "; "")][0] // empty
-     else empty end)
+# Emit one compact JSON record per affected file: {path, content}. Claude
+# Write/Edit produces one record. Codex apply_patch preserves file order, keeps
+# added content scoped to its file, and treats Move to as the effective path.
+kernel_hook_file_records() {
+  printf '%s' "$1" | jq -c '
+    def finish:
+      if .current == null then .
+      else .records += [(.current | .content = (.content | join("\n")))]
+           | .current = null
+      end;
+    if (.tool_input.patch | type) == "string" then
+      (reduce (.tool_input.patch | split("\n")[]) as $line
+        ({records: [], current: null};
+         if ($line | test("^\\*\\*\\* (Add File|Update File|Delete File): ")) then
+           finish
+           | .current = {path: ($line | sub("^\\*\\*\\* (Add File|Update File|Delete File): "; "")), content: []}
+         elif ($line | startswith("*** Move to: ")) and .current != null then
+           .current.path = ($line | sub("^\\*\\*\\* Move to: "; ""))
+         elif ($line | startswith("+")) and .current != null then
+           .current.content += [$line[1:]]
+         else . end)
+       | finish | .records[])
+    else
+      {path: (.tool_input.file_path // .tool_input.path // .file_path // .path // ""),
+       content: (.tool_input.content // .tool_input.new_string // .content // .new_string // "")}
+    end
   ' 2>/dev/null || true
 }
 
+kernel_hook_file_path() {
+  kernel_hook_file_records "$1" | head -1 | jq -r '.path // empty' 2>/dev/null || true
+}
+
 kernel_hook_content() {
-  printf '%s' "$1" | jq -r '
-    .tool_input.content // .tool_input.new_string // .content // .new_string //
-    (if (.tool_input.patch | type) == "string" then
-       [.tool_input.patch | split("\n")[] | select(startswith("+"))] | join("\n")
-     else empty end)
-  ' 2>/dev/null || true
+  kernel_hook_file_records "$1" | head -1 | jq -r '.content // empty' 2>/dev/null || true
 }
 
 kernel_hook_error() {

--- a/hooks/scripts/common.sh
+++ b/hooks/scripts/common.sh
@@ -247,6 +247,36 @@ get_project_root() {
   echo "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 }
 
+# Normalize the two loader payload shapes used by advisory hooks. Claude sends
+# Write/Edit fields under tool_input; Codex sends an apply_patch document.
+kernel_hook_file_path() {
+  printf '%s' "$1" | jq -r '
+    .tool_input.file_path // .tool_input.path // .file_path // .path //
+    (if (.tool_input.patch | type) == "string" then
+       [.tool_input.patch | split("\n")[]
+        | select(test("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "))
+        | sub("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "; "")][0] // empty
+     else empty end)
+  ' 2>/dev/null || true
+}
+
+kernel_hook_content() {
+  printf '%s' "$1" | jq -r '
+    .tool_input.content // .tool_input.new_string // .content // .new_string //
+    (if (.tool_input.patch | type) == "string" then
+       [.tool_input.patch | split("\n")[] | select(startswith("+"))] | join("\n")
+     else empty end)
+  ' 2>/dev/null || true
+}
+
+kernel_hook_error() {
+  printf '%s' "$1" | jq -r '
+    (if (.error | type) == "string" then .error
+     elif (.error.message | type) == "string" then .error.message
+     else .message // .tool_error // "unknown error" end)
+  ' 2>/dev/null || printf '%s\n' 'unknown error'
+}
+
 # The shared Vaults continuity service owns compaction only for a session whose
 # active project is the Vaults root itself. Nested repositories keep KERNEL's
 # deterministic fallback because root-level host hooks may not be loaded there.

--- a/hooks/scripts/log-write.sh
+++ b/hooks/scripts/log-write.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 _LW_START_MS=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo "")
-# PostToolUse hook: Log file writes (async, non-blocking)
+# PostToolUse hook: Log file writes (synchronous, advisory)
 # Replaces the old post-write.sh. No git operations - that's SessionEnd's job.
-# Events: PostToolUse (matcher: Write|Edit), async: true
+# Events: PostToolUse (matcher: Write|Edit)
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '
+  .tool_input.file_path // .tool_input.path //
+  (if (.tool_input.patch | type) == "string" then
+     [.tool_input.patch | split("\n")[]
+      | select(test("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "))
+      | sub("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "; "")][0] // empty
+   else empty end)
+')
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # CLAUDE_PROJECT_DIR is set by Claude Code hook executor
@@ -22,7 +29,7 @@ if [ -n "$_LW_START_MS" ]; then
   if [ -n "$_LW_END" ]; then
     _LW_DUR=$(( _LW_END - _LW_START_MS ))
     _LW_AGENTDB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}/orchestration/agentdb/agentdb"
-    "$_LW_AGENTDB" emit hook "log-write" "$_LW_DUR" "{\"exit_code\":0,\"file\":\"$FILE_PATH\"}" "" "" 2>/dev/null &
+    "$_LW_AGENTDB" emit hook "log-write" "$_LW_DUR" "{\"exit_code\":0,\"file\":\"$FILE_PATH\"}" "" "" 2>/dev/null || true
   fi
 fi
 

--- a/hooks/scripts/log-write.sh
+++ b/hooks/scripts/log-write.sh
@@ -4,33 +4,30 @@ _LW_START_MS=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/nul
 # Replaces the old post-write.sh. No git operations - that's SessionEnd's job.
 # Events: PostToolUse (matcher: Write|Edit)
 
+source "$(dirname "$0")/common.sh"
+
 INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-FILE_PATH=$(echo "$INPUT" | jq -r '
-  .tool_input.file_path // .tool_input.path //
-  (if (.tool_input.patch | type) == "string" then
-     [.tool_input.patch | split("\n")[]
-      | select(test("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "))
-      | sub("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "; "")][0] // empty
-   else empty end)
-')
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # CLAUDE_PROJECT_DIR is set by Claude Code hook executor
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 LOG_DIR="$PROJECT_ROOT/_meta/logs"
 
-mkdir -p "$LOG_DIR"
-echo "{\"timestamp\":\"$TIMESTAMP\",\"tool\":\"$TOOL_NAME\",\"file\":\"$FILE_PATH\"}" >> "$LOG_DIR/actions.jsonl"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
 
-# Emit hook timing
-if [ -n "$_LW_START_MS" ]; then
+while IFS= read -r RECORD; do
+  FILE_PATH=$(printf '%s' "$RECORD" | jq -r '.path // empty' 2>/dev/null)
+  jq -cn --arg timestamp "$TIMESTAMP" --arg tool "$TOOL_NAME" --arg file "$FILE_PATH" \
+    '{timestamp:$timestamp,tool:$tool,file:$file}' >> "$LOG_DIR/actions.jsonl" 2>/dev/null || true
+
   _LW_END=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || true)
-  if [ -n "$_LW_END" ]; then
+  if [ -n "$_LW_START_MS" ] && [ -n "$_LW_END" ]; then
     _LW_DUR=$(( _LW_END - _LW_START_MS ))
     _LW_AGENTDB="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}/orchestration/agentdb/agentdb"
-    "$_LW_AGENTDB" emit hook "log-write" "$_LW_DUR" "{\"exit_code\":0,\"file\":\"$FILE_PATH\"}" "" "" 2>/dev/null || true
+    EMIT_JSON=$(jq -cn --arg file "$FILE_PATH" '{exit_code:0,file:$file}')
+    "$_LW_AGENTDB" emit hook "log-write" "$_LW_DUR" "$EMIT_JSON" "" "" 2>/dev/null || true
   fi
-fi
+done < <(kernel_hook_file_records "$INPUT")
 
 exit 0

--- a/hooks/scripts/validate-json-schema.sh
+++ b/hooks/scripts/validate-json-schema.sh
@@ -5,9 +5,8 @@
 source "$(dirname "$0")/common.sh"
 
 INPUT=$(cat)
-FILE_PATH=$(kernel_hook_file_path "$INPUT")
-
-# Only validate JSON files
+while IFS= read -r RECORD; do
+FILE_PATH=$(printf '%s' "$RECORD" | jq -r '.path // empty' 2>/dev/null)
 case "$FILE_PATH" in
   *.json)
     if [ -f "$FILE_PATH" ]; then
@@ -26,5 +25,6 @@ case "$FILE_PATH" in
     fi
     ;;
 esac
+done < <(kernel_hook_file_records "$INPUT")
 
 exit 0

--- a/hooks/scripts/validate-json-schema.sh
+++ b/hooks/scripts/validate-json-schema.sh
@@ -5,7 +5,7 @@
 source "$(dirname "$0")/common.sh"
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // .path // ""' 2>/dev/null)
+FILE_PATH=$(kernel_hook_file_path "$INPUT")
 
 # Only validate JSON files
 case "$FILE_PATH" in

--- a/hooks/scripts/validate-structure.sh
+++ b/hooks/scripts/validate-structure.sh
@@ -2,12 +2,10 @@
 # KERNEL: Validate file structure on writes
 # Pre-tool hook for Write/Edit — checks structural conventions
 
-set -e
-
 source "$(dirname "$0")/common.sh"
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // .path // ""' 2>/dev/null)
+FILE_PATH=$(kernel_hook_file_path "$INPUT")
 
 # Only validate files we care about
 case "$FILE_PATH" in

--- a/hooks/scripts/validate-structure.sh
+++ b/hooks/scripts/validate-structure.sh
@@ -5,9 +5,8 @@
 source "$(dirname "$0")/common.sh"
 
 INPUT=$(cat)
-FILE_PATH=$(kernel_hook_file_path "$INPUT")
-
-# Only validate files we care about
+while IFS= read -r RECORD; do
+FILE_PATH=$(printf '%s' "$RECORD" | jq -r '.path // empty' 2>/dev/null)
 case "$FILE_PATH" in
   */agents/*.md)
     # Agents must have frontmatter with name and description
@@ -26,6 +25,7 @@ case "$FILE_PATH" in
     fi
     ;;
 esac
+done < <(kernel_hook_file_records "$INPUT")
 
 # Always pass — warnings only, never block
 exit 0

--- a/hooks/scripts/warn-hardcoded.sh
+++ b/hooks/scripts/warn-hardcoded.sh
@@ -5,8 +5,8 @@
 source "$(dirname "$0")/common.sh"
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // .path // ""' 2>/dev/null)
-CONTENT=$(echo "$INPUT" | jq -r '.content // .new_string // ""' 2>/dev/null)
+FILE_PATH=$(kernel_hook_file_path "$INPUT")
+CONTENT=$(kernel_hook_content "$INPUT")
 
 # Only check component/style files
 case "$FILE_PATH" in

--- a/hooks/scripts/warn-hardcoded.sh
+++ b/hooks/scripts/warn-hardcoded.sh
@@ -5,10 +5,9 @@
 source "$(dirname "$0")/common.sh"
 
 INPUT=$(cat)
-FILE_PATH=$(kernel_hook_file_path "$INPUT")
-CONTENT=$(kernel_hook_content "$INPUT")
-
-# Only check component/style files
+while IFS= read -r RECORD; do
+FILE_PATH=$(printf '%s' "$RECORD" | jq -r '.path // empty' 2>/dev/null)
+CONTENT=$(printf '%s' "$RECORD" | jq -r '.content // empty' 2>/dev/null)
 case "$FILE_PATH" in
   *.tsx|*.jsx|*.svelte|*.vue|*.css)
     # Check for hardcoded hex colors
@@ -21,5 +20,6 @@ case "$FILE_PATH" in
     fi
     ;;
 esac
+done < <(kernel_hook_file_records "$INPUT")
 
 exit 0

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.0.1.
+Quick reference for KERNEL v8.0.2.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1332,6 +1332,154 @@ assert "version" not in data, "top-level version breaks the Codex hooks loader"
 PY
 }
 
+test_advisory_hooks_are_synchronous_and_complete() {
+  python3 - "$PLUGIN_ROOT/hooks/hooks.json" <<'PY'
+import json, sys
+data=json.load(open(sys.argv[1]))
+def _walk(x):
+    if isinstance(x, dict):
+        yield x
+        for value in x.values(): yield from _walk(value)
+    elif isinstance(x, list):
+        for value in x: yield from _walk(value)
+assert not any('async' in obj for obj in _walk(data)), 'shared hook manifest must contain no async keys'
+PY
+}
+
+test_six_advisory_hook_commands_are_retained() {
+  python3 - "$PLUGIN_ROOT/hooks/hooks.json" <<'PY'
+import json, sys
+data=json.load(open(sys.argv[1]))
+commands=[]
+def walk(x):
+    if isinstance(x, dict):
+        if x.get('type') == 'command': commands.append(x.get('command'))
+        for value in x.values(): walk(value)
+    elif isinstance(x, list):
+        for value in x: walk(value)
+walk(data)
+expected=[
+  '${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopush.sh install',
+  '${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-structure.sh',
+  '${CLAUDE_PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh',
+  '${CLAUDE_PLUGIN_ROOT}/hooks/scripts/log-write.sh',
+  '${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-json-schema.sh',
+  '${CLAUDE_PLUGIN_ROOT}/hooks/scripts/capture-error.sh',
+]
+for command in expected:
+    assert commands.count(command) == 1, (command, commands)
+PY
+}
+
+test_log_write_consumes_claude_and_codex_payloads() {
+  local root="$TEST_DIR/log-write-project"
+  mkdir -p "$root"
+  printf '%s\n' '{"tool_name":"Write","tool_input":{"file_path":"src/claude.ts"}}' \
+    | CLAUDE_PROJECT_DIR="$root" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+      "$PLUGIN_ROOT/hooks/scripts/log-write.sh" >/dev/null 2>&1 || return 1
+  printf '%s\n' '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Update File: src/codex.ts\n+changed\n*** End Patch"}}' \
+    | CLAUDE_PROJECT_DIR="$root" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+      "$PLUGIN_ROOT/hooks/scripts/log-write.sh" >/dev/null 2>&1 || return 1
+  grep -q '"tool":"Write","file":"src/claude.ts"' "$root/_meta/logs/actions.jsonl" || return 1
+  grep -q '"tool":"apply_patch","file":"src/codex.ts"' "$root/_meta/logs/actions.jsonl"
+}
+
+test_log_write_is_advisory_and_leaves_no_child() {
+  local root="$TEST_DIR/log-write-project" fake="$TEST_DIR/fake-plugin" pid
+  mkdir -p "$root" "$fake/orchestration/agentdb"
+  cat > "$fake/orchestration/agentdb/agentdb" <<'SH'
+#!/bin/bash
+echo $$ > "${KERNEL_TEST_CHILD_PID:?}"
+sleep 0.3
+exit "${KERNEL_TEST_AGENTDB_EXIT:-0}"
+SH
+  chmod +x "$fake/orchestration/agentdb/agentdb"
+  printf '%s\n' '{"tool_name":"Write","tool_input":{"file_path":"src/file.ts"}}' \
+    | KERNEL_TEST_CHILD_PID="$TEST_DIR/child.pid" CLAUDE_PROJECT_DIR="$root" CLAUDE_PLUGIN_ROOT="$fake" \
+      "$PLUGIN_ROOT/hooks/scripts/log-write.sh" >/dev/null 2>&1 || return 1
+  pid=$(cat "$TEST_DIR/child.pid")
+  ! kill -0 "$pid" 2>/dev/null || { echo "FAIL: log-write child survived hook exit"; return 1; }
+  local ec=0
+  printf '%s\n' '{"tool_name":"Write","tool_input":{"file_path":"src/file.ts"}}' \
+    | KERNEL_TEST_CHILD_PID="$TEST_DIR/child.pid" KERNEL_TEST_AGENTDB_EXIT=9 \
+      CLAUDE_PROJECT_DIR="$root" CLAUDE_PLUGIN_ROOT="$fake" \
+      "$PLUGIN_ROOT/hooks/scripts/log-write.sh" >/dev/null 2>&1 || ec=$?
+  assert_exit_code 0 "$ec" "advisory hook must not block on AgentDB failure"
+}
+
+test_advisory_scripts_consume_dual_loader_payloads() {
+  local root="$TEST_DIR/advisory" bad_agent="$TEST_DIR/advisory/agents/bad.md"
+  local css="$TEST_DIR/advisory/app.css" bad_json="$TEST_DIR/advisory/bad.json" output payload patch
+  mkdir -p "$(dirname "$bad_agent")" "$TEST_PROJECT/_meta/agentdb"
+  echo 'missing frontmatter' > "$bad_agent"
+  echo 'body { color: red; }' > "$css"
+  echo '{bad' > "$bad_json"
+
+  payload=$(jq -n --arg p "$bad_agent" '{tool_name:"Write",tool_input:{file_path:$p,content:"missing frontmatter"}}')
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/validate-structure.sh" 2>&1)
+  assert_contains "$output" "$bad_agent" "Claude structure payload path must be consumed" || return 1
+  printf -v patch '*** Begin Patch\n*** Update File: %s\n+missing frontmatter\n*** End Patch' "$bad_agent"
+  payload=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{patch:$patch}}')
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/validate-structure.sh" 2>&1)
+  assert_contains "$output" "$bad_agent" "Codex structure payload path must be consumed" || return 1
+
+  payload=$(jq -n --arg p "$css" '{tool_name:"Write",tool_input:{file_path:$p,content:"color: #abcdef; margin: 12px;"}}')
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/warn-hardcoded.sh" 2>&1)
+  assert_contains "$output" "$css" "Claude content must be consumed" || return 1
+  printf -v patch '*** Begin Patch\n*** Update File: %s\n+color: #abcdef; margin: 12px;\n*** End Patch' "$css"
+  payload=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{patch:$patch}}')
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/warn-hardcoded.sh" 2>&1)
+  assert_contains "$output" "$css" "Codex patch content must be consumed" || return 1
+
+  printf -v patch '*** Begin Patch\n*** Update File: %s\n+{bad\n*** End Patch' "$bad_json"
+  for payload in \
+    "$(jq -n --arg p "$bad_json" '{tool_name:"Write",tool_input:{file_path:$p}}')" \
+    "$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{patch:$patch}}')"; do
+    output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/validate-json-schema.sh" 2>&1)
+    assert_contains "$output" "$bad_json" "JSON validator path must be consumed" || return 1
+  done
+
+  KERNEL_VAULTS="$TEST_PROJECT" AGENTDB_ROOT="$TEST_PROJECT" agentdb init >/dev/null
+  payload=$(jq -n --arg p "$css" '{tool_name:"Write",tool_input:{file_path:$p},error:"claude failure"}')
+  printf '%s\n' "$payload" | KERNEL_VAULTS="$TEST_PROJECT" AGENTDB_ROOT="$TEST_PROJECT" \
+    "$PLUGIN_ROOT/hooks/scripts/capture-error.sh" >/dev/null 2>&1 || return 1
+  printf -v patch '*** Begin Patch\n*** Update File: %s\n+change\n*** End Patch' "$css"
+  payload=$(jq -n --arg patch "$patch" \
+    '{tool_name:"apply_patch",tool_input:{patch:$patch},error:{message:"codex failure"}}')
+  printf '%s\n' "$payload" | KERNEL_VAULTS="$TEST_PROJECT" AGENTDB_ROOT="$TEST_PROJECT" \
+    "$PLUGIN_ROOT/hooks/scripts/capture-error.sh" >/dev/null 2>&1 || return 1
+  assert_contains "$(sqlite3 "$TEST_PROJECT/_meta/agentdb/agent.db" "SELECT group_concat(error, '|') FROM errors;")" "claude failure" || return 1
+  assert_contains "$(sqlite3 "$TEST_PROJECT/_meta/agentdb/agent.db" "SELECT group_concat(error, '|') FROM errors;")" "codex failure"
+}
+
+test_advisory_scripts_fail_open_without_false_positives() {
+  local script ec output root="$TEST_DIR/advisory-safe"
+  mkdir -p "$root"
+  echo '{"ok":true}' > "$root/valid.json"
+  for script in validate-structure.sh warn-hardcoded.sh validate-json-schema.sh capture-error.sh; do
+    ec=0
+    printf '{malformed\n' | KERNEL_VAULTS="$root/missing-vault" CLAUDE_PROJECT_DIR="$root" \
+      "$PLUGIN_ROOT/hooks/scripts/$script" >/dev/null 2>&1 || ec=$?
+    assert_exit_code 0 "$ec" "$script must stay advisory on malformed/downstream failure" || return 1
+  done
+  output=$(jq -n --arg p "$root/valid.json" '{tool_name:"Write",tool_input:{file_path:$p,content:"const color = theme.primary;"}}' \
+    | "$PLUGIN_ROOT/hooks/scripts/warn-hardcoded.sh" 2>&1)
+  assert_equals "" "$output" "safe advisory payload must not warn"
+}
+
+test_critical_guard_scripts_unchanged_for_802() {
+  local expected actual file
+  while read -r expected file; do
+    actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
+    assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
+  done <<'EOF'
+16fb49cbedb3bdc875c4add7cb1de0c993e6528fa4d9d520fc9ee2cba6641a93 guard-bash.sh
+79b46dabd8c9e890d503548cddd98358ec59d888ada4e738e34b05b7ca4f1da1 guard-config.sh
+d3611267b4f135c5b96e8a4a8af60f296b196efc135e3dfbef63d7683065608c detect-secrets.sh
+dbf6680d56dfd5676a420f69f75dcfc5405f0fd53879063859a43b4dcaa5085b guard-context.sh
+EOF
+}
+
 # === Input Validation Tests ===
 
 test_agentdb_numeric_injection_tier() {
@@ -1785,16 +1933,18 @@ test_release_docs_explain_codex_invocation_and_boundaries() {
 }
 
 test_release_changelog_v8_is_current_and_history_preserved() {
-  local v801 v800
+  local v802 v801 v800
+  v802=$(awk '/^## \[8\.0\.2\]/{on=1} /^## \[8\.0\.1\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
   v801=$(awk '/^## \[8\.0\.1\]/{on=1} /^## \[8\.0\.0\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
   v800=$(awk '/^## \[8\.0\.0\]/{on=1} /^## \[7\.23\.0\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
+  [[ "$v802" == *"async"* ]] && [[ "$v802" == *"Codex"* ]] || return 1
   [[ "$v801" == *"incomplete"* ]] && [[ "$v801" == *"Codex"* ]] && [[ "$v801" == *"368"* ]] || return 1
   [[ "$v800" == *"strict JSON"* ]] && [[ "$v800" == *"preflight"* ]] && [[ "$v800" == *"select-runtime.sh"* ]] || return 1
   grep -q '^## \[7.23.0\] - 2026-07-06' "$PLUGIN_ROOT/CHANGELOG.md"
 }
 
 test_release_docs_use_current_801_runtime() {
-  grep -q 'kernel/8\.0\.1/scripts/select-runtime\.sh' "$PLUGIN_ROOT/README.md" || return 1
+  grep -q 'kernel/8\.0\.2/scripts/select-runtime\.sh' "$PLUGIN_ROOT/README.md" || return 1
   ! grep -q 'kernel/8\.0\.0/scripts/select-runtime\.sh' "$PLUGIN_ROOT/README.md" || return 1
   # Historical 8.0.0 release and upgrade references remain valid outside active runtime commands.
   grep -q '^## \[8\.0\.0\] - 2026-07-11' "$PLUGIN_ROOT/CHANGELOG.md"
@@ -1817,7 +1967,7 @@ import json, pathlib, sys
 r=pathlib.Path(sys.argv[1])
 p=json.loads((r/'.claude-plugin/plugin.json').read_text())
 m=json.loads((r/'.claude-plugin/marketplace.json').read_text())['plugins'][0]
-assert p['version']==m['version']=='8.0.1'
+assert p['version']==m['version']=='8.0.2'
 for x in (p,m):
     assert 'JSON' in x['description'] and '33 skills' in x['description'] and '15 specialized agent' in x['description']
 PY
@@ -4145,6 +4295,13 @@ run_test_suite() {
       run_test "hooks.json has SessionStart" test_hooks_json_has_session_start
       run_test "hooks.json has SessionEnd" test_hooks_json_has_session_end
       run_test "hooks.json supports Claude and Codex loaders" test_hooks_json_cross_loader_schema
+      run_test "advisory hooks are synchronous and complete" test_advisory_hooks_are_synchronous_and_complete
+      run_test "six advisory hook commands are retained" test_six_advisory_hook_commands_are_retained
+      run_test "log-write consumes Claude and Codex payloads" test_log_write_consumes_claude_and_codex_payloads
+      run_test "log-write is advisory and leaves no child" test_log_write_is_advisory_and_leaves_no_child
+      run_test "advisory scripts consume dual-loader payloads" test_advisory_scripts_consume_dual_loader_payloads
+      run_test "advisory scripts fail open without false positives" test_advisory_scripts_fail_open_without_false_positives
+      run_test "critical guard scripts unchanged for 8.0.2" test_critical_guard_scripts_unchanged_for_802
       run_test "session-start has compact quick reference" test_session_start_workflow_present
       run_test "session-start points at skill routing" test_session_start_skill_routing
       run_test "session-start has no scripted interrupts" test_session_start_no_scripted_interrupts

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1467,6 +1467,51 @@ test_advisory_scripts_fail_open_without_false_positives() {
   assert_equals "" "$output" "safe advisory payload must not warn"
 }
 
+test_multifile_patch_records_are_isolated_and_complete() {
+  local root="$TEST_DIR/multifile" css="$TEST_DIR/multifile/safe.css"
+  local json="$TEST_DIR/multifile/later.json" agent="$TEST_DIR/multifile/agents/later.md"
+  local moved="$TEST_DIR/multifile/moved.json" patch payload output
+  mkdir -p "$(dirname "$agent")" "$TEST_PROJECT/_meta/agentdb"
+  echo 'body { color: var(--theme); }' > "$css"
+  echo '{bad' > "$json"
+  echo 'missing frontmatter' > "$agent"
+  echo '{bad' > "$moved"
+  printf -v patch '*** Begin Patch\n*** Update File: %s\n+body { color: var(--theme); }\n*** Update File: %s\n+{"color":"#abcdef"}\n*** Update File: %s\n+missing frontmatter\n*** Update File: old.txt\n*** Move to: %s\n+{bad\n*** End Patch' "$css" "$json" "$agent" "$moved"
+  payload=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{patch:$patch},error:{message:"multi failure"}}')
+
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/warn-hardcoded.sh" 2>&1)
+  assert_equals "" "$output" "JSON content must not be attributed to the CSS record" || return 1
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/validate-json-schema.sh" 2>&1)
+  assert_contains "$output" "$json" "later JSON file must be validated" || return 1
+  assert_contains "$output" "$moved" "rename destination must be the effective path" || return 1
+  output=$(printf '%s\n' "$payload" | "$PLUGIN_ROOT/hooks/scripts/validate-structure.sh" 2>&1)
+  assert_contains "$output" "$agent" "later agent file must be structurally checked" || return 1
+
+  KERNEL_VAULTS="$TEST_PROJECT" AGENTDB_ROOT="$TEST_PROJECT" agentdb init >/dev/null
+  printf '%s\n' "$payload" | KERNEL_VAULTS="$TEST_PROJECT" AGENTDB_ROOT="$TEST_PROJECT" \
+    "$PLUGIN_ROOT/hooks/scripts/capture-error.sh" >/dev/null 2>&1 || return 1
+  assert_equals "4" "$(sqlite3 "$TEST_PROJECT/_meta/agentdb/agent.db" "SELECT COUNT(*) FROM errors WHERE error='multi failure';")" "capture-error must record every patch file"
+}
+
+test_log_write_multifile_and_json_roundtrip() {
+  local root="$TEST_DIR/log-json" patch payload weird log
+  mkdir -p "$root"
+  printf -v patch '*** Begin Patch\n*** Update File: first.css\n+safe\n*** Update File: old.json\n*** Move to: later.json\n+{}\n*** End Patch'
+  payload=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{patch:$patch}}')
+  printf '%s\n' "$payload" | CLAUDE_PROJECT_DIR="$root" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    "$PLUGIN_ROOT/hooks/scripts/log-write.sh" >/dev/null 2>&1 || return 1
+  log="$root/_meta/logs/actions.jsonl"
+  assert_equals "2" "$(wc -l < "$log" | tr -d ' ')" "log-write must log every patch record" || return 1
+  assert_equals "first.css,later.json" "$(jq -rs 'map(.file)|join(",")' "$log")" "rename must log destination in order" || return 1
+
+  weird=$'quote" slash\\ line\nnext'
+  payload=$(jq -n --arg p "$weird" '{tool_name:"Write",tool_input:{file_path:$p,content:"safe"}}')
+  printf '%s\n' "$payload" | CLAUDE_PROJECT_DIR="$root" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+    "$PLUGIN_ROOT/hooks/scripts/log-write.sh" >/dev/null 2>&1 || return 1
+  jq -e . "$log" >/dev/null || return 1
+  assert_equals "$weird" "$(tail -1 "$log" | jq -r .file)" "quote/backslash/newline must round-trip through valid JSON"
+}
+
 test_critical_guard_scripts_unchanged_for_802() {
   local expected actual file
   while read -r expected file; do
@@ -4301,6 +4346,8 @@ run_test_suite() {
       run_test "log-write is advisory and leaves no child" test_log_write_is_advisory_and_leaves_no_child
       run_test "advisory scripts consume dual-loader payloads" test_advisory_scripts_consume_dual_loader_payloads
       run_test "advisory scripts fail open without false positives" test_advisory_scripts_fail_open_without_false_positives
+      run_test "multifile patch records are isolated and complete" test_multifile_patch_records_are_isolated_and_complete
+      run_test "log-write multifile and JSON round-trip" test_log_write_multifile_and_json_roundtrip
       run_test "critical guard scripts unchanged for 8.0.2" test_critical_guard_scripts_unchanged_for_802
       run_test "session-start has compact quick reference" test_session_start_workflow_present
       run_test "session-start points at skill routing" test_session_start_skill_routing


### PR DESCRIPTION
## Fix

KERNEL 8.0.2 removes unsupported `async` hook declarations so Codex starts without warning spam while retaining every advisory check.

- runs all six advisory hooks on Claude Code and Codex
- preserves per-file paths/content for multi-file patches and renames
- makes JSON logging safe for quoted, escaped, and newline-containing paths
- keeps advisory failures non-blocking
- leaves critical blocking guards unchanged
- removes detached child-process behavior from write logging

## Verification

- full bounded suite: 377/377
- final focused review: 31/31
- independent review: APPROVE (98%)
- zero async keys; all six commands retained
- real Codex startup fixture: zero async warnings