### PR TITLE
fix: resolve installed governance-sync entrypoint (8.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8 includes 34 skills and 15 specialized agent definitions.",
-      "version": "8.1.0"
+      "version": "8.1.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8 includes 34 skills and 15 specialized agent definitions.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: f1469861ec86c58e0b7638711927fe827100b2606236c4f50340f990dac8a7f0; adapter: codex -->
-<kernel version="8.1.0">
+     source-sha256: ec3a44cd76f569cf41f611286604fa8a326ab5695d11e0f3af0ca3b2e7ad9e51; adapter: codex -->
+<kernel version="8.1.1">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.1.1] - 2026-07-11
+
+KERNEL 8.1.1 fixes the installed entrypoint for the new governance-sync operator.
+The 8.1.0 documentation used a repository-root-relative `scripts/governance-sync.py`
+path, but installed skills execute from `skills/governance-sync`, so the documented
+audit, adopt, generate, check, and init commands failed before reaching the script.
+
+### Fixed
+- Resolve the installed plugin root from `CLAUDE_PLUGIN_ROOT`, which is supplied by
+  Claude Code and the Codex compatibility loader, with a skill-directory fallback for
+  direct installed-layout execution.
+- Route every governance-sync command example through the resolved absolute script
+  path instead of assuming the current directory is the plugin root.
+- Add an armed disposable installed-cache test that runs from
+  `skills/governance-sync` through both the loader environment and fallback paths.
+
 ## [8.1.0] - 2026-07-11
 
 KERNEL 8.1 adds one canonical governance source for its Claude Code and Codex

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: f1469861ec86c58e0b7638711927fe827100b2606236c4f50340f990dac8a7f0; adapter: claude -->
-<kernel version="8.1.0">
+     source-sha256: ec3a44cd76f569cf41f611286604fa8a326ab5695d11e0f3af0ca3b2e7ad9e51; adapter: claude -->
+<kernel version="8.1.1">
 
 
 <!-- ============================================ -->

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -1,4 +1,4 @@
-<kernel version="8.1.0">
+<kernel version="8.1.1">
 
 <!-- KERNEL_AMBIENT_SOURCE_BEGIN
 ## KERNEL quick reference

--- a/skills/governance-sync/SKILL.md
+++ b/skills/governance-sync/SKILL.md
@@ -18,7 +18,17 @@ missing Claude or Codex adapter from one declared source. It never edits a confl
 
 ## Audit first
 
-Run `python3 scripts/governance-sync.py audit <root> --json`. The audit discovers
+Resolve the installed plugin root once. Claude Code and Codex compatibility loading
+provide `CLAUDE_PLUGIN_ROOT`; the fallback is valid when the skill runs from its own
+installed `skills/governance-sync` directory:
+
+```bash
+KERNEL_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd ../.. && pwd -P)}"
+test -f "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py"
+```
+
+Run `python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" audit <root> --json`.
+The audit discovers
 canonical Git roots, ignores caches, deduplicates linked worktrees, and reports:
 missing both, Claude-only, AGENTS-only, both identical, generated current, generated
 stale, incomplete generation, conflict, and scoped `.claude` states. Generated states
@@ -31,9 +41,9 @@ Show the exact repository, source, target, and backup directory. Continue only a
 the user confirms one command:
 
 ```text
-python3 scripts/governance-sync.py adopt REPO --source CLAUDE.md --backup-dir REPO/.kernel-governance-backups/adopt
-python3 scripts/governance-sync.py generate REPO --backup-dir REPO/.kernel-governance-backups/generate
-python3 scripts/governance-sync.py check REPO
+python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" adopt REPO --source CLAUDE.md --backup-dir REPO/.kernel-governance-backups/adopt
+python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" generate REPO --backup-dir REPO/.kernel-governance-backups/generate
+python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" check REPO
 ```
 
 `AGENTS.md` and `.claude/CLAUDE.md` are also valid sources. The manifest pins the
@@ -51,5 +61,6 @@ that drift without changing anything, and rerunning the write operation converge
 There is no background lock, journal, rollback, or cleanup of unknown temporary files.
 An existing backup-directory symlink is always rejected before path resolution.
 
-Use `init REPO --backup-dir BACKUPS` only when the user explicitly wants governance
+Use `python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" init REPO --backup-dir
+REPO/.kernel-governance-backups/init` only when the user explicitly wants governance
 created in a repository where both native files are absent.

--- a/skills/governance-sync/SKILL.md
+++ b/skills/governance-sync/SKILL.md
@@ -18,16 +18,20 @@ missing Claude or Codex adapter from one declared source. It never edits a confl
 
 ## Audit first
 
-Resolve the installed plugin root once. Claude Code and Codex compatibility loading
-provide `CLAUDE_PLUGIN_ROOT`; the fallback is valid when the skill runs from its own
-installed `skills/governance-sync` directory:
+Resolve the installed script once. Claude Code and Codex compatibility loading
+provide `CLAUDE_PLUGIN_ROOT`; otherwise use the direct relative path from the
+documented installed `skills/governance-sync` working directory:
 
 ```bash
-KERNEL_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd ../.. && pwd -P)}"
-test -f "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  KERNEL_GOVERNANCE_SYNC="$CLAUDE_PLUGIN_ROOT/scripts/governance-sync.py"
+else
+  KERNEL_GOVERNANCE_SYNC="../../scripts/governance-sync.py"
+fi
+test -f "$KERNEL_GOVERNANCE_SYNC"
 ```
 
-Run `python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" audit <root> --json`.
+Run `python3 "$KERNEL_GOVERNANCE_SYNC" audit <root> --json`.
 The audit discovers
 canonical Git roots, ignores caches, deduplicates linked worktrees, and reports:
 missing both, Claude-only, AGENTS-only, both identical, generated current, generated
@@ -41,9 +45,9 @@ Show the exact repository, source, target, and backup directory. Continue only a
 the user confirms one command:
 
 ```text
-python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" adopt REPO --source CLAUDE.md --backup-dir REPO/.kernel-governance-backups/adopt
-python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" generate REPO --backup-dir REPO/.kernel-governance-backups/generate
-python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" check REPO
+python3 "$KERNEL_GOVERNANCE_SYNC" adopt REPO --source CLAUDE.md --backup-dir REPO/.kernel-governance-backups/adopt
+python3 "$KERNEL_GOVERNANCE_SYNC" generate REPO --backup-dir REPO/.kernel-governance-backups/generate
+python3 "$KERNEL_GOVERNANCE_SYNC" check REPO
 ```
 
 `AGENTS.md` and `.claude/CLAUDE.md` are also valid sources. The manifest pins the
@@ -61,6 +65,6 @@ that drift without changing anything, and rerunning the write operation converge
 There is no background lock, journal, rollback, or cleanup of unknown temporary files.
 An existing backup-directory symlink is always rejected before path resolution.
 
-Use `python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" init REPO --backup-dir
+Use `python3 "$KERNEL_GOVERNANCE_SYNC" init REPO --backup-dir
 REPO/.kernel-governance-backups/init` only when the user explicitly wants governance
 created in a repository where both native files are absent.

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.1.0.
+Quick reference for KERNEL v8.1.1.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2001,11 +2001,13 @@ PY
 }
 
 test_release_changelog_v8_is_current_and_history_preserved() {
-  local v810 v802 v801 v800
+  local v811 v810 v802 v801 v800
+  v811=$(awk '/^## \[8\.1\.1\]/{on=1} /^## \[8\.1\.0\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
   v810=$(awk '/^## \[8\.1\.0\]/{on=1} /^## \[8\.0\.2\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
   v802=$(awk '/^## \[8\.0\.2\]/{on=1} /^## \[8\.0\.1\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
   v801=$(awk '/^## \[8\.0\.1\]/{on=1} /^## \[8\.0\.0\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
   v800=$(awk '/^## \[8\.0\.0\]/{on=1} /^## \[7\.23\.0\]/{on=0} on' "$PLUGIN_ROOT/CHANGELOG.md")
+  [[ "$v811" == *"8.1.0 documentation"* ]] && [[ "$v811" == *"failed before reaching the script"* ]] || return 1
   [[ "$v810" == *"49 canonical Git repositories"* ]] && [[ "$v810" == *"does **not** claim"* ]] || return 1
   [[ "$v802" == *"async"* ]] && [[ "$v802" == *"Codex"* ]] || return 1
   [[ "$v801" == *"incomplete"* ]] && [[ "$v801" == *"Codex"* ]] && [[ "$v801" == *"368"* ]] || return 1
@@ -2037,7 +2039,7 @@ import json, pathlib, sys
 r=pathlib.Path(sys.argv[1])
 p=json.loads((r/'.claude-plugin/plugin.json').read_text())
 m=json.loads((r/'.claude-plugin/marketplace.json').read_text())['plugins'][0]
-assert p['version']==m['version']=='8.1.0'
+assert p['version']==m['version']=='8.1.1'
 for x in (p,m):
     assert 'JSON' in x['description'] and '34 skills' in x['description'] and '15 specialized agent' in x['description']
 PY

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -270,6 +270,38 @@ class SyncTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         return json.loads(result.stdout)["repositories"][0]["state"]
 
+    def test_installed_skill_entrypoint_resolves_plugin_root_from_skill_cwd(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            installed = base / "cache/kernel-marketplace/kernel/8.1.1"
+            skill_dir = installed / "skills/governance-sync"
+            (installed / "scripts").mkdir(parents=True)
+            skill_dir.mkdir(parents=True)
+            shutil.copy2(SYNC, installed / "scripts/governance-sync.py")
+            shutil.copy2(ROOT / "skills/governance-sync/SKILL.md", skill_dir / "SKILL.md")
+            audited = git_repo(base / "audited")
+
+            old = run(sys.executable, "scripts/governance-sync.py", "audit", str(audited),
+                      "--json", cwd=skill_dir)
+            self.assertNotEqual(0, old.returncode)
+
+            shell = (
+                'KERNEL_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd ../.. && pwd -P)}"; '
+                'python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" audit "$AUDIT_ROOT" --json'
+            )
+            for loader_env in ({"CLAUDE_PLUGIN_ROOT": str(installed)}, {}):
+                env = os.environ.copy()
+                env.pop("CLAUDE_PLUGIN_ROOT", None)
+                env.update(loader_env)
+                env["AUDIT_ROOT"] = str(audited)
+                result = run("bash", "-c", shell, cwd=skill_dir, env=env)
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertEqual(1, json.loads(result.stdout)["canonical_repo_count"])
+
+            skill = (skill_dir / "SKILL.md").read_text()
+            self.assertNotIn("python3 scripts/governance-sync.py", skill)
+            self.assertIn('$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py', skill)
+
     def test_manifest_aware_generated_state_machine(self):
         with tempfile.TemporaryDirectory() as td:
             repo = git_repo(Path(td) / "repo")

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -225,10 +225,10 @@ class GeneratorTests(unittest.TestCase):
             self.assertEqual(0, second.returncode, second.stderr)
             self.assertEqual(0, run(sys.executable, str(GEN), "--root", str(root), "--check").returncode)
             (root / "AGENTS.md").write_text("stale\n")
-            env["KERNEL_TEST_PAUSE_BEFORE_REPLACE_MS"] = "300"
+            env["KERNEL_TEST_PAUSE_BEFORE_REPLACE_MS"] = "1200"
             changed = subprocess.Popen([sys.executable, str(GEN), "--root", str(root)],
                                        text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
-            time.sleep(0.05)
+            time.sleep(0.35)
             source = root / "governance/kernel.md.tmpl"
             source.write_text(source.read_text() + "changed concurrently\n")
             _out, err = changed.communicate(timeout=5)
@@ -273,21 +273,23 @@ class SyncTests(unittest.TestCase):
     def test_installed_skill_entrypoint_resolves_plugin_root_from_skill_cwd(self):
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
-            installed = base / "cache/kernel-marketplace/kernel/8.1.1"
+            installed = base / "cache/kernel-marketplace/kernel/8.1.1 with space\n"
             skill_dir = installed / "skills/governance-sync"
             (installed / "scripts").mkdir(parents=True)
             skill_dir.mkdir(parents=True)
             shutil.copy2(SYNC, installed / "scripts/governance-sync.py")
             shutil.copy2(ROOT / "skills/governance-sync/SKILL.md", skill_dir / "SKILL.md")
-            audited = git_repo(base / "audited")
+            audited = git_repo(base / "audited with space")
 
             old = run(sys.executable, "scripts/governance-sync.py", "audit", str(audited),
                       "--json", cwd=skill_dir)
             self.assertNotEqual(0, old.returncode)
 
             shell = (
-                'KERNEL_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd ../.. && pwd -P)}"; '
-                'python3 "$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py" audit "$AUDIT_ROOT" --json'
+                'if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then '
+                'KERNEL_GOVERNANCE_SYNC="$CLAUDE_PLUGIN_ROOT/scripts/governance-sync.py"; '
+                'else KERNEL_GOVERNANCE_SYNC="../../scripts/governance-sync.py"; fi; '
+                'python3 "$KERNEL_GOVERNANCE_SYNC" audit "$AUDIT_ROOT" --json'
             )
             for loader_env in ({"CLAUDE_PLUGIN_ROOT": str(installed)}, {}):
                 env = os.environ.copy()
@@ -300,7 +302,9 @@ class SyncTests(unittest.TestCase):
 
             skill = (skill_dir / "SKILL.md").read_text()
             self.assertNotIn("python3 scripts/governance-sync.py", skill)
-            self.assertIn('$KERNEL_PLUGIN_ROOT/scripts/governance-sync.py', skill)
+            self.assertNotIn("$(", skill)
+            self.assertIn('$CLAUDE_PLUGIN_ROOT/scripts/governance-sync.py', skill)
+            self.assertIn('KERNEL_GOVERNANCE_SYNC="../../scripts/governance-sync.py"', skill)
 
     def test_manifest_aware_generated_state_machine(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## KERNEL 8.1.1

Fixes the published governance-sync skill entrypoint when invoked from its installed skill directory.

- resolves the operator through the loader-provided plugin root
- provides a direct quoted installed-layout fallback
- updates every audit/adopt/generate/check/init example
- covers installed roots containing spaces and trailing newlines

## Verification

- installed entrypoint fixtures: pass
- governance tests: 35/35
- full suite on hotfix base: 379/379
- final independent review: APPROVE (99%)