### PR TITLE
fix: SessionStart exit 141 (SIGPIPE) hotfix → 8.1.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8 includes 34 skills and 15 specialized agent definitions.",
-      "version": "8.1.2"
+      "version": "8.1.3"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8 includes 24 skills and 10 specialized agent definitions.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: 31979f53e284df31ea133589c270c16cc072ec4d6194d8d17b7dbd0396e7c411; adapter: codex -->
-<kernel version="8.1.2">
+     source-sha256: 8e6a08eb3a445bd85d8c972759a060840a96accdb236d9788b5aa8a62c579686; adapter: codex -->
+<kernel version="8.1.3">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.1.3] - 2026-07-15
+
+Hotfix for a SessionStart boot failure introduced in 8.1.2.
+
+### Fixed
+- **SessionStart no longer aborts with exit 141 (SIGPIPE).** The 8.1.2 agentdb dump cap
+  (`| head -n 50`) closed the pipe early; under `set -eo pipefail` the upstream
+  `agentdb read-start` died with SIGPIPE and took the whole hook down. Replaced with an
+  `awk` cap that reads all input and prints only the first 50 lines, so upstream never gets
+  a broken pipe. This was breaking Codex boot.
+- **Silenced `[: COUNT(*): integer expression expected` stderr spam on every boot.** The
+  stale-contract and error-count checks compared a full `agentdb query` table (header +
+  separator + value) against an integer. Both now extract the trailing numeric via
+  `awk '/^[0-9]/{v=$1} END{print v+0}'` before the comparison.
+
 ## [8.1.2] - 2026-07-15
 
 KERNEL 8.1.2 is the de-bloat release. It removes maximal-delegation doctrine and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: 31979f53e284df31ea133589c270c16cc072ec4d6194d8d17b7dbd0396e7c411; adapter: claude -->
-<kernel version="8.1.2">
+     source-sha256: 8e6a08eb3a445bd85d8c972759a060840a96accdb236d9788b5aa8a62c579686; adapter: claude -->
+<kernel version="8.1.3">
 
 
 <!-- ============================================ -->

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -1,4 +1,4 @@
-<kernel version="8.1.2">
+<kernel version="8.1.3">
 
 <!-- KERNEL_AMBIENT_SOURCE_BEGIN
 ## KERNEL quick reference

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -158,14 +158,18 @@ if [ -f "$VAULTS/_meta/agentdb/agent.db" ]; then
   echo ""
   # Cap the always-loaded agentdb dump so the static rules always survive; only the
   # dynamic memory tail is truncated (uncapped dumps were the SessionStart truncation cause).
+  # Cap to 50 printed lines WITHOUT closing the pipe early: awk reads all input and
+  # only emits the first 50, so upstream `read-start` never gets SIGPIPE (which, under
+  # `set -eo pipefail`, would abort the whole hook with exit 141). `head -n` closed the
+  # pipe early and did exactly that on Codex boot.
   if [ "$VAULTS_CONTINUITY_ACTIVE" -eq 1 ]; then
     "$AGENTDB" read-start 2>/dev/null | awk '
       /^## Last Checkpoint/ { skip=1; next }
       skip && /^## / { skip=0 }
-      !skip { print }
-    ' | head -n 50
+      !skip { if (n < 50) print; n++ }
+    '
   else
-    "$AGENTDB" read-start 2>/dev/null | head -n 50
+    "$AGENTDB" read-start 2>/dev/null | awk 'NR<=50'
   fi
   echo ""
 
@@ -213,13 +217,17 @@ if [ -f "$VAULTS/_meta/agentdb/agent.db" ]; then
   BLOCKERS=""
 
   # Check for stale contracts (>24h with no checkpoint)
-  STALE_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM context WHERE type='contract' AND ts < datetime('now', '-1 day') AND contract_id NOT IN (SELECT COALESCE(contract_id, '') FROM context WHERE type='verdict');" 2>/dev/null || echo "0")
+  # `agentdb query` prints a formatted table (header + separator + value), so pull the
+  # last numeric line and coerce to an int (+0) before any `-gt` comparison.
+  STALE_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM context WHERE type='contract' AND ts < datetime('now', '-1 day') AND contract_id NOT IN (SELECT COALESCE(contract_id, '') FROM context WHERE type='verdict');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
+  STALE_COUNT=${STALE_COUNT:-0}
   if [ "$STALE_COUNT" -gt 0 ]; then
     BLOCKERS="${BLOCKERS}\n- $STALE_COUNT stale contract(s) >24h without verdict"
   fi
 
   # Check for recent errors (>3 in last hour)
-  ERROR_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM errors WHERE ts > datetime('now', '-1 hour');" 2>/dev/null || echo "0")
+  ERROR_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM errors WHERE ts > datetime('now', '-1 hour');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
+  ERROR_COUNT=${ERROR_COUNT:-0}
   if [ "$ERROR_COUNT" -gt 3 ]; then
     BLOCKERS="${BLOCKERS}\n- $ERROR_COUNT errors in last hour (possible loop)"
   fi

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.1.2.
+Quick reference for KERNEL v8.1.3.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>


### PR DESCRIPTION
## The bug
8.1.2's SessionStart hook aborts with **exit 141 (SIGPIPE)**, breaking Codex boot.

The agentdb dump cap I added in 8.1.2 (`| head -n 50`) closes the pipe after 50 lines. Under `set -eo pipefail`, the upstream `agentdb read-start` gets SIGPIPE (141), pipefail propagates it, and `set -e` kills the whole hook.

## The fix
- Replace `head -n 50` with an `awk` cap that **reads all input** and prints only the first 50 lines — upstream never sees a broken pipe. (`head` and early-`exit` awk both close early; the cap has to drain the stream.)
- Fix a second, pre-existing stderr spam: the stale-contract + error-count checks compared a full `agentdb query` table (`COUNT(*)` header + separator + value) against an integer, throwing `[: COUNT(*): integer expression expected` every boot. Both now extract the trailing numeric via `awk '/^[0-9]/{v=$1} END{print v+0}'`.

## Verified
- Live Codex cache copy: **exit 0**, clean stderr, 98 lines out (was 141).
- All **349 tests pass**.
- All 4 local live caches (Claude + Codex, cache + marketplace) synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)