### PR TITLE
fix(hooks): remove lifecycle autopush for 8.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8 includes 34 skills and 15 specialized agent definitions.",
-      "version": "8.1.3"
+      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.4 removes automatic lifecycle network and push sweeps.",
+      "version": "8.1.4"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "8.1.3",
-  "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8 includes 24 skills and 10 specialized agent definitions.",
+  "version": "8.1.4",
+  "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.4 removes automatic lifecycle network and push sweeps.",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: 8e6a08eb3a445bd85d8c972759a060840a96accdb236d9788b5aa8a62c579686; adapter: codex -->
-<kernel version="8.1.3">
+     source-sha256: e250801f0cd549cfabe72a552559185e2df782e53c307e19d65d8f0dd89b45ad; adapter: codex -->
+<kernel version="8.1.4">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.1.4] - 2026-07-15
+
+Patch release removing automatic network and push work from the plugin lifecycle.
+
+### Fixed
+- **SessionEnd no longer runs `autopush.sh sweep`.** Under Codex compatibility handling, the
+  generated adapter exposed this as a per-turn Stop hook. Its vault-wide, unbounded `git fetch`
+  exceeded Codex's 60-second hook budget and could leave an orphan fetch after the hook parent
+  was killed.
+- **Explicit push is now consistent across the published hook manifest.** Kernel retains
+  `autopush.sh sweep` as a manual primitive, but no ambient lifecycle event invokes it.
+- **Cross-loader regression coverage now forbids lifecycle autopush.** A future release fails
+  tests if `SessionEnd` reintroduces `autopush.sh sweep`.
+
 ## [8.1.3] - 2026-07-15
 
 Hotfix for a SessionStart boot failure introduced in 8.1.2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: 8e6a08eb3a445bd85d8c972759a060840a96accdb236d9788b5aa8a62c579686; adapter: claude -->
-<kernel version="8.1.3">
+     source-sha256: e250801f0cd549cfabe72a552559185e2df782e53c307e19d65d8f0dd89b45ad; adapter: claude -->
+<kernel version="8.1.4">
 
 
 <!-- ============================================ -->

--- a/_meta/plans/kernel-8.1.4-codex-stop-hook.md
+++ b/_meta/plans/kernel-8.1.4-codex-stop-hook.md
@@ -1,0 +1,30 @@
+# KERNEL 8.1.4: remove lifecycle autopush
+
+## Goal
+
+Publish a patch release where neither Claude nor Codex automatically performs repository-wide
+network or push work at lifecycle end, and prove the marketplace-installed Codex payload ends a
+real turn without a Stop timeout.
+
+## Scope
+
+- Remove `SessionEnd → autopush.sh sweep` from `hooks/hooks.json`.
+- Replace tests that require SessionEnd with tests forbidding lifecycle autopush.
+- Bump every canonical declaration through `scripts/bump-version.sh 8.1.4`.
+- Update release prose and changelog.
+- Validate, review, merge, tag, publish, reinstall, and run live loader proofs.
+- Remove the Vaults local cache repair workaround after marketplace proof.
+
+## Alternatives
+
+1. Longer timeout: rejected; hides the bug.
+2. Detect Codex inside the script: rejected; brittle loader sniffing and Claude retains auto-push.
+3. Remove automatic lifecycle autopush: chosen; smallest and matches explicit-push doctrine.
+
+## Done-when
+
+- Full test suite and cross-loader tests pass within the release ceiling.
+- `v8.1.4` and GitHub release exist on the merged release commit.
+- Marketplace resolves and installs 8.1.4 into a clean cache.
+- Fresh Codex turn in `dify-meta` exits without Stop errors or surviving fetch children.
+- No Vaults script mutates Kernel's installed cache.

--- a/_meta/research/codex-stop-sessionend-autopush.md
+++ b/_meta/research/codex-stop-sessionend-autopush.md
@@ -1,0 +1,39 @@
+---
+query: Codex compatibility mapping SessionEnd autopush into Stop timeout
+date: 2026-07-15
+ttl: 30
+status: reproduced
+---
+
+# Failure-mode map: SessionEnd autopush under Codex
+
+## Evidence priority
+
+This is an owned plugin defect reproduced against the published 8.1.3 payload. Repository issues
+and production case studies were searched, but no external report was needed or used to infer the
+cause. The exact installed command and process tree are stronger evidence.
+
+| Symptom | Root cause | Fix | Source |
+|---|---|---|---|
+| Codex reports `Stop hook timed out after 60s` after an otherwise completed turn | The shared compatibility manifest wires `SessionEnd` to `autopush.sh sweep`; Codex maps the lifecycle behavior onto Stop, which runs at the end of each turn. | Remove automatic SessionEnd autopush from the published manifest. Push remains explicit. | `hooks/hooks.json`; https://learn.chatgpt.com/docs/hooks.md |
+| Timed-out hook leaves Git work running | `autopush.sh sweep` starts unbounded `git fetch` children across the outermost repository tree; killing the hook parent does not reliably kill descendants. | Never start repository-wide network work from a lifecycle hook. | `hooks/scripts/autopush.sh`; live PPID-1 fetch observed 2026-07-15 |
+| Cross-loader regression tests previously required SessionEnd | Tests encoded the historical auto-push behavior rather than the current explicit-push doctrine. | Replace positive SessionEnd assertions with negative automatic-push assertions and exercise the installed Codex payload. | `tests/run-tests.sh`; `hooks/scripts/autopush-postcommit` |
+
+## Exact reproduction
+
+- Vaults chronicle Stop: 0.022 seconds, exit 0.
+- Vaults checkpoint Stop: 0.229 seconds, exit 0.
+- Kernel 8.1.3 autopush sweep: hung in the first root-repo `git fetch`; user-visible run reached
+  the 60-second hook timeout and left an orphaned fetch.
+
+## Rejected fixes
+
+- Raising the hook timeout preserves unbounded work.
+- Per-fetch timeouts preserve an inappropriate network side effect on every turn.
+- Codex-only environment checks inside `autopush.sh` leave loader detection brittle and retain
+  automatic push behavior that conflicts with the plugin's explicit-push policy.
+
+## Chosen fix
+
+Remove SessionEnd autopush from the canonical plugin manifest, keep the script available only for
+explicit/manual invocation, add negative regression coverage, and release as patch version 8.1.4.

--- a/_meta/reviews/kernel-8.1.4-stop-hook-teardown.md
+++ b/_meta/reviews/kernel-8.1.4-stop-hook-teardown.md
@@ -1,0 +1,42 @@
+# Tear Down: KERNEL 8.1.4 Stop hook
+
+reviewed: 2026-07-15T21:45:00Z
+tier: 3
+scope: 7 source/release files plus installed-payload verification
+
+## Big 5
+
+input_validation: pass — no new external input parser
+edge_cases: pass with action — cover absent SessionEnd, manual sweep availability, install, upgrade, and current-session stale registration
+error_handling: pass — removal deletes an unbounded failure path
+duplication: pass — one canonical manifest remains
+complexity: pass — net deletion
+
+## Security
+
+pass — removes automatic network and remote-write behavior from an ambient hook; no secrets or
+authentication changes.
+
+## Testing
+
+Existing tests incorrectly require SessionEnd and enumerate it in cross-loader expectations.
+Change those assertions before release. Exercise both source manifest parsing and one freshly
+installed Codex payload.
+
+## Architecture
+
+Removing the shared lifecycle registration is preferable to loader sniffing inside the script.
+The manual sweep primitive may remain, but no ambient hook should own the explicit push boundary.
+
+## Verdict: PROCEED
+
+Proceed with the net-deletion approach. Release is blocked until the old positive SessionEnd tests
+are replaced, the full suite passes, and a marketplace-installed 8.1.4 payload completes a real
+Codex Stop boundary.
+
+## Action Items
+
+1. Remove SessionEnd registration from `hooks/hooks.json`.
+2. Replace positive SessionEnd tests with negative lifecycle-autopush tests.
+3. Verify all enumerated docs/fixtures no longer promise automatic end-of-session push.
+4. Run the full ship sequence and installed-payload proof.

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -1,4 +1,4 @@
-<kernel version="8.1.3">
+<kernel version="8.1.4">
 
 <!-- KERNEL_AMBIENT_SOURCE_BEGIN
 ## KERNEL quick reference

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -140,12 +140,6 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-end.sh",
             "timeout": 210,
             "statusMessage": "Running tests + cleaning up session..."
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopush.sh sweep",
-            "timeout": 60,
-            "statusMessage": "Pushing any unpushed commits..."
           }
         ]
       }

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.1.3.
+Quick reference for KERNEL v8.1.4.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -481,6 +481,19 @@ test_hooks_json_has_session_end() {
   fi
 }
 
+test_hooks_json_has_no_lifecycle_autopush() {
+  python3 - "$PLUGIN_ROOT/hooks/hooks.json" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+commands = [
+    hook.get("command", "")
+    for group in data.get("hooks", {}).get("SessionEnd", [])
+    for hook in group.get("hooks", [])
+]
+assert not any("autopush.sh" in command and "sweep" in command for command in commands), commands
+PY
+}
+
 test_session_start_workflow_present() {
   local output
   output=$("$PLUGIN_ROOT/hooks/scripts/session-start.sh" 2>&1)
@@ -4375,6 +4388,7 @@ run_test_suite() {
       run_test "detect-secrets clean file" test_detect_secrets_clean
       run_test "hooks.json has SessionStart" test_hooks_json_has_session_start
       run_test "hooks.json has SessionEnd" test_hooks_json_has_session_end
+      run_test "hooks.json has no lifecycle autopush" test_hooks_json_has_no_lifecycle_autopush
       run_test "hooks.json supports Claude and Codex loaders" test_hooks_json_cross_loader_schema
       run_test "advisory hooks are synchronous and complete" test_advisory_hooks_are_synchronous_and_complete
       run_test "six advisory hook commands are retained" test_six_advisory_hook_commands_are_retained


### PR DESCRIPTION
## Summary
- remove automatic SessionEnd autopush from the published Kernel hook manifest
- retain SessionEnd cleanup and manual sweep as explicit operations
- bump all canonical declarations to 8.1.4 and add a regression that forbids lifecycle autopush

## Root cause
Codex compatibility handling exposed the published SessionEnd autopush as a per-turn Stop hook. The vault-wide fetch exceeded 60 seconds and left an orphan fetch after the hook parent was killed.

## Verification
- hooks: 23 passed
- version sync: 1 passed
- release docs: 9 passed
- full suite: 350 passed, 0 failed
- review: APPROVE