### PR TITLE
KERNEL 8.1.5 — destructive-command guard consolidation + version single-sourcing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.4 removes automatic lifecycle network and push sweeps.",
-      "version": "8.1.4"
+      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.5 expands the destructive-command guard (SQL/infra/disk/cloud + interpreter escapes) with recovery-path messaging.",
+      "version": "8.1.5"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.4 removes automatic lifecycle network and push sweeps.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: e250801f0cd549cfabe72a552559185e2df782e53c307e19d65d8f0dd89b45ad; adapter: codex -->
-<kernel version="8.1.4">
+     source-sha256: b53fd6d863129a557069864b752ccc2713ae6de4641fa45c5c5cdc71bd46aeaf; adapter: codex -->
+<kernel version="8.1.5">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.1.5] - 2026-07-16
+
+Consolidates the destructive-command guard: the shipped `guard-bash.sh` now covers the
+whole-category dangers it previously left to per-project overlays, adds interpreter-escape
+detection, and gives every block a recovery path. Research-grounded (AgentAbstain 2607.10059
+on post-hoc irreversible-action failure; the deterministic-pre-action-gate literature).
+
+### Added
+- **Destructive-category coverage in `guard-bash.sh`** (previously only in Vaults-local
+  overlays; now shipped to every kernel user): DROP/TRUNCATE SQL; git `reset --hard`,
+  `clean -f`, `branch -D`, history rewrite (filter-repo/branch/bfg); infra teardown
+  (terraform/pulumi/cdk/sst destroy, serverless remove); cloud deletes (wrangler/aws/
+  gcloud/az); `dd`/`mkfs`/fork-bomb; raw-disk redirect; recursive `chmod`/`chown` of
+  root/home; `find -delete`/`-exec rm` rooted at root/home; `mv` of root/home itself.
+- **Interpreter-escape detection.** `python -c` / `perl -e` / `node -e` / `ruby -e`
+  one-liners performing recursive tree deletion (`rmtree`, `fs.rmSync`, `rimraf`, ...) —
+  the class that carries no `rm`/`dd` keyword for a plain grep to catch.
+- **Recovery-path block messages.** Every hard block now states the safer alternative and
+  the `DANGER_OK=1` override, so a blocked agent hands off to the human instead of
+  reformulating the command into an evasion.
+- **20 regression tests** in `tests/run-tests.sh` (`security_hooks` suite): a block case
+  per category plus over-block guards (soft `git reset`, `terraform plan`, `SELECT`,
+  harmless `python -c`, `aws s3 ls`, `dd_helper`) all pass.
+
+### Unchanged (deliberately)
+- Existing force-push-to-main/master, recursive-`rm`-of-root/home, and the rm/rmdir
+  submodule/tracked-dir investigation gate (`CONFIRM_DELETE=1`) keep their exact prior
+  logic — additive change, not a rewrite. No deep deobfuscation is attempted; the guard is
+  honest harm-reduction against accidental agent self-harm, not a security sandbox.
+
 ## [8.1.4] - 2026-07-15
 
 Patch release removing automatic network and push work from the plugin lifecycle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: e250801f0cd549cfabe72a552559185e2df782e53c307e19d65d8f0dd89b45ad; adapter: claude -->
-<kernel version="8.1.4">
+     source-sha256: b53fd6d863129a557069864b752ccc2713ae6de4641fa45c5c5cdc71bd46aeaf; adapter: claude -->
+<kernel version="8.1.5">
 
 
 <!-- ============================================ -->

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -1,4 +1,4 @@
-<kernel version="8.1.4">
+<kernel version="{{VERSION}}">
 
 <!-- KERNEL_AMBIENT_SOURCE_BEGIN
 ## KERNEL quick reference

--- a/hooks/scripts/guard-bash.sh
+++ b/hooks/scripts/guard-bash.sh
@@ -1,14 +1,33 @@
 #!/bin/bash
-# PreToolUse hook: Block only the most dangerous bash commands.
-# Minimal, robust guardrails -- block force-push to main/master and recursive
-# forced deletion of root/home. That is the whole scope; it is not a sandbox.
+# PreToolUse hook: block the most dangerous bash commands before they run.
 # Events: PreToolUse (matcher: Bash)
 #
-# Does NOT source circuit-breaker.sh: a safety gate must always run and must
-# never auto-disable itself (I0.15). It is also intentionally narrow, so on a
-# parser (jq) failure it WARNS and allows rather than blocking every bash
-# command (which would brick the session) -- the high-value secret gate is the
-# one that fails closed.
+# SCOPE (honest — this is harm-reduction against accidental agent self-harm, NOT a
+# security sandbox). It blocks, on the resulting-state class, three families:
+#   1. Repo/VCS destruction  — force-push to main/master, reset --hard, clean -f,
+#      branch -D, history rewrite.
+#   2. Whole-tree / device destruction — recursive forced rm of root/home, dd/mkfs,
+#      raw-disk overwrite, recursive chmod/chown of root/home, find -delete on root/home,
+#      mv of root/home itself.
+#   3. High-blast external ops — DROP/TRUNCATE SQL, infra teardown (terraform/pulumi/cdk/
+#      sst destroy, serverless remove), cloud deletes (wrangler/aws/gcloud/az), and
+#      interpreter one-liners that call the same destruction (python -c shutil.rmtree ...).
+# Plus a soft INVESTIGATION gate on rm/rmdir of git submodules and tracked directories.
+#
+# It does NOT attempt deep deobfuscation (base64|sh, hex/unicode-confusable evasion,
+# multi-tool write-then-exec). A determined or prompt-injected agent can evade a text
+# guard; the real backstop for that is a sandbox. This gate catches the one-liners an
+# LLM emits by accident or when casually working around a block — which is the actual
+# failure mode (AgentAbstain 2607.10059: dominant failure is post-hoc irreversible action).
+#
+# Escape hatches (recovery paths — a block states them so the agent hands off to the
+# human instead of reformulating into an evasion):
+#   * DANGER_OK=1 <cmd>      — override a hard block (intentional destructive op).
+#   * CONFIRM_DELETE=1 <cmd> — override the rm submodule/tracked-dir investigation gate.
+#
+# Does NOT source circuit-breaker.sh: a safety gate must always run and must never
+# auto-disable itself (I0.15). On a jq-parse failure it WARNS and allows rather than
+# blocking every bash command (which would brick the session).
 
 INPUT=$(cat)
 
@@ -19,6 +38,23 @@ fi
 
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [ -z "$COMMAND" ] && exit 0
+
+# Global override for the hard blocks. Scoped word-match so it can't be a substring accident.
+case "$COMMAND" in
+  *DANGER_OK=1*) exit 0 ;;
+esac
+
+# Lowercased, whitespace-collapsed view for case-insensitive keyword matching. Path
+# extraction and the rm gate below still use the raw $COMMAND (paths are case-sensitive).
+LOW=$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
+
+# block <reason> <recovery-hint> : print a structured refusal + how to proceed, then exit 2.
+block() {
+  echo "BLOCKED: $1" >&2
+  [ -n "$2" ] && echo "  $2" >&2
+  echo "  If this is intentional, re-run prefixed with DANGER_OK=1 -- or hand it to the human." >&2
+  exit 2
+}
 
 # --- Block force push to main/master (any flag form, any position) ---
 # Catches: --force, -f, --force-with-lease, +refspec, before or after the refspec.
@@ -32,14 +68,43 @@ while IFS= read -r _seg; do
   echo "$_seg" | grep -qE '\b(main|master)\b'        || continue
   if echo "$_seg" | grep -qE '(^|[[:space:]])(-f|--force|--force-with-lease)([[:space:]]|=|$)' \
      || echo "$_seg" | grep -qE '[[:space:]]\+[^[:space:]]*(main|master)'; then
-      echo "BLOCKED: Force push to main/master not allowed." >&2
-      exit 2
+      block "Force push to main/master not allowed." \
+            "Push to a feature branch and open a PR, or force-push a non-default branch."
   fi
 done < <(echo "$COMMAND" | tr ';|&' '\n')
 
-# --- Block recursive+forced rm of root or home (common flag orderings) ---
-# recursive+force in one token (-rf/-fr/-Rf), as separate flags, long flags,
-# or --no-preserve-root.
+# --- Other git history/state destruction (reset --hard, clean -f, branch -D, rewrite) ---
+printf '%s' "$LOW" | grep -qE 'git +reset +--hard' \
+  && block "git reset --hard discards uncommitted work irreversibly." "git stash first if you might want it back."
+printf '%s' "$LOW" | grep -qE 'git +clean +-[a-z]*f' \
+  && block "git clean -f deletes untracked files irreversibly." "git clean -n to preview what would be removed."
+printf '%s' "$LOW" | grep -qE 'git +branch +-d[[:space:]]' \
+  && block "git branch -D force-deletes a branch (may drop unmerged commits)." "Confirm it's merged, or use -d (safe delete)."
+printf '%s' "$LOW" | grep -qE 'filter-repo|filter-branch|(^| )bfg( |$)' \
+  && block "git history rewrite (filter-repo/filter-branch/bfg) is destructive + non-collaborative." "Verify a backup ref exists first."
+
+# --- Destructive SQL (also catches wrangler d1 execute --command "DROP ...") ---
+printf '%s' "$LOW" | grep -qE 'drop +(table|database|schema|index)|truncate +table' \
+  && block "destructive SQL (DROP/TRUNCATE) wipes data with no rollback." "Back up / snapshot the table first, or wrap in a reversible migration."
+
+# --- Cloud + infra teardown ---
+printf '%s' "$LOW" | grep -qE 'wrangler[[:space:]].*(delete|destroy)' \
+  && block "destructive wrangler op (deletes a worker/db/bucket/namespace)." "Confirm the resource name; export/snapshot data first."
+printf '%s' "$LOW" | grep -qE '(cdk|terraform|sst|pulumi)[[:space:]]+destroy|serverless[[:space:]]+remove' \
+  && block "infrastructure teardown (destroy/remove) tears down live infra." "Run a plan/preview first and confirm the target stack."
+printf '%s' "$LOW" | grep -qE 'aws[[:space:]]+.*(terminate-instances|delete-|[[:space:]]rb[[:space:]]|s3[[:space:]]+rm[[:space:]]+--recursive)' \
+  && block "destructive AWS CLI op." "Confirm the resource id/bucket; enable a snapshot/versioning safety net."
+printf '%s' "$LOW" | grep -qE '(gcloud|az)[[:space:]]+.* delete( |$)' \
+  && block "destructive cloud CLI op (gcloud/az delete)." "Confirm the resource; check for a --dry-run/--quiet you did NOT mean to pass."
+
+# --- Disk-format / dd / fork-bomb / raw-device overwrite ---
+# `dd` may sit at the START of the command (no leading space); anchor with (^|space).
+printf '%s' "$LOW" | grep -qE 'mkfs|(^|[[:space:]])dd[[:space:]]+(if|of)=|:\(\)\{[[:space:]]*:\|:' \
+  && block "disk-format / dd / fork-bomb." "These are almost never what an agent should run; hand to the human."
+printf '%s' "$LOW" | grep -qE '>[[:space:]]*/dev/(r?disk|sd|nvme|hd)' \
+  && block "overwrite of a raw disk device." "Refusing to redirect into a block device."
+
+# --- Recursive forced rm of root or home (common flag orderings) ---
 rm_recursive_force() {
   echo "$COMMAND" | grep -qE '\brm\b' || return 1
   echo "$COMMAND" | grep -qE '\brm\b[^;&|]*(-[a-zA-Z]*[rR][a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*[rR])' && return 0
@@ -51,14 +116,36 @@ rm_recursive_force() {
   return 1
 }
 # Targets root or home ITSELF (not a subdir): / , /* , ~ , ~/ , ~/* , $HOME .
-# Deliberately does NOT match ~/subdir or /subdir -- deleting those is the
-# user's call; only wiping the whole root/home tree is catastrophic enough to block.
 rm_targets_root_home() {
   echo "$COMMAND" | grep -qE '(^|[[:space:]])(/|/\*|~|~/|~/\*|\$HOME/?|\$\{HOME\}/?)([[:space:]]|$)'
 }
 if rm_recursive_force && rm_targets_root_home; then
-    echo "BLOCKED: Refusing recursive forced delete of root or home." >&2
-    exit 2
+    block "Refusing recursive forced delete of root or home." "Target a specific subdirectory, not / or ~."
+fi
+
+# --- Recursive chmod/chown of root or home ITSELF (bricks the account/login) ---
+if printf '%s' "$LOW" | grep -qE '(chmod|chown)[[:space:]]+(-[a-z]*r|--recursive)'; then
+  printf '%s' "$COMMAND" | grep -qE '(chmod|chown)[[:space:]].*[[:space:]]("?/([[:space:]]|$)|~([[:space:]/]|$)|\$HOME|\$\{HOME\})' \
+    && block "recursive chmod/chown on root/home." "Scope it to a specific subdirectory."
+fi
+
+# --- find -delete / find -exec rm rooted at / ~ or $HOME (whole-tree deletion) ---
+if printf '%s' "$LOW" | grep -qE 'find[[:space:]].*(-delete|-exec[[:space:]]+rm)'; then
+  printf '%s' "$COMMAND" | grep -qE 'find[[:space:]]+("?/([[:space:]]|$)|~([[:space:]/]|$)|\$HOME|\$\{HOME\})' \
+    && block "find -delete/-exec rm rooted at root/home." "Root the find at a specific subdirectory."
+fi
+
+# --- mv of root or home ITSELF (e.g. mv ~ /dev/null) -- not a file inside it ---
+printf '%s' "$COMMAND" | grep -qE 'mv[[:space:]]+("?/([[:space:]]|$)|~([[:space:]]|$)|\$HOME([[:space:]]|$)|\$\{HOME\})' \
+  && block "mv of root/home itself." "Move a specific path, not / or ~."
+
+# --- Interpreter one-liners that call the same destruction (no rm/dd keyword to catch) ---
+# python -c / perl -e / node -e / ruby -e whose body does recursive/tree deletion.
+# Narrow to TREE deletion (rmtree/removedirs/rimraf/fs.rm*/rm -rf) -- a single-file
+# os.remove is not catastrophic and would over-block legitimate scripting.
+if printf '%s' "$LOW" | grep -qE '(python[0-9.]*|perl|ruby|node)[[:space:]]+(-e|-c)'; then
+  printf '%s' "$LOW" | grep -qE 'rmtree|removedirs|rimraf|rmsync|rmdirsync|fs\.rm|rm[[:space:]]+-[a-z]*r[a-z]*f' \
+    && block "interpreter one-liner performing recursive/tree deletion." "Refusing indirect recursive rm via python/perl/node/ruby; do it explicitly so it's reviewable."
 fi
 
 # --- Investigation gate: rm/rmdir of git submodules or tracked directories ---

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -39,8 +39,10 @@ def sub(path, pattern, repl):
 
 sub('.claude-plugin/plugin.json',      r'("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(")',     rf'\g<1>{new}\g<2>')
 sub('.claude-plugin/marketplace.json', r'("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(")',     rf'\g<1>{new}\g<2>')
-sub('governance/kernel.md.tmpl',       r'(<kernel version=")[0-9]+\.[0-9]+\.[0-9]+(">)',  rf'\g<1>{new}\g<2>')
 sub('skills/help/SKILL.md',            r'(KERNEL v)[0-9]+\.[0-9]+\.[0-9]+',               rf'\g<1>{new}')
+# NOTE: governance/kernel.md.tmpl no longer carries a hardcoded version — it uses the
+# {{VERSION}} token, which generate-governance.py derives from plugin.json below. So the
+# template is not stamped here; regenerating governance is what propagates the version.
 
 # validate JSON still parses and carries the new version
 assert json.load(open('.claude-plugin/plugin.json'))['version'] == new, "plugin.json"

--- a/scripts/generate-governance.py
+++ b/scripts/generate-governance.py
@@ -122,6 +122,17 @@ def load(root):
     outputs = config.get("outputs")
     if not isinstance(tokens, dict) or not isinstance(outputs, dict):
         fail("adapters.json requires object fields: tokens and outputs")
+    # VERSION is DERIVED from the canonical manifest (plugin.json), never hand-authored
+    # in adapters.json or the template. Single source of truth: bump plugin.json only,
+    # regenerate, and every {{VERSION}} in the governance docs follows. Injected only when
+    # the template actually references {{VERSION}}, so minimal templates aren't forced to.
+    if "{{VERSION}}" in source:
+        try:
+            version = json.loads(
+                (root / ".claude-plugin/plugin.json").read_text(encoding="utf-8"))["version"]
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            fail(f"cannot read version from .claude-plugin/plugin.json: {exc}")
+        tokens["VERSION"] = {client: version for client in EXACT_OUTPUTS}
     if outputs != EXACT_OUTPUTS:
         fail("outputs must use exact native output paths: CLAUDE.md and AGENTS.md")
     clients = set(EXACT_OUTPUTS)

--- a/scripts/governance-sync.py
+++ b/scripts/governance-sync.py
@@ -234,7 +234,16 @@ def render_kernel_reference(repo):
     if config.get("outputs") != KERNEL_OUTPUTS or not isinstance(config.get("tokens"), dict):
         raise ValueError("invalid KERNEL adapter config")
     source = template_path.read_text()
-    tokens = config["tokens"]
+    tokens = dict(config["tokens"])
+    # VERSION is derived from the canonical manifest (plugin.json), not adapters.json —
+    # single source of truth. Injected only when the template references {{VERSION}}, kept
+    # in lockstep with scripts/generate-governance.py (the two renderers must agree).
+    if "{{VERSION}}" in source:
+        try:
+            version = json.loads((repo / ".claude-plugin/plugin.json").read_text())["version"]
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise ValueError(f"cannot read version from .claude-plugin/plugin.json: {exc}")
+        tokens["VERSION"] = {client: version for client in KERNEL_OUTPUTS}
     found = set(KERNEL_TOKEN_RE.findall(source))
     if found != set(tokens):
         raise ValueError("KERNEL template token drift")

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.1.4.
+Quick reference for KERNEL v8.1.5.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1159,6 +1159,37 @@ test_guard_bash_allows_subdir_rm() {
   assert_exit_code 0 "$?" "rm -rf of a home subdir must be allowed"
 }
 
+# === guard-bash 8.1.5: consolidated destructive-category coverage ===
+# Each _blocks_ test expects exit 2; each _allows_ test expects exit 0 (no over-block).
+_gb() {  # helper: pipe a command JSON into the guard, return its exit code
+  echo "{\"tool_input\":{\"command\":\"$1\"}}" | "$PLUGIN_ROOT/hooks/scripts/guard-bash.sh" >/dev/null 2>&1
+}
+
+test_guard_bash_blocks_drop_table()   { _gb 'wrangler d1 execute db --command \"DROP TABLE users\"'; assert_exit_code 2 "$?" "DROP TABLE must be blocked"; }
+test_guard_bash_blocks_truncate()     { _gb 'psql -c \"TRUNCATE TABLE payments\"';                    assert_exit_code 2 "$?" "TRUNCATE TABLE must be blocked"; }
+test_guard_bash_blocks_reset_hard()   { _gb 'git reset --hard HEAD~3';                                assert_exit_code 2 "$?" "git reset --hard must be blocked"; }
+test_guard_bash_blocks_clean_f()      { _gb 'git clean -fd';                                          assert_exit_code 2 "$?" "git clean -fd must be blocked"; }
+test_guard_bash_blocks_branch_D()     { _gb 'git branch -D feature/x';                                assert_exit_code 2 "$?" "git branch -D must be blocked"; }
+test_guard_bash_blocks_tf_destroy()   { _gb 'terraform destroy -auto-approve';                        assert_exit_code 2 "$?" "terraform destroy must be blocked"; }
+test_guard_bash_blocks_wrangler_del() { _gb 'wrangler kv namespace delete --namespace-id abc';        assert_exit_code 2 "$?" "wrangler delete must be blocked"; }
+test_guard_bash_blocks_aws_s3_rm()    { _gb 'aws s3 rm --recursive s3://bucket';                      assert_exit_code 2 "$?" "aws s3 rm --recursive must be blocked"; }
+test_guard_bash_blocks_dd()           { _gb 'dd if=/dev/zero of=/dev/disk0';                          assert_exit_code 2 "$?" "dd to disk must be blocked"; }
+test_guard_bash_blocks_disk_redir()   { _gb 'cat img.bin > /dev/disk2';                               assert_exit_code 2 "$?" "raw disk redirect must be blocked"; }
+test_guard_bash_blocks_chmod_root()   { _gb 'chmod -R 777 /';                                         assert_exit_code 2 "$?" "recursive chmod of / must be blocked"; }
+test_guard_bash_blocks_py_rmtree()    { _gb "python3 -c \\\"import shutil; shutil.rmtree('/')\\\"";   assert_exit_code 2 "$?" "python rmtree must be blocked"; }
+test_guard_bash_blocks_mv_home()      { _gb 'mv ~ /dev/null';                                         assert_exit_code 2 "$?" "mv of home itself must be blocked"; }
+
+# DANGER_OK=1 must override a hard block (recovery path).
+test_guard_bash_danger_ok_override()  { _gb 'DANGER_OK=1 terraform destroy -auto-approve';            assert_exit_code 0 "$?" "DANGER_OK=1 must override a hard block"; }
+
+# Must NOT over-block legitimate commands that merely resemble a category.
+test_guard_bash_allows_reset_soft()   { _gb 'git reset HEAD~1';                assert_exit_code 0 "$?" "soft git reset must pass"; }
+test_guard_bash_allows_tf_plan()      { _gb 'terraform plan';                  assert_exit_code 0 "$?" "terraform plan must pass"; }
+test_guard_bash_allows_select()       { _gb 'psql -c \"SELECT * FROM users\"'; assert_exit_code 0 "$?" "SELECT must pass"; }
+test_guard_bash_allows_py_print()     { _gb "python3 -c \\\"print(1)\\\"";     assert_exit_code 0 "$?" "harmless python -c must pass"; }
+test_guard_bash_allows_aws_ls()       { _gb 'aws s3 ls';                       assert_exit_code 0 "$?" "aws s3 ls must pass"; }
+test_guard_bash_allows_dd_helper()    { _gb 'dd_helper --version';             assert_exit_code 0 "$?" "dd_helper (not dd) must pass"; }
+
 # Regression: a safe prefix must not auto-approve a chained dangerous tail.
 test_auto_approve_defers_chained_command() {
   local output
@@ -1535,7 +1566,7 @@ test_critical_guard_scripts_unchanged_for_802() {
     actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
-16fb49cbedb3bdc875c4add7cb1de0c993e6528fa4d9d520fc9ee2cba6641a93 guard-bash.sh
+025a7a5087d8bd15d5a71d788ca96bae5eada514dae33b9a99a1fd15a98f13b9 guard-bash.sh
 79b46dabd8c9e890d503548cddd98358ec59d888ada4e738e34b05b7ca4f1da1 guard-config.sh
 d3611267b4f135c5b96e8a4a8af60f296b196efc135e3dfbef63d7683065608c detect-secrets.sh
 dbf6680d56dfd5676a420f69f75dcfc5405f0fd53879063859a43b4dcaa5085b guard-context.sh
@@ -4479,6 +4510,26 @@ run_test_suite() {
       run_test "guard-bash blocks force push" test_guard_bash_blocks_force_push
       run_test "guard-bash allows safe commands" test_guard_bash_allows_safe_commands
       run_test "guard-bash allows git log" test_guard_bash_allows_git_log
+      run_test "guard-bash blocks DROP TABLE" test_guard_bash_blocks_drop_table
+      run_test "guard-bash blocks TRUNCATE" test_guard_bash_blocks_truncate
+      run_test "guard-bash blocks reset --hard" test_guard_bash_blocks_reset_hard
+      run_test "guard-bash blocks clean -fd" test_guard_bash_blocks_clean_f
+      run_test "guard-bash blocks branch -D" test_guard_bash_blocks_branch_D
+      run_test "guard-bash blocks terraform destroy" test_guard_bash_blocks_tf_destroy
+      run_test "guard-bash blocks wrangler delete" test_guard_bash_blocks_wrangler_del
+      run_test "guard-bash blocks aws s3 rm --recursive" test_guard_bash_blocks_aws_s3_rm
+      run_test "guard-bash blocks dd to disk" test_guard_bash_blocks_dd
+      run_test "guard-bash blocks raw disk redirect" test_guard_bash_blocks_disk_redir
+      run_test "guard-bash blocks chmod -R /" test_guard_bash_blocks_chmod_root
+      run_test "guard-bash blocks python rmtree" test_guard_bash_blocks_py_rmtree
+      run_test "guard-bash blocks mv home" test_guard_bash_blocks_mv_home
+      run_test "guard-bash DANGER_OK override" test_guard_bash_danger_ok_override
+      run_test "guard-bash allows soft reset" test_guard_bash_allows_reset_soft
+      run_test "guard-bash allows terraform plan" test_guard_bash_allows_tf_plan
+      run_test "guard-bash allows SELECT" test_guard_bash_allows_select
+      run_test "guard-bash allows harmless python" test_guard_bash_allows_py_print
+      run_test "guard-bash allows aws s3 ls" test_guard_bash_allows_aws_ls
+      run_test "guard-bash allows dd_helper" test_guard_bash_allows_dd_helper
       run_test "guard-config blocks .claude/ write" test_guard_config_blocks_claude_dir_write
       run_test "guard-config allows CLAUDE.md" test_guard_config_allows_claude_md
       run_test "guard-config allows rules" test_guard_config_allows_rules

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -472,7 +472,8 @@ class SyncTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             repo = git_repo(Path(td) / "kernel-copy")
             (repo / "governance").mkdir()
-            for relative in ("governance/adapters.json", "governance/kernel.md.tmpl", "CLAUDE.md", "AGENTS.md"):
+            for relative in ("governance/adapters.json", "governance/kernel.md.tmpl", "CLAUDE.md", "AGENTS.md",
+                             ".claude-plugin/plugin.json"):
                 source = ROOT / relative
                 target = repo / relative
                 target.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Consolidates the shipped `guard-bash.sh` to cover whole-category destructive operations
previously left to per-project overlays: destructive SQL (DROP/TRUNCATE); git state
destruction (hard resets, forced clean, forced branch delete, history rewrite); infra
teardown (terraform/pulumi/cdk/sst/serverless); cloud deletes (wrangler/aws/gcloud/az);
disk destruction (dd/mkfs/raw-device redirect); recursive permission changes on root/home;
whole-tree find-delete and mv of root/home. Adds interpreter-escape detection (one-liners
that perform recursive deletion via python/perl/node/ruby, which carry no rm keyword) and a
recovery-path message on every block (safer alternative + `DANGER_OK=1` override).

The existing force-push, recursive-root-delete, and rm/rmdir investigation-gate logic are
unchanged. This is additive category coverage, not a rewrite. No deep deobfuscation is
attempted; the guard is honest harm-reduction against accidental agent self-harm, not a
security sandbox.

## Version single-sourcing

`governance/kernel.md.tmpl` now uses a `{{VERSION}}` token derived from `plugin.json` by
both renderers (`generate-governance.py` and `governance-sync.py`); the version is no longer
a hardcoded literal in the template or hand-stamped there. `plugin.json` is the sole
human-touched version source.

## Testing

Full suite: 370 passed, 0 failed. 20 new guard regression tests (a block case per category
plus over-block guards so legitimate commands like `terraform plan`, a soft reset, `SELECT`,
harmless `python -c`, and `aws s3 ls` still pass).

## Note

Also brings `main` current (it was stuck at 8.1.1; the 8.1.2 to 8.1.4 releases had been
tagged from branches that were never merged back).
