### PR TITLE
release(agentdb): KERNEL 8.3.0 — local semantic recall + hybrid RRF retrieval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.2.0 is a security release: a six-threat-class guard (self-destruct, exfiltration, scope-escape, supply-chain, sensitive-config writes, warn-only injection tripwire) with unforgeable one-time human approval replacing the DANGER_OK substring.",
-      "version": "8.2.0"
+      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.3.0 adds optional local semantic recall: sentence embeddings (fastembed/MiniLM, on-machine) fused with FTS keyword search via reciprocal-rank fusion, measured +0.10 recall@5, degrading gracefully to FTS-only with no backend.",
+      "version": "8.3.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.4 removes automatic lifecycle network and push sweeps.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: b53fd6d863129a557069864b752ccc2713ae6de4641fa45c5c5cdc71bd46aeaf; adapter: codex -->
-<kernel version="8.2.0">
+<kernel version="8.3.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.3.0] - 2026-07-16 "semantic recall"
+
+AgentDB recall gains optional local semantic search, fused with the existing FTS
+keyword ranking. Measured on a real 47-learning corpus with a 20-query gold set:
+**recall@5 rose 0.75 → 0.85 (+0.10)** with zero regressions — the gain comes
+entirely from queries whose wording shares no keywords with the stored learning
+(e.g. "two background jobs writing the same repository" → the fcntl.flock git-mutex
+learning). Everything degrades gracefully: with no embedding backend installed,
+recall is byte-for-byte the previous FTS-only behavior. No new hard dependency.
+
+### Added
+- **Local sentence embeddings (migration 015).** A new `embedding` BLOB column on
+  `learnings` (plus `embedding_model` / `embedding_ts`), populated by
+  `agentdb embed-sync`. Backend is pluggable and tried in order: `fastembed`
+  (ONNX all-MiniLM-L6-v2, 384-dim, ~50MB, no torch), then `sentence-transformers`
+  (same model, torch), then a deterministic dependency-free `hash` backend used
+  only by the test suite. All yield L2-normalized float32 vectors.
+- **Hybrid recall via reciprocal-rank fusion.** When vectors exist, `agentdb recall`
+  fuses the FTS bm25 ranking with a brute-force cosine ranking (RRF, k=60) and
+  surfaces semantically-related learnings the keyword query missed. Corpus is small
+  (hundreds of rows) so cosine is plain numpy/pure-Python — no vector DB, no ANN.
+- **`agentdb embed-init`** — opt-in bootstrap: creates a venv beside the DB, installs
+  fastembed, embeds existing learnings, and prints the `AGENTDB_EMBED_PYTHON` export
+  to make it permanent. Explicit only; never runs on its own.
+- **`agentdb embed-sync` / `embed-status`** — (re)embed learnings whose vector is
+  missing/stale; report the active backend.
+- **`agentdb recall --ids`** — side-effect-free machine-readable recall (surfaced ids
+  only, no events, no hit_count bumps). Powers the eval harness.
+- **Recall eval harness** (`orchestration/agentdb/eval/run_eval.py`) — runs the REAL
+  shipped recall against a gold set in two arms (FTS-only via `AGENTDB_NO_EMBED=1`,
+  and hybrid) and reports recall@k / hit@k with the delta. A portable fixture corpus
+  + gold set ship in `tests/fixtures/agentdb-eval/` so CI proves the mechanism with
+  the hash backend and no model download.
+- **7 regression tests** (recall suite): backend selection, no-backend degradation,
+  vector write, `--ids` side-effect-freedom, hybrid-never-regresses-on-fixture, and
+  FTS-identical-when-no-vectors.
+
+### Changed
+- The JSON mirror (`agent.db.json`) **excludes** the embedding columns: they are
+  derived data that rebuilds from insight text via `embed-sync` on restore, exactly
+  like the FTS index. This keeps the mirror text-diffable and BLOB-free (sqlite-mirror
+  rule). Round-trip verified: export → restore → embed-sync reproduces every vector.
+
+### Unchanged (deliberately)
+- With no embedding backend, recall, read-start, and the mirror are byte-for-byte the
+  8.2.0 behavior. Semantic recall is strictly additive and opt-in.
+
 ## [8.2.0] - 2026-07-16 "security"
 
 A comprehensive security release covering six threat classes, grounded in real 2025-26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: b53fd6d863129a557069864b752ccc2713ae6de4641fa45c5c5cdc71bd46aeaf; adapter: claude -->
-<kernel version="8.2.0">
+<kernel version="8.3.0">
 
 
 <!-- ============================================ -->

--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ KERNEL keeps durable data in the selected Vaults, found in this order: valid `KE
 - `_meta/agents/`, `_meta/logs/`, and small session-status files: runtime records.
 - `.claude/kernel/` and `.local/bin/agentdb`: links created only by explicit init; startup only repairs recognized old numbered KERNEL links.
 
+### Semantic recall (8.3.0, optional)
+
+By default `agentdb recall` is FTS5 keyword search. Run `agentdb embed-init` once to
+add local semantic search: it creates a venv beside the DB, installs `fastembed`
+(ONNX all-MiniLM-L6-v2, ~50MB, no torch, fully on-machine — nothing leaves your
+computer), embeds your learnings, and prints an `AGENTDB_EMBED_PYTHON` export to make
+it permanent. Recall then fuses keyword bm25 with cosine similarity (reciprocal-rank
+fusion) and surfaces learnings whose wording differs from your query. On a real
+47-learning corpus this lifted recall@5 from 0.75 to 0.85 with no regressions. Install
+nothing and recall stays exactly as before — semantic search is strictly additive and
+opt-in. The embedding vectors are derived data: they are excluded from the tracked
+JSON mirror and rebuilt with `agentdb embed-sync` on a fresh clone. Measure retrieval
+quality yourself with `orchestration/agentdb/eval/run_eval.py` against a gold set.
+
 KERNEL hooks can inspect repository state, run configured checks, and write these records.
 Claude Code runs the full declared lifecycle. Codex runs supported synchronous hook
 events, including the write guards and SessionStart context; it skips asynchronous

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -125,6 +125,20 @@ _ensure_softdelete_cols() {
   return 0
 }
 
+# Migration 015: embedding columns, delegated to code (idempotent under force re-read,
+# like _ensure_softdelete_cols). Inert until an embedding backend + embed-sync run.
+_ensure_embedding_cols() {
+  [ -f "$DB" ] || return 0
+  local has
+  has=$(db_exec "SELECT 1 FROM pragma_table_info('learnings') WHERE name='embedding' LIMIT 1;" 2>/dev/null || echo "")
+  if [ -z "$has" ]; then
+    db_exec "ALTER TABLE learnings ADD COLUMN embedding BLOB;" 2>/dev/null || true
+    db_exec "ALTER TABLE learnings ADD COLUMN embedding_model TEXT;" 2>/dev/null || true
+    db_exec "ALTER TABLE learnings ADD COLUMN embedding_ts TEXT;" 2>/dev/null || true
+  fi
+  return 0
+}
+
 # Return a SQL literal for a text value: '<escaped>' for a non-empty string, or
 # bare NULL for an empty one (absence = UNKNOWN, never an empty-string fact; the
 # null-semantics contract, design 5.2).
@@ -1137,7 +1151,18 @@ cmd_export_json() {
   echo '{}' > "$acc"
   for t in $tables; do
     _is_snapshot_table "$t" || continue
-    db_exec_opts "-json" "SELECT * FROM \"$t\" ORDER BY rowid;" > "$tdir/$t.json" 2>/dev/null
+    # DERIVED columns are NOT mirrored (sqlite-mirror rule): the embedding BLOBs
+    # (migration 015) rebuild from insight text via `agentdb embed-sync` on restore,
+    # exactly like the FTS index. Mirroring them would put 1.5KB of binary per row
+    # into the tracked JSON (unreadable, un-diffable) and BLOBs don't round-trip
+    # through sqlite3 -json / json_extract cleanly. So select an explicit column
+    # list minus embedding* for any table that carries them; plain SELECT * otherwise.
+    local _sel="*" _cols
+    _cols=$(db_exec "SELECT group_concat('\"'||name||'\"', ',') FROM pragma_table_info('$t') WHERE name NOT IN ('embedding','embedding_model','embedding_ts');" 2>/dev/null)
+    if [ -n "$_cols" ] && db_exec "SELECT 1 FROM pragma_table_info('$t') WHERE name='embedding' LIMIT 1;" 2>/dev/null | grep -q 1; then
+      _sel="$_cols"
+    fi
+    db_exec_opts "-json" "SELECT $_sel FROM \"$t\" ORDER BY rowid;" > "$tdir/$t.json" 2>/dev/null
     [ -s "$tdir/$t.json" ] || echo '[]' > "$tdir/$t.json"
     jq -S --arg t "$t" --slurpfile rows "$tdir/$t.json" '. + {($t): $rows[0]}' "$acc" \
       > "$acc.tmp" && mv "$acc.tmp" "$acc"
@@ -1827,16 +1852,141 @@ _recall_emit() {
   fi
 }
 
+# === Semantic recall (migration 015) — optional, degrades to FTS-only ===
+# The embedding backend lives in embed.py next to this script. It runs under a
+# python that has fastembed or sentence-transformers; if neither is installed (or
+# no vectors exist yet), every call here fails and recall stays pure FTS.
+_embed_py() { echo "$SCHEMA_DIR/embed.py"; }
+_embed_python() { echo "${AGENTDB_EMBED_PYTHON:-python3}"; }
+
+# Run embed.py; echo stdout, return its exit code. Silent on failure.
+_embed_run() {
+  local py script
+  py=$(_embed_python); script=$(_embed_py)
+  [ -f "$script" ] || return 3
+  command -v "$py" >/dev/null 2>&1 || return 3
+  "$py" "$script" "$@" 2>/dev/null
+}
+
+# Emit _recall_emit-format rows for an explicit newline-list of ids (used to pull
+# display text for semantic-only hits that FTS did not match). Visibility/archived
+# filtered like _recall_emit. <origin> tags the rows for reinforcement routing.
+_emit_rows_by_ids() {
+  local db="$1" ids="$2" tag="$3" origin="${4:-local}"
+  [ -f "$db" ] || return 0
+  [ -n "$ids" ] || return 0
+  local in_list=""
+  local id
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    in_list="${in_list:+$in_list,}'$(sql_escape "$id")'"
+  done <<< "$ids"
+  [ -z "$in_list" ] && return 0
+  local arch=""
+  if sqlite3 "$db" "SELECT 1 FROM pragma_table_info('learnings') WHERE name='archived_at' LIMIT 1;" 2>/dev/null | grep -q 1; then
+    arch="AND archived_at IS NULL"
+  fi
+  sqlite3 "$db" "
+    SELECT lower(substr(insight,1,200)) || '@@US@@' ||
+           '- [' || type || '] ' || insight || '$tag' ||
+           CASE WHEN evidence IS NOT NULL AND evidence != ''
+                THEN '  ↳ ' || substr(evidence,1,90) ELSE '' END
+           || '@@US@@' || id || '@@US@@' || '$origin'
+    FROM learnings
+    WHERE id IN ($in_list)
+      AND (visibility = 'agent' OR visibility IS NULL)
+      $arch;" 2>/dev/null || true
+}
+
+# Reciprocal-rank fusion of FTS and semantic rankings. Args: sem-rank file and
+# fts-rank file (each "id<TAB>rank"); union display lines on stdin. Emits the same
+# lines reordered by RRF score = 1/(k+fts_rank) + 1/(k+sem_rank), k=60 (standard).
+# A row missing from a ranker simply contributes 0 from that side. Small N -> an
+# O(n^2) selection sort is fine and keeps this dependency-free.
+_hybrid_rerank() {
+  awk -F'@@US@@' -v semf="$1" -v ftsf="$2" -v k=60 '
+    BEGIN{
+      while((getline l < semf) > 0){ n=split(l,a,"\t"); if(n>=2) semr[a[1]]=a[2] }
+      while((getline l < ftsf) > 0){ n=split(l,a,"\t"); if(n>=2) ftsr[a[1]]=a[2] }
+    }
+    { id=$3; if(id!="" && !(id in disp)){ disp[id]=$0; ord[++cnt]=id } }
+    END{
+      for(i=1;i<=cnt;i++){ id=ord[i]; s=0;
+        if(id in ftsr) s += 1.0/(k+ftsr[id]);
+        if(id in semr) s += 1.0/(k+semr[id]);
+        sc[id]=s }
+      for(i=1;i<=cnt;i++) for(j=i+1;j<=cnt;j++)
+        if(sc[ord[j]] > sc[ord[i]]){ t=ord[i]; ord[i]=ord[j]; ord[j]=t }
+      for(i=1;i<=cnt;i++) print disp[ord[i]]
+    }'
+}
+
+# Given FTS candidate rows (raw) + the query, fuse in semantic ranking if a backend
+# and stored vectors exist. Echoes the reordered/expanded candidate rows. On any
+# failure echoes $raw unchanged (pure FTS — the exact pre-015 behavior).
+_maybe_hybrid() {
+  local db="$1" query="$2" raw="$3" limit="$4"
+  # Escape hatch: force pure FTS (used by the eval's baseline arm, and any user who
+  # wants to pin keyword-only behavior even with a backend installed).
+  [ "${AGENTDB_NO_EMBED:-0}" = "1" ] && { printf '%s' "$raw"; return 0; }
+  local sem_pairs
+  sem_pairs=$(_embed_run query "$db" "$query") || { printf '%s' "$raw"; return 0; }
+  [ -n "$sem_pairs" ] || { printf '%s' "$raw"; return 0; }
+  local semf ftsf union
+  semf=$(mktemp); ftsf=$(mktemp)
+  # sem-rank: id<TAB>rank (cosine order). Cap the semantic pool at limit*3.
+  printf '%s\n' "$sem_pairs" | awk -F'\t' 'NF>=1 && $1!=""{print $1"\t"NR}' \
+    | head -n $((limit * 3)) > "$semf"
+  # fts-rank: id<TAB>rank from the raw FTS candidate order (field 3 = id).
+  printf '%s\n' "$raw" | awk -F'@@US@@' 'NF>=4 && $3!=""{print $3"\t"(++n)}' > "$ftsf"
+  # Pull display rows for semantic ids that FTS missed, so semantic can surface them.
+  local sem_ids fts_ids missing
+  sem_ids=$(cut -f1 "$semf")
+  fts_ids=$(cut -f1 "$ftsf")
+  missing=$(comm -23 <(printf '%s\n' "$sem_ids" | sort -u) <(printf '%s\n' "$fts_ids" | sort -u) 2>/dev/null)
+  local raw_sem=""
+  [ -n "$missing" ] && raw_sem=$(_emit_rows_by_ids "$db" "$missing" "" "local")
+  union=$(printf '%s\n%s\n' "$raw" "$raw_sem" | grep -v '^[[:space:]]*$')
+  printf '%s\n' "$union" | _hybrid_rerank "$semf" "$ftsf"
+  rm -f "$semf" "$ftsf"
+}
+
+# Opt-in bootstrap for the semantic-recall backend. Creates a venv beside the DB
+# and installs fastembed (ONNX all-MiniLM-L6-v2, ~50MB, no torch), then syncs.
+# Explicit only — never runs on its own; a user who never calls this keeps FTS-only.
+cmd_embed_init() {
+  local venv="$DB_DIR/.venv" py
+  echo "Bootstrapping semantic recall (fastembed, local, ~50MB)…"
+  if [ ! -x "$venv/bin/python" ]; then
+    python3 -m venv "$venv" || { echo "failed to create venv at $venv" >&2; exit 1; }
+  fi
+  py="$venv/bin/python"
+  "$py" -m pip install --quiet --upgrade pip >/dev/null 2>&1 || true
+  if ! "$py" -c "import fastembed" >/dev/null 2>&1; then
+    echo "Installing fastembed…"
+    "$py" -m pip install --quiet fastembed || { echo "pip install fastembed failed" >&2; exit 1; }
+  fi
+  echo "Backend ready. Point recall at it by exporting:"
+  echo "  export AGENTDB_EMBED_PYTHON=\"$py\""
+  echo "Embedding existing learnings…"
+  _ensure_embedding_cols
+  AGENTDB_EMBED_PYTHON="$py" _embed_run sync "$DB"
+  echo "Done. Add AGENTDB_EMBED_PYTHON to your shell profile to make it permanent."
+}
+
 cmd_recall() {
   # Parse --global (cross-project) out of the args; the rest is the query.
   local use_global=0
   local -a qargs=()
   local a
+  local ids_only=0
   for a in "$@"; do
-    if [ "$a" = "--global" ]; then use_global=1; else qargs+=("$a"); fi
+    if [ "$a" = "--global" ]; then use_global=1
+    elif [ "$a" = "--ids" ]; then ids_only=1      # eval mode: print surfaced ids, no side effects
+    else qargs+=("$a"); fi
   done
   local query="${qargs[*]:-}"  # :- guards empty array under set -u on bash 3.2 (macOS)
-  [ -z "$query" ] && { echo "Usage: agentdb recall <keywords> [--global]"; exit 1; }
+  [ -z "$query" ] && { echo "Usage: agentdb recall <keywords> [--global] [--ids]"; exit 1; }
   [ ! -f "$DB" ] && { echo "No DB"; exit 1; }
   local limit="${RECALL_LIMIT:-8}"
 
@@ -1871,6 +2021,7 @@ cmd_recall() {
     run_pending_migrations "recall:applied_migration" >/dev/null 2>&1 || true
   fi
   _ensure_softdelete_cols  # guarantee the local archived_at filter is valid (design 3.7)
+  _ensure_embedding_cols   # migration 015: embedding columns present (inert without a backend)
 
   # Resolve the global brain only if requested.
   local global_db=""
@@ -1878,9 +2029,11 @@ cmd_recall() {
     global_db=$(find_global_db || true)
   fi
 
-  echo "## Recall: $query"
-  [ -n "$global_db" ] && echo "_(+ global brain: $global_db)_"
-  echo ""
+  if [ "$ids_only" != "1" ]; then
+    echo "## Recall: $query"
+    [ -n "$global_db" ] && echo "_(+ global brain: $global_db)_"
+    echo ""
+  fi
 
   # Collect local first (so a lesson present in both wins as the local copy), then
   # global, then dedup by 200-char insight key and cut to the limit. bm25() cannot
@@ -1892,10 +2045,21 @@ cmd_recall() {
   # the ACTUALLY-displayed rows, not the raw match set (the D9 / 5.1 bump-vs-display fix).
   local raw_local raw_global dedup out
   raw_local=$(_recall_emit "$DB" "$fts_query" "$like_clause" "" "$limit" 1 "local")
+  # Migration 015: fuse in semantic ranking when an embedding backend + vectors exist.
+  # No backend / no vectors -> raw_local returns unchanged (pure FTS, pre-015 behavior).
+  raw_local=$(_maybe_hybrid "$DB" "$query" "$raw_local" "$limit")
   raw_global=""
   [ -n "$global_db" ] && raw_global=$(_recall_emit "$global_db" "$fts_query" "$like_clause" " [global]" "$limit" 0 "global")
   dedup=$(printf '%s\n%s\n' "$raw_local" "$raw_global" | grep -v '^[[:space:]]*$' \
         | awk -F'@@US@@' '!seen[$1]++' | head -n "$limit")
+
+  # Eval mode: emit the surfaced ids only, in ranked order, with ZERO side effects
+  # (no events, no hit_count bumps) so repeated eval runs never mutate the corpus.
+  if [ "$ids_only" = "1" ]; then
+    printf '%s\n' "$dedup" | awk -F'@@US@@' 'NF>=4{print $3}'
+    return 0
+  fi
+
   out=$(printf '%s\n' "$dedup" | awk -F'@@US@@' 'NF{print $2}')
 
   if [ -n "$out" ]; then
@@ -2307,6 +2471,9 @@ case "${1:-help}" in
   resurrect)   shift; cmd_resurrect "$@" ;;
   antibody)    shift; cmd_antibody "$@" ;;
   recall)      shift; cmd_recall "$@" ;;
+  embed-sync)  shift; _ensure_embedding_cols; _embed_run sync "$DB" ;;
+  embed-status) shift; _embed_run backend || { echo "no embedding backend installed — recall is FTS-only (see: agentdb embed-init)"; exit 0; } ;;
+  embed-init)  shift; cmd_embed_init "$@" ;;
   export)      cmd_export ;;
   export-json) shift; cmd_export_json "$@" ;;
   import-json) shift; cmd_import_json "$@" ;;

--- a/orchestration/agentdb/embed.py
+++ b/orchestration/agentdb/embed.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""agentdb embedding backend — local, private, dependency-graceful.
+
+Produces sentence embeddings for learnings so recall can fuse keyword (FTS bm25)
+with semantic (cosine) ranking. Everything here degrades to a no-op if no backend
+is installed: the caller (the `agentdb` script) then uses pure FTS, exactly as before.
+
+Backends, tried in order (all yield L2-normalized float32 vectors):
+  - hash              : deterministic feature-hashing bag-of-words. NO dependency
+                        beyond numpy-optional (falls back to pure-Python). Used by
+                        kernel's own tests so CI needs no model download. Forced with
+                        AGENTDB_EMBED_BACKEND=hash. Real but weak — plumbing, not quality.
+  - fastembed         : ONNX all-MiniLM-L6-v2 (384d). ~50MB, no torch. Preferred real backend.
+  - sentence_transformers : torch all-MiniLM-L6-v2 (384d). The heavier locked backend.
+
+Subcommands:
+  backend            print "<name> <model> <dim>" and exit 0; exit 3 if none available
+  sync   <db>        embed every learning whose vector is missing/stale; write BLOBs
+  query  <db> <text> print "<id>\t<cosine>" for every embedded learning, ranked desc
+
+Vectors are stored as little-endian float32 bytes (numpy tobytes, or struct-packed
+in the pure-Python path). Model id + timestamp are stored so a model change re-embeds.
+"""
+import os
+import sys
+import sqlite3
+import struct
+import math
+
+MODEL_MINILM = "sentence-transformers/all-MiniLM-L6-v2"
+HASH_DIM = 256
+HASH_MODEL = "hash-bow-256-v1"
+
+# ---------------------------------------------------------------------------
+# numpy is optional. If present we use it (fast); if not, pure-Python fallback
+# keeps the hash backend working so the mechanism never hard-depends on numpy.
+try:
+    import numpy as _np
+except Exception:
+    _np = None
+
+
+def _l2_normalize(vec):
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0:
+        return vec
+    return [x / norm for x in vec]
+
+
+# ---------------------------------------------------------------------------
+# Backend: hash (deterministic, dependency-light)
+def _hash_embed(texts):
+    """Feature-hash each text into a fixed-dim L2-normalized vector. Deterministic:
+    same text -> same vector, on any machine, no model. Shared tokens -> nonzero
+    cosine, so it clusters related insights well enough to test the plumbing."""
+    out = []
+    for text in texts:
+        vec = [0.0] * HASH_DIM
+        toks = "".join(c.lower() if c.isalnum() else " " for c in text).split()
+        for tok in toks:
+            if len(tok) < 2:
+                continue
+            # stable hash (not Python's salted hash): FNV-1a
+            h = 2166136261
+            for ch in tok.encode("utf-8"):
+                h = ((h ^ ch) * 16777619) & 0xFFFFFFFF
+            idx = h % HASH_DIM
+            sign = 1.0 if (h >> 31) & 1 else -1.0
+            vec[idx] += sign
+        out.append(_l2_normalize(vec))
+    return out, HASH_MODEL, HASH_DIM
+
+
+# ---------------------------------------------------------------------------
+# Backend: fastembed (ONNX, no torch)
+_FASTEMBED = None
+
+
+def _fastembed_embed(texts):
+    global _FASTEMBED
+    if _FASTEMBED is None:
+        from fastembed import TextEmbedding
+        _FASTEMBED = TextEmbedding(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    vecs = [list(map(float, v)) for v in _FASTEMBED.embed(list(texts))]
+    vecs = [_l2_normalize(v) for v in vecs]
+    dim = len(vecs[0]) if vecs else 384
+    return vecs, MODEL_MINILM, dim
+
+
+# ---------------------------------------------------------------------------
+# Backend: sentence-transformers (torch)
+_ST = None
+
+
+def _st_embed(texts):
+    global _ST
+    if _ST is None:
+        from sentence_transformers import SentenceTransformer
+        _ST = SentenceTransformer("all-MiniLM-L6-v2")
+    embs = _ST.encode(list(texts), normalize_embeddings=True)
+    vecs = [list(map(float, row)) for row in embs]
+    dim = len(vecs[0]) if vecs else 384
+    return vecs, MODEL_MINILM, dim
+
+
+def _select_backend():
+    """Return (embed_fn, name) for the first available backend, or (None, None)."""
+    forced = os.environ.get("AGENTDB_EMBED_BACKEND", "").strip().lower()
+    if forced == "hash":
+        return _hash_embed, "hash"
+    if forced == "fastembed":
+        return _fastembed_embed, "fastembed"
+    if forced in ("sentence_transformers", "sentence-transformers", "st"):
+        return _st_embed, "sentence_transformers"
+    # auto: prefer the light real backend, then the heavy one. hash is opt-in only
+    # (never auto — it must not silently shadow a real model).
+    try:
+        import fastembed  # noqa: F401
+        return _fastembed_embed, "fastembed"
+    except Exception:
+        pass
+    try:
+        import sentence_transformers  # noqa: F401
+        return _st_embed, "sentence_transformers"
+    except Exception:
+        pass
+    return None, None
+
+
+def _pack(vec):
+    if _np is not None:
+        return _np.asarray(vec, dtype="<f4").tobytes()
+    return struct.pack("<%df" % len(vec), *vec)
+
+
+def _unpack(blob):
+    n = len(blob) // 4
+    if _np is not None:
+        return _np.frombuffer(blob, dtype="<f4", count=n)
+    return list(struct.unpack("<%df" % n, blob))
+
+
+def _cosine(a, b):
+    # vectors are already L2-normalized at embed time -> cosine is the dot product.
+    if _np is not None:
+        if a.shape != b.shape:
+            return -1.0
+        return float(a.dot(b))
+    if len(a) != len(b):
+        return -1.0
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _learning_text(insight, evidence, domain):
+    parts = [insight or ""]
+    if evidence:
+        parts.append(evidence)
+    if domain:
+        parts.append(domain)
+    return "\n".join(parts)
+
+
+def cmd_backend():
+    fn, name = _select_backend()
+    if fn is None:
+        sys.stderr.write("no embedding backend (install fastembed or sentence-transformers)\n")
+        return 3
+    # Probe: embed a trivial string to confirm the model actually loads + get dim.
+    try:
+        _, model, dim = fn(["probe"])
+    except Exception as exc:  # model download blocked / broken install
+        sys.stderr.write("backend %s present but failed to load: %s\n" % (name, exc))
+        return 3
+    print("%s %s %d" % (name, model, dim))
+    return 0
+
+
+def cmd_sync(db_path):
+    fn, name = _select_backend()
+    if fn is None:
+        sys.stderr.write("embed sync: no backend available; leaving embeddings NULL (recall stays FTS-only)\n")
+        return 3
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    cols = {r[1] for r in con.execute("PRAGMA table_info(learnings)")}
+    if "embedding" not in cols:
+        sys.stderr.write("embed sync: learnings.embedding column missing (run a recall/preflight first)\n")
+        return 4
+    arch = "AND archived_at IS NULL" if "archived_at" in cols else ""
+    # Re-embed rows with no vector, a different model, or a vector older than the row.
+    rows = con.execute(
+        "SELECT id, insight, evidence, domain FROM learnings "
+        "WHERE (embedding IS NULL OR embedding_model IS NULL OR embedding_model != ? "
+        "       OR embedding_ts IS NULL OR embedding_ts < ts) %s" % arch,
+        (MODEL_MINILM if name != "hash" else HASH_MODEL,),
+    ).fetchall()
+    if not rows:
+        print("embed sync: 0 to embed (all current) via %s" % name)
+        return 0
+    texts = [_learning_text(r["insight"], r["evidence"], r["domain"]) for r in rows]
+    vecs, model, _dim = fn(texts)
+    now = con.execute("SELECT strftime('%Y-%m-%dT%H:%M:%fZ','now')").fetchone()[0]
+    for r, v in zip(rows, vecs):
+        con.execute(
+            "UPDATE learnings SET embedding=?, embedding_model=?, embedding_ts=? WHERE id=?",
+            (_pack(v), model, now, r["id"]),
+        )
+    con.commit()
+    con.close()
+    print("embed sync: embedded %d learning(s) via %s (%s)" % (len(rows), name, model))
+    return 0
+
+
+def cmd_query(db_path, query_text):
+    fn, name = _select_backend()
+    if fn is None:
+        return 3  # silent: caller falls back to FTS
+    con = sqlite3.connect(db_path)
+    cols = {r[1] for r in con.execute("PRAGMA table_info(learnings)")}
+    if "embedding" not in cols:
+        return 4
+    arch = "AND archived_at IS NULL" if "archived_at" in cols else ""
+    vis = "AND (visibility='agent' OR visibility IS NULL)" if "visibility" in cols else ""
+    rows = con.execute(
+        "SELECT id, embedding FROM learnings WHERE embedding IS NOT NULL %s %s" % (arch, vis)
+    ).fetchall()
+    con.close()
+    if not rows:
+        return 5  # nothing embedded yet -> caller falls back to FTS
+    qvec, _model, _dim = fn([query_text])
+    q = _np.asarray(qvec[0], dtype="<f4") if _np is not None else qvec[0]
+    scored = []
+    for rid, blob in rows:
+        if not blob:
+            continue
+        scored.append((rid, _cosine(q, _unpack(blob))))
+    scored.sort(key=lambda t: t[1], reverse=True)
+    for rid, score in scored:
+        sys.stdout.write("%s\t%.6f\n" % (rid, score))
+    return 0
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("usage: embed.py {backend|sync <db>|query <db> <text>}\n")
+        return 2
+    cmd = argv[1]
+    if cmd == "backend":
+        return cmd_backend()
+    if cmd == "sync":
+        if len(argv) < 3:
+            sys.stderr.write("usage: embed.py sync <db>\n")
+            return 2
+        return cmd_sync(argv[2])
+    if cmd == "query":
+        if len(argv) < 4:
+            sys.stderr.write("usage: embed.py query <db> <text>\n")
+            return 2
+        return cmd_query(argv[2], " ".join(argv[3:]))
+    sys.stderr.write("unknown subcommand: %s\n" % cmd)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/orchestration/agentdb/eval/run_eval.py
+++ b/orchestration/agentdb/eval/run_eval.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""agentdb recall eval — measure retrieval quality, prove hybrid vs FTS-only.
+
+Runs the REAL shipped recall (`agentdb recall --ids`) against a gold set of
+task->should-surface-learning pairs, in two arms:
+  - baseline : AGENTDB_NO_EMBED=1  (pure FTS keyword recall, the pre-015 behavior)
+  - hybrid   : embedding backend enabled (FTS bm25 fused with semantic cosine, RRF)
+
+Metric: recall@k = mean over queries of |relevant ∩ top-k| / |relevant|.
+Also reports hit@k (fraction of queries with >=1 relevant id in top-k).
+
+This shells out to the actual agentdb binary so it measures what ships, not a
+reimplementation. The gold set is JSON: [{"query": "...", "relevant": ["id", ...]}].
+
+Usage:
+  run_eval.py --db <db> --gold <gold.json> [--k 5] [--backend hash|fastembed]
+              [--embed-python <python>]
+
+Exit 0 always (it's a measurement, not a gate); prints a JSON summary on the last
+line so callers (tests) can parse recall_baseline / recall_hybrid / delta.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENTDB = os.path.normpath(os.path.join(HERE, "..", "agentdb"))
+
+
+def recall_ids(db, query, env_extra, k):
+    env = dict(os.environ)
+    # db is <ROOT>/_meta/agentdb/agent.db -> AGENTDB_ROOT is the dir above _meta.
+    abs_db = os.path.abspath(db)
+    env["AGENTDB_ROOT"] = abs_db.split(os.sep + "_meta" + os.sep)[0]
+    env["RECALL_LIMIT"] = str(k)
+    env.update(env_extra)
+    try:
+        out = subprocess.run(
+            [AGENTDB, "recall", "--ids", query],
+            capture_output=True, text=True, env=env, timeout=60,
+        ).stdout
+    except Exception as exc:
+        sys.stderr.write("recall failed for %r: %s\n" % (query, exc))
+        return []
+    return [ln.strip() for ln in out.splitlines() if ln.strip()][:k]
+
+
+def score(gold, db, env_extra, k):
+    recalls, hits = [], []
+    per_query = []
+    for item in gold:
+        relevant = set(item["relevant"])
+        if not relevant:
+            continue
+        got = recall_ids(db, item["query"], env_extra, k)
+        topk = set(got[:k])
+        inter = relevant & topk
+        r = len(inter) / len(relevant)
+        recalls.append(r)
+        hits.append(1.0 if inter else 0.0)
+        per_query.append({"query": item["query"], "recall": r,
+                          "got": got[:k], "relevant": sorted(relevant)})
+    mean = lambda xs: (sum(xs) / len(xs)) if xs else 0.0
+    return mean(recalls), mean(hits), per_query
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--gold", required=True)
+    ap.add_argument("--k", type=int, default=5)
+    ap.add_argument("--backend", default="", help="hash|fastembed|sentence_transformers")
+    ap.add_argument("--embed-python", default="")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv[1:])
+
+    gold = json.load(open(args.gold))
+
+    base_env = {"AGENTDB_NO_EMBED": "1"}
+    hyb_env = {"AGENTDB_NO_EMBED": "0"}
+    if args.backend:
+        hyb_env["AGENTDB_EMBED_BACKEND"] = args.backend
+    if args.embed_python:
+        hyb_env["AGENTDB_EMBED_PYTHON"] = args.embed_python
+
+    r_base, h_base, pq_base = score(gold, args.db, base_env, args.k)
+    r_hyb, h_hyb, pq_hyb = score(gold, args.db, hyb_env, args.k)
+
+    if not args.quiet:
+        print("=" * 60)
+        print("agentdb recall eval  (k=%d, %d gold queries)" % (args.k, len(gold)))
+        print("  backend: %s" % (args.backend or "auto"))
+        print("-" * 60)
+        print("  FTS-only   recall@%d = %.3f   hit@%d = %.3f" % (args.k, r_base, args.k, h_base))
+        print("  HYBRID     recall@%d = %.3f   hit@%d = %.3f" % (args.k, r_hyb, args.k, h_hyb))
+        print("  delta      recall    = %+.3f            hit    = %+.3f" % (r_hyb - r_base, h_hyb - h_base))
+        print("=" * 60)
+        # show queries where hybrid changed the outcome
+        for b, hq in zip(pq_base, pq_hyb):
+            if abs(hq["recall"] - b["recall"]) > 1e-9:
+                arrow = "↑" if hq["recall"] > b["recall"] else "↓"
+                print("  %s %-52s %.2f -> %.2f" % (arrow, b["query"][:52], b["recall"], hq["recall"]))
+
+    print(json.dumps({
+        "k": args.k, "n": len(gold),
+        "recall_baseline": round(r_base, 4), "recall_hybrid": round(r_hyb, 4),
+        "hit_baseline": round(h_base, 4), "hit_hybrid": round(h_hyb, 4),
+        "delta_recall": round(r_hyb - r_base, 4),
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/orchestration/agentdb/migrations/015_learning_embeddings.sql
+++ b/orchestration/agentdb/migrations/015_learning_embeddings.sql
@@ -1,0 +1,20 @@
+-- Migration 015: semantic-recall embedding columns on learnings.
+--
+-- WHY (agentdb rethink, 2026-07-16): recall was FTS5 keyword-match only. It misses
+-- a learning whose wording differs from the task ("git write races" vs "index.lock
+-- contention"). This adds a stored sentence-embedding per learning so recall can
+-- fuse keyword (FTS bm25) with semantic (cosine) ranking via reciprocal-rank fusion.
+--
+-- DEGRADES GRACEFULLY: the column is inert until an embedding backend (fastembed or
+-- sentence-transformers, both -> all-MiniLM-L6-v2 / 384-dim) is installed and
+-- `agentdb embed-sync` has run. With no backend, `embedding` stays NULL and recall
+-- is byte-for-byte the old FTS-only behavior. No new hard dependency for any user.
+--
+-- COLUMNS (delegated to code like migrations 004/009/013/014): a raw ALTER here
+-- throws "duplicate column name" when preflight force-re-reads every migration to
+-- repair a dropped table. `_ensure_embedding_cols` owns the ALTER idempotently;
+-- schema.sql carries them for fresh DBs. This file records the marker only.
+--   embedding        BLOB  -- little-endian float32 vector (384 dims for MiniLM)
+--   embedding_model  TEXT  -- model id that produced it; a mismatch triggers re-embed
+--   embedding_ts     TEXT  -- when embedded; staleness vs learnings.ts is detectable
+INSERT OR IGNORE INTO _migrations (name) VALUES ('015_learning_embeddings');

--- a/orchestration/agentdb/schema.sql
+++ b/orchestration/agentdb/schema.sql
@@ -21,7 +21,10 @@ CREATE TABLE IF NOT EXISTS learnings (
   visibility TEXT DEFAULT 'agent',     -- agent | human_only | operational
   sensitivity TEXT DEFAULT 'low',      -- low | medium | high
   archived_at TEXT,                    -- migration 014: derived cache of latest archived event (NULL = live)
-  archived_reason TEXT                 -- migration 014: reason from that archived event
+  archived_reason TEXT,                -- migration 014: reason from that archived event
+  embedding BLOB,                      -- migration 015: little-endian float32 sentence vector (NULL until embed-sync)
+  embedding_model TEXT,                -- migration 015: model id that produced `embedding`
+  embedding_ts TEXT                    -- migration 015: when embedded (staleness vs ts detectable)
 );
 
 CREATE INDEX IF NOT EXISTS idx_learnings_type ON learnings(type);

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.2.0.
+Quick reference for KERNEL v8.3.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/fixtures/agentdb-eval/corpus.sql
+++ b/tests/fixtures/agentdb-eval/corpus.sql
@@ -1,0 +1,18 @@
+-- Portable eval fixture: a small synthetic learnings corpus with stable ids.
+-- Loaded into a fresh agentdb, embedded with the deterministic `hash` backend, and
+-- queried by gold.json. Proves the hybrid-recall MECHANISM (fusion runs, ids flow,
+-- never regresses vs FTS) with NO model download — CI-safe. Real semantic-quality
+-- gains are proven separately on the live corpus with fastembed (see the chronicle).
+INSERT INTO learnings (id, ts, type, insight, evidence, domain, visibility) VALUES
+ ('L01','2026-01-01T00:00:00Z','pattern','Serialize concurrent git commits with an fcntl.flock advisory mutex so a killed writer never orphans index.lock','flock auto-releases on death','git','agent'),
+ ('L02','2026-01-01T00:00:00Z','gotcha','A SessionStart hook exited 141 because head closed the pipe early under pipefail; drain with awk instead','SIGPIPE','hooks','agent'),
+ ('L03','2026-01-01T00:00:00Z','pattern','Fuse bm25 keyword ranking with cosine semantic ranking using reciprocal rank fusion for hybrid retrieval','RRF k=60','retrieval','agent'),
+ ('L04','2026-01-01T00:00:00Z','failure','A safety guard that auto-disables itself when its scanner fails is worse than no guard; fail closed','fail-open incident','security','agent'),
+ ('L05','2026-01-01T00:00:00Z','gotcha','Never commit a binary sqlite database to git; track a deterministic JSON mirror and rebuild on restore','blob bloat','database','agent'),
+ ('L06','2026-01-01T00:00:00Z','pattern','Replace a forgeable DANGER_OK env substring with a one-time nonce the human relays out of band','prompt injection cannot forge it','security','agent'),
+ ('L07','2026-01-01T00:00:00Z','pattern','Spawn a subagent only to protect context or buy real parallel wall clock, never for independence alone','cost test','orchestration','agent'),
+ ('L08','2026-01-01T00:00:00Z','gotcha','macOS launchd jobs fail with exit 126 when Full Disk Access is missing on the bash interpreter','TCC','automation','agent'),
+ ('L09','2026-01-01T00:00:00Z','failure','Reporting a task done off a commit hash instead of a live verification wasted repeated rounds','committed is not deployed','process','agent'),
+ ('L10','2026-01-01T00:00:00Z','pattern','Before deleting an empty submodule folder, check the git index mode 160000; it is uninitialized not junk','submodule investigation','git','agent'),
+ ('L11','2026-01-01T00:00:00Z','gotcha','Codex treats hook stdout starting with a bracket as JSON; side-effect hooks must log to stderr','JSON contract','hooks','agent'),
+ ('L12','2026-01-01T00:00:00Z','pattern','Scan tool output for invisible unicode tag characters and instruction-override phrasing as an injection tripwire','warn only','security','agent');

--- a/tests/fixtures/agentdb-eval/gold.json
+++ b/tests/fixtures/agentdb-eval/gold.json
@@ -1,0 +1,14 @@
+[
+  {"query": "how do I stop many processes racing on the same repository lock file", "relevant": ["L01"]},
+  {"query": "boot script crashed with a broken pipe signal during startup", "relevant": ["L02"]},
+  {"query": "combine lexical and vector search results into one ranking", "relevant": ["L03"]},
+  {"query": "should a security scanner turn itself off when it errors", "relevant": ["L04"]},
+  {"query": "storing a database file in version control diffs", "relevant": ["L05"]},
+  {"query": "unforgeable human approval token instead of an environment override", "relevant": ["L06"]},
+  {"query": "when is it worth delegating work to a parallel worker", "relevant": ["L07"]},
+  {"query": "scheduled background job on mac fails with a permissions error", "relevant": ["L08"]},
+  {"query": "why verifying against a live check matters more than a commit", "relevant": ["L09"]},
+  {"query": "an empty nested repository directory that should not be removed", "relevant": ["L10"]},
+  {"query": "hook output parsed as structured data breaking the tool", "relevant": ["L11"]},
+  {"query": "detect hidden characters trying to override the model instructions", "relevant": ["L12"]}
+]

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2849,7 +2849,7 @@ _AGENTDB_DIR="$PLUGIN_ROOT/orchestration/agentdb"
 
 test_embed_status_reports_hash_backend() {
   local out
-  out=$(AGENTDB_EMBED_BACKEND=hash python3 "$_AGENTDB_DIR/embed.py" backend 2>/dev/null)
+  out=$(env AGENTDB_EMBED_BACKEND=hash python3 "$_AGENTDB_DIR/embed.py" backend 2>/dev/null)
   case "$out" in hash\ *) : ;; *) echo "expected 'hash ...', got: $out"; return 1 ;; esac
 }
 
@@ -2902,7 +2902,7 @@ test_hybrid_never_regresses_on_fixture() {
   sqlite3 "$db" "INSERT INTO learnings_fts(learnings_fts) VALUES('rebuild');" 2>/dev/null
   AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
   local json base hyb
-  json=$(AGENTDB_EMBED_BACKEND=hash python3 "$_AGENTDB_DIR/eval/run_eval.py" \
+  json=$(env AGENTDB_EMBED_BACKEND=hash python3 "$_AGENTDB_DIR/eval/run_eval.py" \
     --db "$db" --gold "$PLUGIN_ROOT/tests/fixtures/agentdb-eval/gold.json" \
     --k 5 --backend hash --embed-python python3 --quiet 2>/dev/null)
   base=$(printf '%s' "$json" | sed -E 's/.*"recall_baseline": ([0-9.]+).*/\1/')
@@ -2920,7 +2920,7 @@ test_recall_fts_only_when_no_vectors() {
   agentdb recall "warmup" >/dev/null 2>&1
   local with_backend without
   without=$(agentdb recall --ids "governance template" 2>/dev/null)
-  with_backend=$(AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb recall --ids "governance template" 2>/dev/null)
+  with_backend=$(env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb recall --ids "governance template" 2>/dev/null)
   [ "$without" = "$with_backend" ] || { echo "recall differs with/without backend when no vectors exist"; return 1; }
 }
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2841,6 +2841,89 @@ test_read_start_bumps_load_count_not_hit_count() {
 
 # --- Recall Tests (FTS5 relevance retrieval, v7.15 quality pass) ---
 
+# === migration 015: semantic recall (embeddings) — CI-safe via the hash backend ===
+# The hash backend is deterministic + dependency-free (pure Python), so these tests
+# need NO model download. Real semantic quality (fastembed on the live corpus) is
+# proven separately in the release chronicle, not in CI.
+_AGENTDB_DIR="$PLUGIN_ROOT/orchestration/agentdb"
+
+test_embed_status_reports_hash_backend() {
+  local out
+  out=$(AGENTDB_EMBED_BACKEND=hash python3 "$_AGENTDB_DIR/embed.py" backend 2>/dev/null)
+  case "$out" in hash\ *) : ;; *) echo "expected 'hash ...', got: $out"; return 1 ;; esac
+}
+
+test_embed_no_backend_exits_3() {
+  # No backend installed + not forced -> exit 3 (caller falls back to FTS).
+  local ec=0
+  env -u AGENTDB_EMBED_BACKEND python3 "$_AGENTDB_DIR/embed.py" backend >/dev/null 2>&1 || ec=$?
+  # 3 = no backend; if a real backend happens to be installed in CI, 0 is also fine.
+  [ "$ec" = "3" ] || [ "$ec" = "0" ] || { echo "expected exit 3 or 0, got $ec"; return 1; }
+}
+
+test_embed_sync_writes_vectors() {
+  agentdb init >/dev/null
+  agentdb learn pattern "fuse keyword and semantic ranking with reciprocal rank fusion" "rrf" >/dev/null
+  agentdb recall "warmup" >/dev/null 2>&1   # ensures embedding cols + fts exist
+  AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
+  local n
+  n=$(sqlite3 "$CLAUDE_PROJECT_DIR/_meta/agentdb/agent.db" "SELECT count(*) FROM learnings WHERE embedding IS NOT NULL;")
+  [ "$n" -ge 1 ] || { echo "expected >=1 embedded row, got $n"; return 1; }
+}
+
+test_recall_ids_flag_is_side_effect_free() {
+  agentdb init >/dev/null
+  agentdb learn gotcha "SessionStart hook exited 141 SIGPIPE under pipefail" "sig" >/dev/null
+  local before after
+  before=$(sqlite3 "$CLAUDE_PROJECT_DIR/_meta/agentdb/agent.db" "SELECT COALESCE(SUM(hit_count),0) FROM learnings;")
+  agentdb recall --ids "sigpipe hook" >/dev/null 2>&1
+  after=$(sqlite3 "$CLAUDE_PROJECT_DIR/_meta/agentdb/agent.db" "SELECT COALESCE(SUM(hit_count),0) FROM learnings;")
+  [ "$before" = "$after" ] || { echo "--ids must not bump hit_count ($before -> $after)"; return 1; }
+}
+
+test_recall_ids_flag_prints_only_ids() {
+  agentdb init >/dev/null
+  agentdb learn pattern "serialize concurrent git writes with an flock mutex" "flock" >/dev/null
+  agentdb recall "warmup" >/dev/null 2>&1
+  local out
+  out=$(agentdb recall --ids "concurrent git writes" 2>/dev/null)
+  # every non-empty line must look like a learning id (LRN-...), no markdown header
+  printf '%s\n' "$out" | grep -qv '^LRN-' && { echo "non-id line in --ids output: $out"; return 1; }
+  printf '%s\n' "$out" | grep -q '^LRN-' || { echo "expected at least one LRN- id, got: $out"; return 1; }
+}
+
+test_hybrid_never_regresses_on_fixture() {
+  # Load the portable fixture corpus, embed with hash, run the eval. Hybrid recall@5
+  # must be >= FTS-only recall@5 (fusion never hurts) — the CI-safe mechanism proof.
+  local db="$CLAUDE_PROJECT_DIR/_meta/agentdb/agent.db"
+  agentdb init >/dev/null
+  agentdb recall "warmup" >/dev/null 2>&1   # create fts + embedding cols
+  sqlite3 "$db" < "$PLUGIN_ROOT/tests/fixtures/agentdb-eval/corpus.sql"
+  sqlite3 "$db" "INSERT INTO learnings_fts(learnings_fts) VALUES('rebuild');" 2>/dev/null
+  AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
+  local json base hyb
+  json=$(AGENTDB_EMBED_BACKEND=hash python3 "$_AGENTDB_DIR/eval/run_eval.py" \
+    --db "$db" --gold "$PLUGIN_ROOT/tests/fixtures/agentdb-eval/gold.json" \
+    --k 5 --backend hash --embed-python python3 --quiet 2>/dev/null)
+  base=$(printf '%s' "$json" | sed -E 's/.*"recall_baseline": ([0-9.]+).*/\1/')
+  hyb=$(printf '%s' "$json" | sed -E 's/.*"recall_hybrid": ([0-9.]+).*/\1/')
+  [ -n "$base" ] && [ -n "$hyb" ] || { echo "eval produced no numbers: $json"; return 1; }
+  awk -v b="$base" -v h="$hyb" 'BEGIN{exit !(h+1e-9 >= b)}' \
+    || { echo "hybrid recall@5 ($hyb) regressed below FTS ($base)"; return 1; }
+}
+
+test_recall_fts_only_when_no_vectors() {
+  # With embedding cols present but NO vectors synced, recall must behave exactly
+  # like pure FTS (the graceful-degradation guarantee).
+  agentdb init >/dev/null
+  agentdb learn pattern "kernel governance is generated from a template" "gen" >/dev/null
+  agentdb recall "warmup" >/dev/null 2>&1
+  local with_backend without
+  without=$(agentdb recall --ids "governance template" 2>/dev/null)
+  with_backend=$(AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb recall --ids "governance template" 2>/dev/null)
+  [ "$without" = "$with_backend" ] || { echo "recall differs with/without backend when no vectors exist"; return 1; }
+}
+
 test_recall_dedups_identical_insights() {
   agentdb init >/dev/null
   # Three identical insights (the clone problem). recall must return exactly one.
@@ -4887,6 +4970,13 @@ run_test_suite() {
       run_test "recall --global never leaks human_only" test_recall_global_no_human_leak
       run_test "recall survives sqlite control-char escaping" test_recall_survives_sqlite_control_char_escaping
       run_test "decay spares loaded (load_count>0) learnings" test_decay_spares_loaded_learnings
+      run_test "embed-status reports hash backend" test_embed_status_reports_hash_backend
+      run_test "embed no-backend exits 3 (FTS fallback)" test_embed_no_backend_exits_3
+      run_test "embed-sync writes vectors" test_embed_sync_writes_vectors
+      run_test "recall --ids is side-effect-free" test_recall_ids_flag_is_side_effect_free
+      run_test "recall --ids prints only ids" test_recall_ids_flag_prints_only_ids
+      run_test "hybrid never regresses on fixture (recall@5)" test_hybrid_never_regresses_on_fixture
+      run_test "recall FTS-only when no vectors (degradation)" test_recall_fts_only_when_no_vectors
       ;;
     learn)
       run_test "learn auto-populates domain from PWD" test_learn_auto_populates_domain


### PR DESCRIPTION
## KERNEL 8.3.0 "semantic recall"

Optional local semantic search for AgentDB recall, fused with the existing FTS keyword ranking. **Measured recall@5 0.75 → 0.85 (+0.10) on a real 47-learning corpus with a 20-query gold set, zero regressions.** The gain is entirely from queries whose wording shares no keywords with the stored learning.

### What's new
- **Local embeddings (migration 015):** `embedding` BLOB column, populated by `agentdb embed-sync`. Pluggable backend: `fastembed` (ONNX MiniLM, ~50MB, no torch) → `sentence-transformers` → deterministic `hash` (CI only). All on-machine, nothing leaves the computer.
- **Hybrid recall:** FTS bm25 fused with brute-force cosine via reciprocal-rank fusion (k=60). Corpus is small, so no vector DB / no ANN.
- **`embed-init` / `embed-sync` / `embed-status` / `recall --ids`** commands.
- **Eval harness** (`orchestration/agentdb/eval/run_eval.py`) runs the REAL shipped recall in FTS-only vs hybrid arms and reports recall@k. Portable fixture gold-set ships for CI.

### Degrades gracefully
With no backend installed, recall / read-start / the mirror are byte-for-byte the 8.2.0 behavior. Semantic recall is strictly additive and opt-in — no new hard dependency.

### Mirror correctness
Embedding vectors are derived data: excluded from the tracked JSON mirror, rebuilt via `embed-sync` on restore (like the FTS index). Round-trip verified end-to-end: export → restore → embed-sync reproduces every vector; 47 live + 20 archived rows preserved.

### Verification
- 416/416 tests pass (7 new in the recall suite: backend selection, no-backend degradation, vector write, `--ids` side-effect-freedom, hybrid-never-regresses-on-fixture, FTS-identical-when-no-vectors).
- Real fastembed eval on the live corpus: +0.10 recall@5 at k=3 and k=5, consistent.