### PR TITLE
feat: add context-led marketing site workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.4.0 cuts SessionStart context ~74% (a lean startup surface replaces the task-blind 50-learning dump; the agent recalls what its task needs via 8.3.0 semantic recall), on top of local semantic recall (fastembed/MiniLM, RRF fusion) and the 8.2.0 six-threat-class security guard.",
-      "version": "8.4.0"
+      "description": "Durable project memory, bounded JSON handoffs, 35 engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.5.0 adds context-led frontend and honest marketing-site methods, plus concrete repeatable AgentDB recall prompts while preserving the lean 8.4.0 startup surface.",
+      "version": "8.5.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "8.4.0",
-  "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.1.4 removes automatic lifecycle network and push sweeps.",
+  "version": "8.5.0",
+  "description": "Durable project memory, bounded JSON handoffs, 35 engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.5.0 adds context-led frontend and honest marketing-site methods, plus concrete repeatable AgentDB recall prompts.",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: b53fd6d863129a557069864b752ccc2713ae6de4641fa45c5c5cdc71bd46aeaf; adapter: codex -->
-<kernel version="8.4.0">
+     source-sha256: 217e339d59806b5839c31d163a34b1dca2e8ad6e64888d2aaa1cd3705749c02f; adapter: codex -->
+<kernel version="8.5.0">
 
 
 <!-- ============================================ -->
@@ -27,7 +27,7 @@
 
 <philosophy>
 Every AI-written line is a liability. Research proves solutions before coding.
-AgentDB-first. Read at start, write at end. Continuity depends on it.
+AgentDB-first. Recall before acting, write at end. Continuity depends on it.
 Stable governance lives here. Fast-changing run state lives in AgentDB and `_meta/`, not in governance docs.
 Most SWE work is solved problems. Find the solution, don't invent it.
 Default to implementing inline. Delegate only to protect context, buy real parallel wall-clock, or get independent verification, never for independence alone.
@@ -43,7 +43,8 @@ Ask at decision points. A 5-second question saves 5 minutes of wrong-direction w
 <!-- ============================================ -->
 
 <agentdb>
-agentdb read-start                                           # ON_START (mandatory)
+agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global  # Before acting
+agentdb read-start                                           # Full audit/resume context only
 agentdb write-end '{"did":"X","next":"Y","blocked":"Z"}'    # ON_END (mandatory)
 agentdb learn failure|pattern "what" "evidence"              # When discovered
 agentdb contract '{"goal":"X","constraints":"Y","tier":N}'  # Tier 2+
@@ -51,6 +52,9 @@ agentdb verdict pass|fail '{"tested":[],"evidence":"","issues":[]}'  # Adversary
 agentdb query "SELECT ..."                                   # Read agent output
 
 Location: _meta/agentdb/agent.db
+Use concrete task nouns, library/subsystem names, discovered paths/symbols, and exact
+errors or desired outcomes. Recall again after repo inspection reveals better terms,
+when scope or hypothesis changes, and whenever a new failure appears.
 </agentdb>
 
 <!-- ============================================ -->
@@ -63,7 +67,7 @@ Location: _meta/agentdb/agent.db
   <tier n="3" risk="high" role="orchestrator">Hard to undo, quiet if wrong, or wide blast radius. Contract → surgeon → adversary → verify.</tier>
 
   <rule>Tier by reversibility × silence × blast radius. File count is only a weak hint. Ambiguous = assume higher tier.</rule>
-  <rule>Read AgentDB at every tier. Implement inline by default; delegate to agents only when the work is heavy and file-disjoint, explicitly requested, or needs independent verification.</rule>
+  <rule>Recall from AgentDB at every tier. Implement inline by default; delegate to agents only when the work is heavy and file-disjoint, explicitly requested, or needs independent verification.</rule>
   <rule>IF tier >= 2: run $kernel:tearitapart before implementation.</rule>
 </tiers>
 
@@ -87,7 +91,7 @@ Location: _meta/agentdb/agent.db
 </agents>
 
 <flow>
-  Read context (agentdb read-start, _meta/research/) → research anti-patterns before solutions →
+  Recall task context (agentdb recall with concrete keywords, _meta/research/) → research anti-patterns before solutions →
   tier the work → define success before coding → execute (inline by default; delegate heavy file-disjoint work → surgeon → verify) → learn (agentdb learn).
   Never implement the first idea: generate 2-3 approaches, choose simplest. Details live in the skills, not here.
 </flow>
@@ -213,7 +217,8 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <skill id="orchestration" triggers="multi-agent, parallel, tier 2+">Multi-agent coordination. AgentDB contracts, 4 fault tolerance layers, context transfer.</skill>
   <skill id="context-mgmt" triggers="compaction, handoff, memory, tokens">Context engineering. Progressive disclosure, AgentDB offloading, compaction strategies. Use native /context for usage check.</skill>
 
-  <skill id="frontend" triggers="UI, frontend, styling, visual">$kernel:frontend skill. Anti-convergence aesthetic. Mood variants: abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal.</skill>
+  <skill id="frontend" triggers="UI, frontend, styling, visual">Context-led interface design. Derive art direction from product, audience, brand, content, and the existing design system; mood variants are optional lenses.</skill>
+  <skill id="marketing-site" triggers="marketing site, landing page, company website, client website, conversion, positioning, CTA">Honest marketing-site strategy: audience, offer, proof, objections, action, privacy, art direction, and client handoff.</skill>
   <skill id="app-dev" triggers="app, mobile, store submission, build, deploy, fastlane">Mobile/web build pipeline: fastlane-first local builds, store submission, pre-submission checklists. EAS only as a stated exception.</skill>
 
   <!-- EXPERIMENTATION -->
@@ -227,7 +232,7 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
 
 <anti_patterns>
   <!-- Critical only. Extended rules: _meta/reference/heuristics.md, conventions.md -->
-  <block action="skip_agentdb_read">Read at start, prior failures and patterns inform this session.</block>
+  <block action="skip_agentdb_recall">Recall before acting and again when the task's files, scope, hypothesis, or failure changes.</block>
   <block action="skip_agentdb_write">Write at end, next session needs your learnings.</block>
   <block action="skip_research">Reinvent solved problems. Check _meta/research/ first.</block>
   <block action="solution_before_antipattern">Search what breaks BEFORE what works.</block>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.5.0] - 2026-07-16 "context before style"
+
+Turns frontend guidance from a fixed visual recipe into product judgment, adds an
+ambient marketing/client-site methodology, and makes semantic recall easier to use well.
+
+### Added
+- **`marketing-site` methodology** for landing pages, product/company sites, portfolios,
+  campaigns, and client websites. It covers audience, positioning, offer, proof,
+  objections, CTA, privacy reality, and client delivery without deploying on its own.
+- **Client delivery checklist** for approvals, asset rights, account ownership,
+  launch/rollback, editable handoff, and ongoing privacy/maintenance responsibility.
+- **Regression contracts** for skill composition, ambient/explicit safety, context-led
+  frontend behavior, concrete recall keywords, rerun triggers, and lean-output size.
+
+### Changed
+- **`frontend` v2 is context-led.** Product, audience, brand, content, repository design
+  system, accessibility, performance, and rendered visual QA are hard bars. Fonts,
+  asymmetry, gradients, layered dark surfaces, huge type, and motion are contextual tools,
+  not Kernel's mandatory house style. Existing mood variants remain optional lenses.
+- **`landing-page` v2 composes `marketing-site` + `frontend`.** It stays explicit-only,
+  follows the project's configured stack/deploy target, treats a user's named deploy
+  request as confirmation, verifies 375/768/1440 output, and checks live nested assets,
+  legal pages, and conversion paths after deployment.
+- **AgentDB recall now teaches a concrete query recipe:** feature + subsystem/library +
+  files/symbols + exact error or desired outcome. Startup, build, debug, diagnose, help,
+  and the CLI guide say to recall again after discovery, scope/hypothesis changes, or a
+  new failure. The lean startup surface remains capped by regression at 12 lines.
+
 ## [8.4.0] - 2026-07-16 "lean session"
 
 Cuts the SessionStart context injection from ~3,700 tokens to ~950 — a **74% reduction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: b53fd6d863129a557069864b752ccc2713ae6de4641fa45c5c5cdc71bd46aeaf; adapter: claude -->
-<kernel version="8.4.0">
+     source-sha256: 217e339d59806b5839c31d163a34b1dca2e8ad6e64888d2aaa1cd3705749c02f; adapter: claude -->
+<kernel version="8.5.0">
 
 
 <!-- ============================================ -->
@@ -27,7 +27,7 @@
 
 <philosophy>
 Every AI-written line is a liability. Research proves solutions before coding.
-AgentDB-first. Read at start, write at end. Continuity depends on it.
+AgentDB-first. Recall before acting, write at end. Continuity depends on it.
 Stable governance lives here. Fast-changing run state lives in AgentDB and `_meta/`, not in governance docs.
 Most SWE work is solved problems. Find the solution, don't invent it.
 Default to implementing inline. Delegate only to protect context, buy real parallel wall-clock, or get independent verification, never for independence alone.
@@ -43,7 +43,8 @@ Ask at decision points. A 5-second question saves 5 minutes of wrong-direction w
 <!-- ============================================ -->
 
 <agentdb>
-agentdb read-start                                           # ON_START (mandatory)
+agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global  # Before acting
+agentdb read-start                                           # Full audit/resume context only
 agentdb write-end '{"did":"X","next":"Y","blocked":"Z"}'    # ON_END (mandatory)
 agentdb learn failure|pattern "what" "evidence"              # When discovered
 agentdb contract '{"goal":"X","constraints":"Y","tier":N}'  # Tier 2+
@@ -51,6 +52,9 @@ agentdb verdict pass|fail '{"tested":[],"evidence":"","issues":[]}'  # Adversary
 agentdb query "SELECT ..."                                   # Read agent output
 
 Location: _meta/agentdb/agent.db
+Use concrete task nouns, library/subsystem names, discovered paths/symbols, and exact
+errors or desired outcomes. Recall again after repo inspection reveals better terms,
+when scope or hypothesis changes, and whenever a new failure appears.
 </agentdb>
 
 <!-- ============================================ -->
@@ -63,7 +67,7 @@ Location: _meta/agentdb/agent.db
   <tier n="3" risk="high" role="orchestrator">Hard to undo, quiet if wrong, or wide blast radius. Contract → surgeon → adversary → verify.</tier>
 
   <rule>Tier by reversibility × silence × blast radius. File count is only a weak hint. Ambiguous = assume higher tier.</rule>
-  <rule>Read AgentDB at every tier. Implement inline by default; delegate to agents only when the work is heavy and file-disjoint, explicitly requested, or needs independent verification.</rule>
+  <rule>Recall from AgentDB at every tier. Implement inline by default; delegate to agents only when the work is heavy and file-disjoint, explicitly requested, or needs independent verification.</rule>
   <rule>IF tier >= 2: run /kernel:tearitapart before implementation.</rule>
 </tiers>
 
@@ -87,7 +91,7 @@ Location: _meta/agentdb/agent.db
 </agents>
 
 <flow>
-  Read context (agentdb read-start, _meta/research/) → research anti-patterns before solutions →
+  Recall task context (agentdb recall with concrete keywords, _meta/research/) → research anti-patterns before solutions →
   tier the work → define success before coding → execute (inline by default; delegate heavy file-disjoint work → surgeon → verify) → learn (agentdb learn).
   Never implement the first idea: generate 2-3 approaches, choose simplest. Details live in the skills, not here.
 </flow>
@@ -213,7 +217,8 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <skill id="orchestration" triggers="multi-agent, parallel, tier 2+">Multi-agent coordination. AgentDB contracts, 4 fault tolerance layers, context transfer.</skill>
   <skill id="context-mgmt" triggers="compaction, handoff, memory, tokens">Context engineering. Progressive disclosure, AgentDB offloading, compaction strategies. Use native /context for usage check.</skill>
 
-  <skill id="frontend" triggers="UI, frontend, styling, visual">/kernel:frontend skill. Anti-convergence aesthetic. Mood variants: abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal.</skill>
+  <skill id="frontend" triggers="UI, frontend, styling, visual">Context-led interface design. Derive art direction from product, audience, brand, content, and the existing design system; mood variants are optional lenses.</skill>
+  <skill id="marketing-site" triggers="marketing site, landing page, company website, client website, conversion, positioning, CTA">Honest marketing-site strategy: audience, offer, proof, objections, action, privacy, art direction, and client handoff.</skill>
   <skill id="app-dev" triggers="app, mobile, store submission, build, deploy, fastlane">Mobile/web build pipeline: fastlane-first local builds, store submission, pre-submission checklists. EAS only as a stated exception.</skill>
 
   <!-- EXPERIMENTATION -->
@@ -227,7 +232,7 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
 
 <anti_patterns>
   <!-- Critical only. Extended rules: _meta/reference/heuristics.md, conventions.md -->
-  <block action="skip_agentdb_read">Read at start, prior failures and patterns inform this session.</block>
+  <block action="skip_agentdb_recall">Recall before acting and again when the task's files, scope, hypothesis, or failure changes.</block>
   <block action="skip_agentdb_write">Write at end, next session needs your learnings.</block>
   <block action="skip_research">Reinvent solved problems. Check _meta/research/ first.</block>
   <block action="solution_before_antipattern">Search what breaks BEFORE what works.</block>

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Useful skill groups:
 - Workflows: `ingest`, `diagnose`, `dream`, `metrics`, `forge`, `experiment`
 - State: `handoff`, `checkpoint`, `retrospective`
 - Validation: `validate`, `review`, `tearitapart`
-- Methods: `build`, `testing`, `debug`, `security`, `architecture`, `git`, `frontend`, and more
+- Methods: `build`, `testing`, `debug`, `security`, `architecture`, `git`, `frontend`, `marketing-site`, and more
 - Setup/reference: `init`, `help`, `landing-page`
 
-There are 24 skills and 10 specialized Claude Code agent definitions in this release.
+There are 35 skills and 15 specialized Claude Code agent definitions in this release.
 
 `governance-sync` is explicit-only. It audits Git repositories for `CLAUDE.md` /
 `AGENTS.md` gaps and can generate a missing native adapter after showing conflicts,
@@ -178,8 +178,10 @@ quality yourself with `orchestration/agentdb/eval/run_eval.py` against a gold se
 Because recall is now task-driven, the SessionStart context is lean: a learning count, a
 `agentdb recall` pointer, and the top few highest-hit failures — about 950 tokens, down
 from ~3,700 when startup dumped ~50 task-blind learnings every session. The agent recalls
-what its task needs instead of receiving everything up front. Run `agentdb read-start`
-explicitly (no flag) any time you want the full weighted memory dump.
+what its task needs instead of receiving everything up front. Recall with concrete nouns:
+feature + subsystem/library + discovered files/symbols + exact error or desired outcome.
+Run it again after discovery, when scope or hypothesis changes, or when a new failure appears.
+Run `agentdb read-start` explicitly (no flag) only when you want the full weighted memory dump.
 
 KERNEL hooks can inspect repository state, run configured checks, and write these records.
 Claude Code runs the full declared lifecycle. Codex runs supported synchronous hook

--- a/_meta/plans/kernel-marketing-recall.md
+++ b/_meta/plans/kernel-marketing-recall.md
@@ -1,0 +1,28 @@
+# Kernel marketing + recall contract
+
+Goal: make frontend work context-led, add reusable marketing/client judgment, keep explicit landing-page shipping simple, and make AgentDB recall easier to use well.
+
+## Scope
+
+- Refactor `skills/frontend/SKILL.md`: product/brand fit, hierarchy, accessibility, responsive behavior, performance, and visual QA are hard bars; specific aesthetics become optional direction.
+- Add ambient `skills/marketing-site/`: audience, offer, proof, objections, CTA, privacy, and client handoff. It may advise, never deploy.
+- Refactor explicit-only `skills/landing-page/` to compose marketing + frontend and handle scaffold, verification, and provider-neutral deployment.
+- Put a compact keyword recipe and rerun triggers in canonical governance and `agentdb read-start --lean`.
+- Reinforce recall at high-frequency build/debug/diagnose entry points without copying a long policy everywhere.
+
+## Acceptance
+
+- Normal-language marketing/client website requests can surface `marketing-site`; deployment still requires explicit `landing-page` invocation or direct user authorization.
+- Frontend preserves an existing design system and derives art direction from evidence; no universal font/layout/color recipe remains.
+- Marketing guidance forbids invented testimonials, customers, metrics, guarantees, or fake urgency.
+- Recall says to use feature/subsystem, files/symbols, and exact error/outcome keywords; rerun after discovery, scope/hypothesis change, or a new failure.
+- Lean memory output remains compact and generated governance stays byte-synced.
+- Targeted regressions and the full suite pass; unrelated dirty files remain unstaged.
+
+## Verification
+
+1. Run focused skill, governance, recall, and migration tests.
+2. Generate and check native governance adapters.
+3. Run the full test suite and skill validator.
+4. Review the exact diff, bump minor version, validate release docs.
+5. Merge/tag/push through the repository release flow, upgrade marketplace install, and inspect the installed payload.

--- a/_meta/reviews/kernel-marketing-recall-review.md
+++ b/_meta/reviews/kernel-marketing-recall-review.md
@@ -1,0 +1,43 @@
+# Code review: Kernel 8.5.0 marketing + recall
+
+Verdict: APPROVE
+
+## Scope reviewed
+
+- Frontend v2, marketing-site v1, landing-page v2, client-delivery reference.
+- Recall recipe/rerun behavior in governance, generated startup, AgentDB lean/guide/help,
+  build, debug, and diagnose.
+- Version, release docs, inventory, regression tests, and generated adapters.
+
+## Findings resolved
+
+1. Removed duplicate `marketing-site` registration from the workflow registry; it belongs
+   once in the methodology registry.
+2. Updated stale README/Quickstart skill counts to 35 and kept the Claude/Codex agent
+   boundary explicit.
+3. Replaced remaining governance/help language that made full `read-start` sound mandatory;
+   task recall is primary, full read is for audit/resume.
+4. Kept the lean surface bounded (regression max 12 lines) while adding the concrete recipe.
+5. Preserved landing-page explicit-only deployment and made existing user deploy intent count.
+
+## Verification
+
+- Focused marketing, read-start, governance, release-doc, version-sync suites: pass.
+- Full suite: 426 passed, 0 failed.
+- Generated governance: current.
+- `git diff --check`: pass.
+- `agents/openai.yaml`: parses as YAML.
+- Generic skill-creator validator cannot validate Kernel's extended frontmatter keys
+  (`kernel`, `user-invocable`, `disable-model-invocation`); Kernel's own taxonomy/frontmatter
+  tests pass. Safety metadata was not weakened for generic compatibility.
+
+## Release isolation
+
+- Git ref writes fail with `Operation not permitted` in the nested submodule metadata, so the
+  release branch was built in a clean temporary clone from `origin/main`.
+- Concurrent user-owned AgentDB graph work is modifying `orchestration/agentdb/agentdb`,
+  `tests/run-tests.sh`, eval code, migration 016, and `graph.py`. Those changes are excluded
+  from the clean release diff.
+- Clean clone: 421/422 in one run; the sole failure was the sandbox refusing to rewrite the
+  real installed-plugin selector. The same compaction suite passed 8/8 with a disposable cache
+  selector. The source checkout passed 426/426, including the concurrent graph tests.

--- a/_meta/reviews/kernel-marketing-recall-teardown.md
+++ b/_meta/reviews/kernel-marketing-recall-teardown.md
@@ -1,0 +1,22 @@
+# Pre-build teardown: marketing + recall
+
+Verdict: PROCEED
+
+## What could break
+
+1. **Frontend becomes mush.** Removing style mandates can leave generic advice. Keep objective gates and require an explicit art-direction rationale plus visual QA.
+2. **A new house style survives under softer wording.** Treat variants as opt-in lenses; tests should reject the old unconditional font/layout/surface bans.
+3. **Marketing invents proof.** Hard-block fabricated customers, testimonials, metrics, guarantees, scarcity, and “trusted by” decoration.
+4. **Ambient advice causes side effects.** `marketing-site` must be methodology-only. `landing-page` stays explicit-only because it can deploy.
+5. **Recall bloats every session.** Add at most a compact recipe and rerun sentence. Full explanation belongs in governance/workflows, not the hook payload.
+6. **Recall guidance drifts.** Canonical governance generates both native files and the hook block; regressions assert the same concrete keyword families.
+7. **Provider assumptions age badly.** Landing deployment follows project config/user target first; Cloudflare Workers Static Assets is an example, not a universal default.
+8. **Concurrent work is swallowed.** Exclude `_meta/.session_id` and `orchestration/agentdb/eval/run_eval.py` from staging and diff review.
+
+## Required proof
+
+- Failing tests first for new skill routing/composition and recall language.
+- Targeted suites green before the full suite.
+- Generated governance check green.
+- Final staged diff contains only contract scope.
+- Installed marketplace payload contains the new skill and keyword recipe after release.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -119,7 +119,7 @@ was removed.
 
 ## Codex behavior boundaries
 
-Codex loads all 34 KERNEL skills, with explicit calls written as `$kernel:<name>`.
+Codex loads all 35 KERNEL skills, with explicit calls written as `$kernel:<name>`.
 Use `$kernel:governance-sync` (or Claude's `/kernel:governance-sync`) to audit native
 instruction coverage. Writes require explicit confirmation and a backup directory.
 Explicit-only skills (5): `experiment`, `forge`, `governance-sync`, `init`,

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -4,11 +4,13 @@
 ## KERNEL quick reference
 
 ```
-agentdb recall "<task keywords>" [--global]        # relevance lookup before acting
+agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" [--global]
 agentdb learn failure|pattern|gotcha "what" "why"  # capture as discovered
 agentdb write-end '{"did":"X","learned":["Y"]}'    # at session end
 agentdb wtf                                        # confused? full ref: agentdb guide
 ```
+
+Recall with concrete nouns, not prose. Recall again after discovery, when scope/hypothesis changes, or on a new failure.
 
 Optimize for the fastest correct, robust path. Tier by reversibility x blast radius, NOT file count. Gate hard only where an op is irreversible. T1 execute, T2 plan+verify, T3 confirm.
 Default is inline. Spawn a subagent only to protect context, to buy real wall-clock on heavy file-disjoint work, when explicitly asked, or for independent verification, never for independence alone. When work is genuinely high-blast-radius or delegated, contract it, then verify with an adversary.
@@ -39,7 +41,7 @@ KERNEL_AMBIENT_SOURCE_END -->
 
 <philosophy>
 Every AI-written line is a liability. Research proves solutions before coding.
-AgentDB-first. Read at start, write at end. Continuity depends on it.
+AgentDB-first. Recall before acting, write at end. Continuity depends on it.
 Stable governance lives here. Fast-changing run state lives in AgentDB and `_meta/`, not in governance docs.
 Most SWE work is solved problems. Find the solution, don't invent it.
 Default to implementing inline. Delegate only to protect context, buy real parallel wall-clock, or get independent verification, never for independence alone.
@@ -55,7 +57,8 @@ Ask at decision points. A 5-second question saves 5 minutes of wrong-direction w
 <!-- ============================================ -->
 
 <agentdb>
-agentdb read-start                                           # ON_START (mandatory)
+agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global  # Before acting
+agentdb read-start                                           # Full audit/resume context only
 agentdb write-end '{"did":"X","next":"Y","blocked":"Z"}'    # ON_END (mandatory)
 agentdb learn failure|pattern "what" "evidence"              # When discovered
 agentdb contract '{"goal":"X","constraints":"Y","tier":N}'  # Tier 2+
@@ -63,6 +66,9 @@ agentdb verdict pass|fail '{"tested":[],"evidence":"","issues":[]}'  # Adversary
 agentdb query "SELECT ..."                                   # Read agent output
 
 Location: _meta/agentdb/agent.db
+Use concrete task nouns, library/subsystem names, discovered paths/symbols, and exact
+errors or desired outcomes. Recall again after repo inspection reveals better terms,
+when scope or hypothesis changes, and whenever a new failure appears.
 </agentdb>
 
 <!-- ============================================ -->
@@ -75,7 +81,7 @@ Location: _meta/agentdb/agent.db
   <tier n="3" risk="high" role="orchestrator">Hard to undo, quiet if wrong, or wide blast radius. Contract → surgeon → adversary → verify.</tier>
 
   <rule>Tier by reversibility × silence × blast radius. File count is only a weak hint. Ambiguous = assume higher tier.</rule>
-  <rule>Read AgentDB at every tier. Implement inline by default; delegate to agents only when the work is heavy and file-disjoint, explicitly requested, or needs independent verification.</rule>
+  <rule>Recall from AgentDB at every tier. Implement inline by default; delegate to agents only when the work is heavy and file-disjoint, explicitly requested, or needs independent verification.</rule>
   <rule>IF tier >= 2: run {{INVOKE_PREFIX}}tearitapart before implementation.</rule>
 </tiers>
 
@@ -99,7 +105,7 @@ Location: _meta/agentdb/agent.db
 </agents>
 
 <flow>
-  Read context (agentdb read-start, _meta/research/) → research anti-patterns before solutions →
+  Recall task context (agentdb recall with concrete keywords, _meta/research/) → research anti-patterns before solutions →
   tier the work → define success before coding → execute (inline by default; delegate heavy file-disjoint work → surgeon → verify) → learn (agentdb learn).
   Never implement the first idea: generate 2-3 approaches, choose simplest. Details live in the skills, not here.
 </flow>
@@ -225,7 +231,8 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <skill id="orchestration" triggers="multi-agent, parallel, tier 2+">Multi-agent coordination. AgentDB contracts, 4 fault tolerance layers, context transfer.</skill>
   <skill id="context-mgmt" triggers="compaction, handoff, memory, tokens">Context engineering. Progressive disclosure, AgentDB offloading, compaction strategies. Use native /context for usage check.</skill>
 
-  <skill id="frontend" triggers="UI, frontend, styling, visual">{{INVOKE_PREFIX}}frontend skill. Anti-convergence aesthetic. Mood variants: abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal.</skill>
+  <skill id="frontend" triggers="UI, frontend, styling, visual">Context-led interface design. Derive art direction from product, audience, brand, content, and the existing design system; mood variants are optional lenses.</skill>
+  <skill id="marketing-site" triggers="marketing site, landing page, company website, client website, conversion, positioning, CTA">Honest marketing-site strategy: audience, offer, proof, objections, action, privacy, art direction, and client handoff.</skill>
   <skill id="app-dev" triggers="app, mobile, store submission, build, deploy, fastlane">Mobile/web build pipeline: fastlane-first local builds, store submission, pre-submission checklists. EAS only as a stated exception.</skill>
 
   <!-- EXPERIMENTATION -->
@@ -239,7 +246,7 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
 
 <anti_patterns>
   <!-- Critical only. Extended rules: _meta/reference/heuristics.md, conventions.md -->
-  <block action="skip_agentdb_read">Read at start, prior failures and patterns inform this session.</block>
+  <block action="skip_agentdb_recall">Recall before acting and again when the task's files, scope, hypothesis, or failure changes.</block>
   <block action="skip_agentdb_write">Write at end, next session needs your learnings.</block>
   <block action="skip_research">Reinvent solved problems. Check _meta/research/ first.</block>
   <block action="solution_before_antipattern">Search what breaks BEFORE what works.</block>

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -125,11 +125,13 @@ cat << 'KERNEL_CONTEXT'
 ## KERNEL quick reference
 
 ```
-agentdb recall "<task keywords>" [--global]        # relevance lookup before acting
+agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" [--global]
 agentdb learn failure|pattern|gotcha "what" "why"  # capture as discovered
 agentdb write-end '{"did":"X","learned":["Y"]}'    # at session end
 agentdb wtf                                        # confused? full ref: agentdb guide
 ```
+
+Recall with concrete nouns, not prose. Recall again after discovery, when scope/hypothesis changes, or on a new failure.
 
 Optimize for the fastest correct, robust path. Tier by reversibility x blast radius, NOT file count. Gate hard only where an op is irreversible. T1 execute, T2 plan+verify, T3 confirm.
 Default is inline. Spawn a subagent only to protect context, to buy real wall-clock on heavy file-disjoint work, when explicitly asked, or for independent verification, never for independence alone. When work is genuinely high-blast-radius or delegated, contract it, then verify with an adversary.

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -1,11 +1,11 @@
 #!/bin/bash
 # KERNEL AgentDB CLI
-# Every agent reads on start, writes on end. No exceptions.
+# Every agent recalls task context before acting and writes on end. No exceptions.
 #
 # USAGE:
 #   agentdb init                    # Initialize per-project DB
-#   agentdb read-start              # Generic top-N learnings (session start)
-#   agentdb recall <keywords>       # RELEVANCE search — the right learning for THIS task (FTS5)
+#   agentdb recall <keywords>       # Task-relevant context; rerun as the task changes
+#   agentdb read-start              # Full generic top-N context for audit/resume
 #   agentdb write-end <json>        # Checkpoint before stopping
 #   agentdb learn <type> <insight>  # Record learning
 #   agentdb contract <json>         # Create contract
@@ -513,7 +513,9 @@ cmd_read_start() {
       local n_all n_fail top_fail
       n_all=$(db_exec "SELECT COUNT(*) FROM learnings WHERE archived_at IS NULL;" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
       n_fail=$(db_exec "SELECT COUNT(*) FROM learnings WHERE archived_at IS NULL AND type IN ('failure','gotcha');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
-      echo "## Memory: ${n_all} learnings (${n_fail} failures/gotchas). For this task run: agentdb recall \"<keywords>\""
+      echo "## Memory: ${n_all} learnings (${n_fail} failures/gotchas)."
+      echo "Recall now: agentdb recall \"<feature> <subsystem> <files/symbols> <error/outcome>\" [--global]"
+      echo "Recall again when scope, files, hypothesis, or failure changes. Use concrete nouns, not prose."
       echo ""
       top_fail=$(db_exec "SELECT '- [' || type || '] ' || insight FROM learnings WHERE archived_at IS NULL AND type IN ('failure','gotcha') ORDER BY hit_count DESC, ts DESC LIMIT 5;" 2>/dev/null)
       if [ -n "$top_fail" ]; then
@@ -1117,7 +1119,9 @@ cmd_guide() {
   cat <<'GUIDE'
 # AgentDB Quick Reference
 
-Starting work?      agentdb read-start
+Starting work?      agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global
+New files/failure?  Recall again with the new concrete nouns
+Full audit/resume?  agentdb read-start
 Something broke?    agentdb wtf
 Learned something?  agentdb learn failure "description" "evidence"
                     agentdb learn pattern "description" "evidence"
@@ -2524,7 +2528,8 @@ case "${1:-help}" in
     echo "CORE COMMANDS:"
     echo "  init                    Initialize DB + apply migrations"
     echo "  preflight               Validate schema + environment health"
-    echo "  read-start              Context for starting work"
+    echo "  recall <keywords> [--global]  Task context; rerun as files/scope/failure change"
+    echo "  read-start              Full generic context for audit/resume"
     echo "  write-end <json>        Checkpoint before stopping"
     echo "  learn <type> <insight>  Record learning (failure|pattern|gotcha|preference)"
     echo "  contract <json>         Create new contract"

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -11,8 +11,9 @@ kernel:
 
 # BUILD SKILL
 
-Prerequisite: AgentDB read-start has run. Reference on demand:
-skills/build/reference/build-research.md.
+Prerequisite: run `agentdb recall` with the feature, subsystem/library, known files or
+symbols, and desired outcome. Run it again after repository inspection reveals better
+paths/symbols or the scope changes. Reference on demand: skills/build/reference/build-research.md.
 
 ## Goal first
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -19,8 +19,10 @@ The failure you see is NOT where the bug is. Binary search upstream.
 Systematic methodology beats ad-hoc guessing. The process is the multiplier.
 </purpose>
 
-<prerequisite>AgentDB read-start has run; check past failures, you may have seen this
-pattern. Reference on demand: skills/debug/reference/debug-research.md.</prerequisite>
+<prerequisite>Run `agentdb recall` with the exact error text, subsystem/library, failing
+test, and known files/symbols. Recall again when the hypothesis changes or a new failure
+appears; that is a new retrieval question. Reference on demand:
+skills/debug/reference/debug-research.md.</prerequisite>
 
 <steps>
 1. **REPRODUCE**: get specific before touching code.

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -19,7 +19,9 @@ Mixing diagnosis with implementation means the surgeon starts cutting before the
 </purpose>
 
 <on_start>
-agentdb read-start   # surface prior failures/gotchas first — a known bug class shortcuts the diagnosis
+agentdb recall "<exact error> <subsystem> <test> <files/symbols>" --global
+# Recall again after isolation reveals better symbols, when the hypothesis changes,
+# or when a different failure appears.
 </on_start>
 
 <skill_load>

--- a/skills/frontend/SKILL.md
+++ b/skills/frontend/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: frontend
-description: "Frontend aesthetics and UI implementation. Break generic AI aesthetic patterns. Create distinctive, surprising interfaces. Supports mood variants that guide aesthetic direction without constraining execution. Triggers: frontend, ui, styling, css, visual, theme, component, layout, aesthetic, abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal."
+description: "Context-led frontend design and UI implementation. Derives art direction from the product, audience, brand, content, and existing design system; prevents generic AI defaults without imposing a Kernel house style. Triggers: frontend, ui, styling, css, visual, theme, component, layout, responsive, accessibility, design system, aesthetic, abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal."
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 kernel:
   kind: methodology
-  version: 1
+  version: 2
   side_effects: none
   confirmation: none
 ---
@@ -12,101 +12,97 @@ kernel:
 <skill id="frontend">
 
 <purpose>
-Break distributional convergence. Every generation must feel intentional and distinct.
-Generic AI aesthetic ("slop") is the failure mode.
-You are good at CSS. You are bad at breaking patterns. This skill fixes the latter.
+Make interfaces feel intentional because their visual choices fit the actual product.
+Distinctiveness is not a pile of effects. It is a coherent point of view with fewer
+unexamined defaults.
 </purpose>
 
-<invocation>
-/design                      → No variant. Choose your own direction. Surprise.
-/design --variant={name}     → Load variants/{name}.md for mood guidance.
+<context-fit>
+Before styling, recover the evidence already present in the task and repository:
 
-Variant files define VIBE not implementation.
-You choose fonts, colors, spacing, motion.
-Never copy same font/palette/layout between generations even within same variant.
-</invocation>
+1. Product: what the interface does and which action matters most.
+2. Audience and use context: device, environment, familiarity, urgency, accessibility needs.
+3. Brand: existing tokens, logo, type, imagery, voice, screenshots, and reference qualities.
+4. Content: real density, length, hierarchy, empty/error/loading states, and localization risk.
+5. Technical constraints: current stack, component library, performance budget, supported browsers.
+
+Preserve and extend the existing design system when one exists. Do not replace a coherent
+brand because a variant or personal preference is louder. If the evidence is incomplete,
+make the smallest reversible assumption and state it; ask only when the answer changes the
+product direction.
+</context-fit>
+
+<art-direction>
+Write a tiny direction before implementation:
+
+- desired feeling in 2-3 plain words;
+- one dominant visual idea;
+- typography, color, layout, imagery, and motion choices tied to evidence;
+- 2-3 defaults to avoid for this specific project.
+
+No choice is universally premium. A system font can be correct for speed or platform
+familiarity. Symmetry can communicate calm. Flat color can be the strongest choice. Huge
+type, gradients, glass, noise, asymmetry, and animation are tools—not proof of taste.
+</art-direction>
 
 <variants>
-abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal
-
-Read variants/ directory for full mood definitions.
-Each defines sensory direction and emotional target—not specs.
+Optional lenses: abyss, spatial, verdant, substrate, ember, arctic, void, patina, signal.
+Load `variants/{name}.md` when the user names one or when exploration genuinely benefits.
+Variants describe mood, never mandatory components, fonts, palettes, effects, or layouts.
 </variants>
 
-<principles type="always-active">
+<hard-bars>
+- Hierarchy: the primary action and reading order are obvious without explanation.
+- Responsive: content fits and remains usable at the project breakpoints; touch targets are
+  at least 44px where touch is expected.
+- Accessible: semantic structure, keyboard operation, visible focus, useful labels/alt text,
+  AA contrast, reduced-motion support, and no meaning encoded by color alone.
+- Content-real: test realistic long/short copy plus empty, error, loading, and disabled states
+  when the interface has them.
+- Performance: avoid decorative weight that delays the main content; size images, subset or
+  avoid webfonts, and use JavaScript only for behavior that needs it.
+- System-fit: reuse the repository's components, tokens, naming, and state patterns unless the
+  task explicitly includes changing the system.
+</hard-bars>
 
-<typography>
-1. Distinctive fonts only — NEVER: Inter, Roboto, Arial, Open Sans, system-ui, Helvetica, SF Pro
-2. Pair weight extremes (300 + 700+). Avoid 400–500 middle zone entirely.
-3. Headers 3x+ body size minimum. Tight tracking on large, relaxed on small.
-4. (gate: if same font used in last 3 outputs → pick a different one)
-</typography>
+<implementation>
+Use the smallest structure the product needs. Reusable components should follow the existing
+stack; a one-off static section does not need a component framework. Centralize repeated
+visual decisions in tokens. Prefer CSS for presentation, semantic HTML for structure, and
+progressive enhancement for interaction.
 
-<color>
-1. CSS custom properties for all colors. One dominant + one sharp accent.
-2. Dark modes require 5+ background shade layers. Single dark color = amateur.
-3. Warm text on dark: bone/cream tones. Never pure white on dark.
-4. (gate: palette derives from variant mood, not memorized hex values)
-</color>
-
-<motion>
-1. CSS-only first. JS only when CSS literally cannot achieve it.
-2. One orchestrated entrance beats scattered micro-interactions.
-3. Organic easing always: cubic-bezier curves, never linear. Breathing > snapping.
-4. (gate: vary timing per project — no reused duration scale)
-</motion>
-
-<layout>
-1. Asymmetry over symmetry. Grid-break moments over uniform grids.
-2. Whitespace is a design element. Use aggressively to create tension.
-3. Full-bleed mixed with contained sections creates rhythm.
-4. (gate: uniform section heights = amateur → vary intentionally)
-</layout>
-
-<surfaces>
-1. NEVER flat single-color backgrounds.
-2. Layer: gradients, translucent surfaces, backdrop-blur, subtle noise.
-3. Cards need visible depth: shadow, border, or background differentiation.
-4. Dark backgrounds need hue tint. Light from within (glow) beats external illumination.
-</surfaces>
-
-<core>
-1. Prompt for taste, not implementation. Describe WHAT the user should feel; model chooses HOW.
-2. Component-first. Build pieces (nav, hero, cards), then compose. Never full pages in one shot.
-3. Mobile-first as constraint: specify column limits and 44px touch targets upfront.
-4. Functional color (encodes meaning: status, priority, state) beats decorative color.
-5. Accessibility = design advantage. WCAG contrast forces better color decisions.
-</core>
-
-<reference>
-Skill-specific: skills/frontend/reference/design-research.md
-</reference>
-
-</principles>
+Motion must explain change, guide attention, or provide feedback. If it does none of those,
+remove it. Decorative texture, depth, and unusual composition need the same justification.
+</implementation>
 
 <anti-convergence>
-After generating, ask: "Have I seen this exact combination before?"
-If yes → change the most dominant visual element immediately.
-If variant starts producing similar outputs → interpret it more loosely.
-Constraints breed creativity. Variant mood is springboard not cage.
+Generic output usually comes from an unexamined default, not from a forbidden ingredient.
+Before finishing, name the most dominant visual decision and ask:
+
+1. What evidence caused this choice?
+2. Is it inherited from the product, or copied from recent model habits?
+3. Would removing it make the interface clearer or more specific?
+
+Common warning signs—not automatic bans—include purple gradient startup pages, identical
+rounded cards, default component-library styling, ornamental dashboards, centered-everything
+layouts, decorative blobs, fake testimonials, and a fashionable font with no brand reason.
+Change a warning sign when it is unexamined; keep it when the context earns it.
 </anti-convergence>
 
-<anti-patterns>
-<block>System/generic fonts (Inter, Roboto, Arial, system-ui)</block>
-<block>Purple-gradient-on-white (the AI slop signature)</block>
-<block>Neon cyan + pink + purple together (vaporwave cliché)</block>
-<block>Flat single-color backgrounds</block>
-<block>Uniform section heights and widths</block>
-<block>Heavy font weights on everything (use weight contrast)</block>
-<block>Repeating same aesthetic across generations</block>
-<block>Following variant too literally (it's a vibe not a spec)</block>
-<block>Centered everything (break the symmetry)</block>
-<block>Stock icon libraries without customization</block>
-<block>Rounded corners on everything (vary or eliminate)</block>
-</anti-patterns>
+<verification>
+Do visual QA on rendered output, not source alone. Inspect screenshots at the task's target
+sizes (for a general web page, start with 375, 768, and 1440 widths), then exercise keyboard,
+focus, hover/touch, overflow, and reduced motion. Fix the largest hierarchy or usability
+problem first and re-check. Never claim visual completion without seeing the rendered result.
+</verification>
+
+<reference>
+Read `skills/frontend/reference/design-research.md` when deeper rationale is useful.
+</reference>
 
 <on_complete>
-agentdb write-end '{"skill":"design","variant":"<if-used>","fonts":["<list-for-tracking>"],"aesthetic":"<2-word-summary>","dominant_color":"<name-not-hex>"}'
+Report the art direction, evidence behind the dominant choices, sizes/states visually checked,
+and any accessibility or performance bar not verified.
 </on_complete>
 
 </skill>

--- a/skills/frontend/reference/design-research.md
+++ b/skills/frontend/reference/design-research.md
@@ -126,9 +126,10 @@ Tested with and without design prompts across multiple generations:
    adjust weight/width/style dynamically are the foundation of responsive typography.
    Use variable fonts as default, not just distinctive static fonts.
 
-2. Calling out specific anti-patterns works better than positive instructions.
-   "Never use Inter" is more effective than "use interesting fonts." The model
-   needs to know what to AVOID more than what to DO.
+2. Calling out project-specific anti-patterns works better than vague positive
+   instructions. "Do not fall back to the component-library demo styling" is useful
+   when that is the observed default. Permanent ingredient bans merely create a new
+   default and can fight an existing brand or platform convention.
 
 3. The distilled aesthetics prompt (typography + color + motion + backgrounds)
    consistently outperforms any single-dimension prompt. All four dimensions
@@ -158,8 +159,8 @@ Why it works: anchors quality expectations to known high-bar products.
 Why it works: functional constraints produce better design than aesthetic ones.
 
 ### Pattern 4: Anti-Pattern Callout
-"No generic AI aesthetic. No purple gradients. No Inter. Surprise me."
-Why it works: removes the model's safe defaults, forces creative choices.
+"Keep our existing type system. Avoid the default rounded-card dashboard composition."
+Why it works: names the actual convergence risk without imposing unrelated taste.
 
 ### Pattern 5: Emotional Target
 "The user should feel calm confidence. Like a well-organized workspace."
@@ -219,7 +220,7 @@ their training distribution. Specific manifestations:
 
 Mitigations that work:
 - Rotate aesthetic references between generations.
-- Explicitly ban recently-used fonts/palettes in the prompt.
+- Name recently repeated choices as warnings and require a reason to reuse them.
 - Use variant system (abyss, ember, arctic, etc.) to force different starting points.
 - Request unexpected combinations: "editorial typography with brutalist layout."
 - Include randomization directive: "Make a choice I wouldn't expect."
@@ -238,8 +239,9 @@ From Lovable and v0's patterns, the optimal structure:
 1. Global tokens: CSS custom properties for colors, spacing, typography scale.
    Defined once, referenced everywhere. This is the only place hex codes belong.
 
-2. Component library: shadcn/ui as base (AI tools are optimized for it).
-   Customize via CSS variables, not by forking components.
+2. Component library: use the repository's established library and extension pattern.
+   A new project may choose a battle-tested base such as shadcn/ui, but tool familiarity
+   is not a product reason by itself.
 
 3. Layout patterns: define page-level compositions separate from components.
    "Dashboard layout" is not a component; it's a composition of components.
@@ -258,50 +260,31 @@ For any design task, include these in order of importance:
 
 1. WHO uses this and in what context (user, device, environment)
 2. WHAT it should feel like (mood, 2-3 adjectives, emotional target)
-3. WHAT to avoid (specific anti-patterns, banned defaults)
+3. WHAT to avoid (specific unexamined defaults seen in this project or recent output)
 4. CONSTRAINTS (max colors, mobile-first, accessibility requirements)
 5. REFERENCE quality level (what products/sites set the bar)
 
-Skip: exact hex codes, exact font names, exact pixel values, implementation details.
-Those are execution decisions. Let the model make them within your constraints.
+Existing brand tokens, fonts, and layout rules are evidence, not over-specification.
+For a greenfield direction, avoid premature pixel-level instructions and choose execution
+details within the stated constraints.
 
 ---
 
-## Principles Rationale (moved from SKILL.md 2026-05-28)
+## Contextual heuristics (updated 2026-07-16)
 
-### Typography — expanded rules
-- Weight extremes: pair 300 with 700+. Avoid the 400–500 middle zone entirely.
-- Size contrast: headers 3x+ body minimum. Go bigger.
-- Tracking: tight on large text, relaxed on small. Never default.
-- CRITICAL: If you've used the same font in your last 3 outputs, pick a different one.
+These are options to test, not universal rules:
 
-### Color — expanded rules
-- One dominant + one sharp accent beats even distribution every time.
-- Dark modes need 5+ background shade layers. Single dark color = amateur.
-- Derive palette from variant mood. Never memorized hex values.
-- Warm text colors. Bone/cream tones on dark. Never pure white on dark.
-
-### Motion — expanded rules
-- One orchestrated entrance beats scattered micro-interactions.
-- Organic easing always: cubic-bezier curves, never linear.
-- Breathing > snapping. Drift > jump. Ease > instant.
-- Vary timing per project. Don't reuse same duration scale.
-
-### Layout — expanded rules
-- Whitespace as design element. Use aggressively where it creates tension.
-- Full-bleed mixed with contained sections creates rhythm.
-- Uniform section heights = amateur. Vary intentionally.
-- Let content dictate structure, not templates.
-
-### Surfaces — expanded rules
-- Layer: gradients, translucent surfaces, backdrop-blur, subtle noise.
-- Cards need visible depth: shadow, border, or background differentiation.
-- Dark backgrounds need hue tint. Never pure black or pure gray.
-- Light from within (glow, shadow-color) beats external illumination.
-
-### Core principles — rationale
-- Prompt for taste, not implementation: Describe WHAT the user should feel; let the model choose HOW. Intent over specification. Mood, constraints, and anti-patterns beat hex codes and font names.
-- Component-first builds pieces (nav, hero, cards), then composes. Never generate full pages in one shot.
-- Mobile-first as constraint, not afterthought. Specify column limits and touch targets upfront.
-- Functional color encodes meaning (status, priority, state) — always beats decorative color.
-- Accessibility is a design advantage. WCAG contrast ratios force better color decisions. 44px touch targets prevent cramped layouts.
+- Typography contrast can clarify hierarchy, but editorial restraint, platform-native type,
+  or a narrow brand scale may be the better fit.
+- A dominant color and accent can focus attention, while monochrome or a broader semantic
+  palette may better serve the content.
+- Layered dark surfaces can explain depth; a deliberately flat field can be cleaner and more
+  memorable. Count neither shades nor effects as quality.
+- Asymmetry and mixed-width sections can create energy; symmetry and repetition can create
+  trust, speed, or calm. Let the message and task choose.
+- Motion should explain change, guide attention, or provide feedback. One entrance animation
+  is not automatically better than none.
+- Components improve repeated behavior. One-off static composition should not be forced into
+  component machinery merely to satisfy a ritual.
+- Accessibility, responsive behavior, realistic content states, and rendered visual QA remain
+  hard constraints because they improve the actual interface rather than enforce a style.

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.4.0.
+Quick reference for KERNEL v8.5.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>
@@ -32,7 +32,7 @@ Before showing help, check the actual state of the plugin as loaded in your cont
 4. Report what you see, don't just recite docs.
 
 ```bash
-agentdb read-start
+agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global
 ```
 </on_start>
 
@@ -147,7 +147,7 @@ durable end-of-session state is required.
 <philosophy>
 <principle id="research_first">Research anti-patterns before solutions. Most problems are already solved.</principle>
 <principle id="tests_first">Define success before coding. Tests before implementation.</principle>
-<principle id="agentdb">Read at start. Write at end. Memory persists across sessions.</principle>
+<principle id="agentdb">Recall task context before acting. Recall again as the task changes. Write at end.</principle>
 <principle id="big5">Big 5: input validation, edge cases, error handling, duplication, complexity.</principle>
 <principle id="builtin">Built-in beats library. Library beats custom. Prove you need complexity.</principle>
 </philosophy>

--- a/skills/landing-page/SKILL.md
+++ b/skills/landing-page/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: landing-page
-description: "Guided landing page generator. Interview → scaffold → enforce → deploy. Static HTML/CSS optimized for Cloudflare Pages. All architectural decisions are hypotheses until proven by /kernel:experiment."
+description: "Explicit landing-page build and deployment operator. Loads marketing strategy and frontend judgment, scaffolds the smallest suitable site, verifies rendered behavior, and deploys to the user's or project's configured target."
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, WebSearch, WebFetch
 disable-model-invocation: true
 kernel:
   kind: operator
-  version: 1
+  version: 2
   side_effects: deploys
   confirmation: on_side_effect
 ---
@@ -14,65 +14,58 @@ kernel:
 <skill id="landing-page">
 
 <purpose>
-Ship a fast, distinctive static landing page. Interview the human for the real inputs,
-scaffold a minimal static site, enforce the non-negotiable quality bars, deploy. Explicit
-invocation only, it deploys. Keep this skill small: the model already knows how to build a
-static page, this just supplies the interview, the guardrails, and the deploy path.
+Build, verify, and optionally deploy a focused landing page. This is the explicit operator;
+strategy and aesthetics come from the methodology skills it composes.
 </purpose>
 
-<skill_load>skills/frontend/SKILL.md</skill_load>
+<skill_load>
+Load `skills/marketing-site/SKILL.md` and `skills/frontend/SKILL.md` before writing.
+</skill_load>
 
-<interview>
-Ask the human, briefly, before writing anything (skip any the human already gave):
-1. What is this page for, one sentence, and who lands on it?
-2. The single action you want them to take (the primary CTA).
-3. Brand: name, any existing colors/font/logo, and a reference site whose feel you like.
-4. Content: headline, subhead, 2-4 value points, social proof if any, footer links.
-5. Domain + where it deploys (default: Cloudflare Pages).
-Do not invent brand facts. Unknown = ask, never fill with a plausible guess.
-</interview>
+<inputs>
+Use answers already present in the request/repository. Resolve only what materially changes
+the build: audience, desired action, offer/proof, brand/assets, required content/legal pages,
+real CTA destination, domain, and deploy target. Never invent brand facts or proof.
+</inputs>
 
-<build>
-- Static only by default: one `index.html`, one `styles.css`, assets in `/assets`. Add JS
-  only for a real interaction, never for layout. No framework unless the human asks.
-- Follow skills/frontend for aesthetic: no generic AI look, no Inter-by-default, no emoji
-  chrome. Pick a distinctive type + color system grounded in the brand answers.
-- Responsive by construction: verify at 375 / 768 / 1440. Content never overflows the body.
-- One clear CTA above the fold, repeated once lower. Everything serves that action.
-- Accessibility: semantic landmarks, alt text, visible focus, keyboard reaches every control,
-  contrast passes AA.
-</build>
+<scaffold>
+- Follow the existing repository and stack first. For a new simple page, prefer static
+  HTML/CSS with JavaScript only for real behavior; add a framework only when requirements earn it.
+- Build the content argument with `marketing-site`; build the visual system with `frontend`.
+- Add only the pages and integrations the brief needs. If forms, analytics, cookies, payments,
+  embeds, or accounts touch data, create/update a privacy page that matches the real behavior.
+- Keep secrets and deploy credentials out of source.
+</scaffold>
 
-<enforce>
-Before deploy, these are hard bars, not suggestions:
-- Loads with zero console errors at all three breakpoints.
-- Largest Contentful Paint image is sized/compressed; no multi-MB hero.
-- No secrets, analytics keys, or tokens in the committed source.
-- Every link resolves; the CTA points somewhere real.
-- Lighthouse-style sanity: no render-blocking bloat, fonts subset or system.
-</enforce>
+<verify-local>
+- Render and do visual QA at 375 / 768 / 1440 widths unless the product defines better targets.
+- Check hierarchy, realistic content, overflow, keyboard/focus, reduced motion, contrast, images,
+  console errors, links, metadata, and CTA/form success plus error paths.
+- Confirm the privacy policy matches actual collection and third parties.
+- Run the repository's tests/build/lint and fix failures before deployment.
+</verify-local>
 
 <deploy>
-- Cloudflare Pages by default (`wrangler pages deploy ./` or the project's configured path).
-- Confirm the deploy target with the human before pushing (this skill has side_effects: deploys).
-- After deploy, VERIFY LIVE: curl the deployed URL, confirm 200 + the headline is in the HTML.
-  "Deployed" is not "working" until the served asset is checked. Report the live URL.
+- Use the project's configured deploy command and provider. If none exists, choose the smallest
+  provider-appropriate static deployment; Cloudflare Workers Static Assets is one option, not a
+  universal default.
+- If the user already named the deploy target and asked to deploy, that counts as confirmation.
+  Otherwise surface the resolved account/project/domain before the side effect.
+- After deploy, verify the live URL: status 200, headline/content marker, nested assets, legal
+  page, and conversion path. Static assets can propagate briefly, so retry a short bounded check
+  before diagnosing a successful deploy as broken.
 </deploy>
 
-<hypotheses>
-Architecture choices here (static-first, single CTA, system fonts) are defaults, not dogma.
-A repeated better result promotes via /kernel:experiment, it does not get hardcoded as a rule.
-</hypotheses>
-
-<hard_stops>
-- Never deploy without explicit human confirmation of the target.
-- Never commit secrets or a key into the page source.
-- Never report the page done off a commit, verify the live URL first.
-</hard_stops>
+<hard-stops>
+- No fabricated proof, shippable placeholders, fake form success, or dead CTA.
+- No secrets in committed source.
+- No “done” claim based only on source, build, commit, or deploy output; inspect the rendered
+  page locally and the served page after deployment.
+</hard-stops>
 
 <on_end>
-Report: the live URL (verified), the breakpoints checked, and any bar you could not meet
-(state it plainly, never claim a green you did not observe).
+Report the live URL if deployed, target widths and paths checked, claims/proof source, privacy
+behavior, and any verification bar not observed.
 </on_end>
 
 </skill>

--- a/skills/marketing-site/SKILL.md
+++ b/skills/marketing-site/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: marketing-site
+description: "Honest marketing and client-site methodology for landing pages, product/company websites, portfolios, launch or campaign pages, service-business sites, and conversion copy. Clarifies audience, positioning, offer, proof, objections, CTA, privacy, art direction, and client handoff before implementation. Triggers: marketing site, landing page, company website, product website, portfolio, campaign page, client website, conversion, positioning, offer, value proposition, CTA, social proof, testimonial, privacy policy."
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+kernel:
+  kind: methodology
+  version: 1
+  side_effects: none
+  confirmation: none
+---
+
+<skill id="marketing-site">
+
+<purpose>
+Turn a product or service into a focused, credible website. The page should help a specific
+person understand the offer, trust it, and take the next useful action—without marketing
+theater or a generic template wearing different nouns.
+</purpose>
+
+<skill_load>skills/frontend/SKILL.md</skill_load>
+
+<inputs>
+Recover what the user and repository already supplied before asking questions:
+
+1. Audience: who arrives, what they know, and what situation brought them here.
+2. Desired action: install, buy, book, join, contact, learn, or compare.
+3. Offer: what changes for the visitor, how it works, and why this option is different.
+4. Friction: objections, risks, missing information, switching cost, and alternatives.
+5. Proof: product behavior, demo, screenshots, founder expertise, customer evidence, data.
+6. Brand and constraints: voice, assets, references, legal/privacy needs, stack, deadline.
+
+Do not force an interview when the brief answers these. Ask only for a missing choice that
+would materially change the page; otherwise make a reversible assumption and label it.
+</inputs>
+
+<truth-rules>
+Never invent customers, testimonials, metrics, guarantees, awards, integrations, press logos,
+scarcity, fake urgency, or “trusted by” claims. Placeholder proof must be visibly marked as a
+placeholder and cannot ship. Describe capabilities at the strength the evidence supports.
+Specific and modest beats impressive and false.
+</truth-rules>
+
+<strategy>
+Write a one-sentence positioning statement:
+“For [audience in situation], [offer] helps [outcome] by [mechanism/difference].”
+
+Then choose a page argument that fits the buying decision. A useful default is:
+problem or desire → promise → mechanism → proof → objections → action.
+It is a diagnostic spine, not a mandatory section order. A familiar plugin may need one sharp
+idea and a demo; an expensive service may need process, proof, risk reduction, and detail.
+
+Give each section one job. Prefer one primary CTA; secondary actions are allowed when they
+serve a genuinely different visitor state. CTA copy should name the next step, not “Submit.”
+</strategy>
+
+<copy>
+- Lead with the visitor's outcome or tension, then make the mechanism concrete.
+- Use the user's language and real nouns. Delete adjectives that the page cannot prove.
+- Keep the headline, subhead, visual, and CTA mutually reinforcing.
+- Answer the strongest objection near the claim that creates it.
+- Let product screenshots, examples, demos, and specifics carry more weight than slogans.
+- Match detail to consequence: higher price/risk needs more explanation and reassurance.
+</copy>
+
+<art-direction>
+Use `skills/frontend/SKILL.md`. Derive the visual direction from audience, brand, offer,
+content, and references. A provocative page earns its tension through the idea; it does not
+need random visual aggression. Preserve an existing design system when present.
+</art-direction>
+
+<privacy-and-trust>
+The privacy page must describe the actual implementation: what data is collected, why, where
+it goes, retention/deletion, cookies or analytics, form/email providers, user choices, contact,
+and effective date. If the site collects nothing, say so plainly and still disclose hosting
+logs or third parties that may receive technical data. Do not copy a broad boilerplate policy
+that claims tools the site does not use. Flag jurisdiction-specific legal review when stakes
+require it; do not present generated copy as legal advice.
+</privacy-and-trust>
+
+<client-delivery>
+For client work, confirm who approves copy/design, who owns supplied assets, the domain and
+accounts, analytics/consent choices, editable-source handoff, launch/rollback plan, and who
+maintains the site. Keep credentials in the client's account or secure environment—not source.
+Read `skills/marketing-site/references/client-delivery.md` for the compact handoff checklist.
+</client-delivery>
+
+<verification>
+Check the rendered page at target widths and follow every conversion path. Verify all claims
+against supplied evidence, every CTA and legal link, keyboard/focus behavior, performance,
+metadata/share preview, form success/error states, and the deployed privacy behavior.
+</verification>
+
+<output>
+State the audience, desired action, positioning, page argument, proof used, art direction,
+assumptions/placeholders, privacy reality, and what was actually verified.
+</output>
+
+</skill>

--- a/skills/marketing-site/agents/openai.yaml
+++ b/skills/marketing-site/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "KERNEL Marketing Site"
+  short_description: "Shape honest, focused marketing websites"
+  default_prompt: "Use $marketing-site to shape an honest, focused marketing website."

--- a/skills/marketing-site/references/client-delivery.md
+++ b/skills/marketing-site/references/client-delivery.md
@@ -1,0 +1,26 @@
+# Client website delivery checklist
+
+Use only the parts that match the engagement.
+
+## Before build
+
+- Decision maker and approval moments are named.
+- Audience, offer, primary action, proof, objections, and success measure are agreed.
+- Logo, fonts, images, copy, and licenses have an owner; missing assets are explicit.
+- Scope separates launch requirements from later ideas.
+- Domain, hosting, forms, email, analytics, consent, and payment accounts have owners.
+
+## Before launch
+
+- Client approves final copy, claims, pricing, proof, and legal pages.
+- Accessibility, responsive layouts, metadata, favicon/share image, performance, links,
+  forms, analytics/consent, 404, redirects, and rollback are checked.
+- Production credentials live in client-controlled accounts or secure environment variables.
+- DNS change timing, rollback owner, and post-launch observation window are agreed.
+
+## Handoff
+
+- Provide editable source, deployment instructions, account/ownership map, asset licenses,
+  content update path, backup/rollback steps, and known limitations.
+- Record who maintains dependencies, content, privacy disclosures, and domain renewals.
+- Never call a launch complete until the production URL and conversion path are exercised.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2231,17 +2231,19 @@ test_release_metadata_and_inventory_are_truthful() {
   local skills agents
   skills=$(find "$PLUGIN_ROOT/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d ' ')
   agents=$(find "$PLUGIN_ROOT/agents" -maxdepth 1 -name '*.md' ! -name README.md | wc -l | tr -d ' ')
-  assert_equals 34 "$skills" "skill inventory"
+  assert_equals 35 "$skills" "skill inventory"
   assert_equals 15 "$agents" "agent inventory"
   python3 - "$PLUGIN_ROOT" <<'PY'
 import json, pathlib, sys
 r=pathlib.Path(sys.argv[1])
 p=json.loads((r/'.claude-plugin/plugin.json').read_text())
 m=json.loads((r/'.claude-plugin/marketplace.json').read_text())['plugins'][0]
-assert p['version']==m['version']=='8.1.1'
+assert p['version']==m['version']=='8.5.0'
 for x in (p,m):
-    assert 'JSON' in x['description'] and '34 skills' in x['description'] and '15 specialized agent' in x['description']
+    assert '35 engineering skills' in x['description'] and '8.5.0' in x['description']
 PY
+  grep -q 'There are 35 skills and 15 specialized Claude Code agent definitions' "$PLUGIN_ROOT/README.md" || return 1
+  grep -q 'Codex loads all 35 KERNEL skills' "$PLUGIN_ROOT/docs/QUICKSTART.md" || return 1
   grep -q 'validate | latest | divergence | preflight | compile | resume | activate | deactivate' "$PLUGIN_ROOT/README.md"
 }
 
@@ -2839,6 +2841,8 @@ test_read_start_lean_is_minimal() {
   full=$(agentdb read-start)
   assert_contains "$lean" "## Memory:" || return 1
   assert_contains "$lean" "agentdb recall" || return 1
+  assert_contains "$lean" '<feature> <subsystem> <files/symbols> <error/outcome>' || return 1
+  assert_contains "$lean" "Recall again when scope, files, hypothesis, or failure changes" || return 1
   # failures surface unconditionally; the 12 plain patterns do NOT (recall-on-demand)
   assert_contains "$lean" "prod outage" || return 1
   echo "$lean" | grep -q "cache computation number" && { echo "lean must NOT dump non-failure patterns"; return 1; }
@@ -2848,6 +2852,16 @@ test_read_start_lean_is_minimal() {
   # at realistic volume lean is materially smaller than the full dump
   local ll fl; ll=$(printf '%s\n' "$lean" | wc -l); fl=$(printf '%s\n' "$full" | wc -l)
   [ "$ll" -lt "$fl" ] || { echo "lean ($ll lines) should be smaller than full ($fl lines)"; return 1; }
+  [ "$ll" -le 12 ] || { echo "lean keyword guidance grew too large ($ll lines, max 12)"; return 1; }
+}
+
+test_session_start_has_concrete_recall_recipe() {
+  local output
+  output=$("$PLUGIN_ROOT/hooks/scripts/session-start.sh" 2>&1)
+  assert_contains "$output" '<feature> <subsystem> <files/symbols> <error/outcome>' || return 1
+  assert_contains "$output" "Recall again after discovery" || return 1
+  assert_contains "$output" "scope/hypothesis changes" || return 1
+  assert_contains "$output" "new failure" || return 1
 }
 
 test_read_start_full_still_has_weighted_and_tail() {
@@ -4539,6 +4553,41 @@ test_migration_side_effecting_skills_not_ambient() {
   assert_exit_code 0 "$bad" "side-effecting skills must not fire ambiently"
 }
 
+# === Marketing + Frontend Skill Tests ===
+
+test_marketing_site_methodology_contract() {
+  local skill="$PLUGIN_ROOT/skills/marketing-site/SKILL.md"
+  local ui="$PLUGIN_ROOT/skills/marketing-site/agents/openai.yaml"
+  assert_file_exists "$skill" || return 1
+  assert_file_exists "$ui" || return 1
+  grep -q '^  kind: methodology' "$skill" || return 1
+  ! grep -q '^disable-model-invocation: true' "$skill" || return 1
+  grep -q 'skills/frontend/SKILL.md' "$skill" || return 1
+  grep -q 'testimonials.*metrics.*guarantees\|metrics.*testimonials.*guarantees' "$skill" || return 1
+  grep -q 'privacy' "$skill" || return 1
+  grep -q 'client' "$skill" || return 1
+  grep -q '\$marketing-site' "$ui"
+}
+
+test_frontend_is_context_led_not_house_style() {
+  local skill="$PLUGIN_ROOT/skills/frontend/SKILL.md"
+  grep -q '<context-fit>' "$skill" || return 1
+  grep -q 'Preserve and extend the existing design system' "$skill" || return 1
+  grep -q 'visual QA' "$skill" || return 1
+  ! grep -q 'Distinctive fonts only — NEVER' "$skill" || return 1
+  ! grep -q 'NEVER flat single-color backgrounds' "$skill"
+}
+
+test_landing_page_composes_marketing_and_frontend() {
+  local skill="$PLUGIN_ROOT/skills/landing-page/SKILL.md"
+  grep -q '^disable-model-invocation: true' "$skill" || return 1
+  grep -q 'skills/marketing-site/SKILL.md' "$skill" || return 1
+  grep -q 'skills/frontend/SKILL.md' "$skill" || return 1
+  grep -q 'user already named the deploy target' "$skill" || return 1
+  grep -q '375 / 768 / 1440' "$skill" || return 1
+  grep -q 'project.*configured.*deploy' "$skill"
+}
+
 test_migration_kernel_taxonomy_blocks_parse() {
   # every SKILL.md frontmatter parses and carries kernel.kind
   python3 - "$PLUGIN_ROOT" <<'PYINNER'
@@ -4993,8 +5042,14 @@ run_test_suite() {
     read_start)
       run_test "read-start outputs Known Gotchas section" test_read_start_outputs_gotchas
       run_test "read-start --lean is minimal (8.4.0)" test_read_start_lean_is_minimal
+      run_test "session-start gives concrete recall recipe" test_session_start_has_concrete_recall_recipe
       run_test "read-start full keeps weighted + tail" test_read_start_full_still_has_weighted_and_tail
       run_test "read-start bumps load_count not hit_count" test_read_start_bumps_load_count_not_hit_count
+      ;;
+    marketing)
+      run_test "marketing-site is ambient methodology" test_marketing_site_methodology_contract
+      run_test "frontend is context-led, not a house style" test_frontend_is_context_led_not_house_style
+      run_test "landing-page composes marketing + frontend" test_landing_page_composes_marketing_and_frontend
       ;;
     recall)
       run_test "recall dedups identical insights" test_recall_dedups_identical_insights
@@ -5140,6 +5195,7 @@ main() {
     run_test_suite "pre_ship_app"
     run_test_suite "entropy_adaptive"
     run_test_suite "read_start"
+    run_test_suite "marketing"
     run_test_suite "recall"
     run_test_suite "learn"
     run_test_suite "version_sync"


### PR DESCRIPTION
## What changed
- make frontend design context-led instead of enforcing a Kernel house style
- add an ambient marketing-site methodology for positioning, proof, privacy, and client delivery
- keep landing-page explicit-only while composing marketing + frontend
- teach concrete AgentDB recall keywords and when to recall again

## Verification
- source checkout: 426 passed, 0 failed
- isolated release clone: 421/422 in one run; the sandbox-only runtime-selector failure passes 8/8 with a disposable cache selector
- governance, release docs, version sync, and focused marketing/recall suites pass
- concurrent AgentDB graph work is excluded from this branch