### PR TITLE
release(agentdb): KERNEL 8.5.1 — learning graph + promotion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, 35 engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.5.0 adds context-led frontend and honest marketing-site methods, plus concrete repeatable AgentDB recall prompts while preserving the lean 8.4.0 startup surface.",
-      "version": "8.5.0"
+      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.5.1 adds a learning graph over AgentDB memory (semantic edges + recurring-failure promotion to doctrine candidates), on top of 8.5.0 marketing/frontend skills, 8.4.0 lean session start, 8.3.0 local semantic recall, and the 8.2.0 six-threat security guard.",
+      "version": "8.5.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Durable project memory, bounded JSON handoffs, 35 engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.5.0 adds context-led frontend and honest marketing-site methods, plus concrete repeatable AgentDB recall prompts.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 217e339d59806b5839c31d163a34b1dca2e8ad6e64888d2aaa1cd3705749c02f; adapter: codex -->
-<kernel version="8.5.0">
+<kernel version="8.5.1">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.5.1] - 2026-07-17 "learning graph"
+
+The second AgentDB lever after embeddings: a knowledge graph OVER the learnings, plus a
+promotion detector for recurring failures. Builds on 8.3.0 semantic recall — the same
+vectors now power edges and clustering. Fully additive; no change to recall or session
+behavior.
+
+### Added
+- **`agentdb graph build | neighbors | stats`** — a `learning_edges` table connecting
+  learnings that are semantically related (cosine over the migration-015 embeddings) or
+  explicitly `[[link]]`-referenced. `neighbors <id>` lists a learning's related lessons;
+  `stats` summarizes edge counts. Distinct from the context-load telemetry in
+  `nodes`/`edges` (migration 002).
+- **`agentdb promote [--min N]`** — clusters recurring failures (connected components over
+  cohesive edges, similarity ≥ 0.55, default min cluster size 3) and surfaces them as
+  candidate doctrine themes for review. It never auto-writes doctrine. `hit_count` is
+  deliberately NOT used as a signal — it measures recall relevance, not recurrence, and is
+  inflated by surfacing.
+- **`orchestration/agentdb/graph.py`** — the engine (numpy-optional; pure-Python cosine
+  fallback). Migration 016 records provenance; the table self-creates via the engine's DDL.
+
+### Changed
+- `learning_edges` is **excluded from the JSON mirror** — derived data that rebuilds from
+  the embeddings + `[[links]]` via `agentdb graph build`, like the embedding BLOBs and FTS.
+- Recall eval (`eval/run_eval.py`) now reports **recall@1/@3/@10 + MRR**, and the RRF
+  fusion constant is tunable via `AGENTDB_RRF_K` (default 60, confirmed optimal on a sweep).
+
+### Verified
+- On a real 47-learning corpus: 29 semantic edges; `promote` surfaces one coherent cluster
+  (three Codex-hooks-in-the-vault failures) and nothing spurious. Widened recall gold set
+  (48 queries) shows hybrid's real win is ranking precision: recall@1 +0.146, MRR +0.107.
+- Tests: 4 new graph tests (build, promote-finds-cluster, promote-empty, mirror-exclusion);
+  full source suite green.
+
 ## [8.5.0] - 2026-07-16 "context before style"
 
 Turns frontend guidance from a fixed visual recipe into product judgment, adds an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 217e339d59806b5839c31d163a34b1dca2e8ad6e64888d2aaa1cd3705749c02f; adapter: claude -->
-<kernel version="8.5.0">
+<kernel version="8.5.1">
 
 
 <!-- ============================================ -->

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ feature + subsystem/library + discovered files/symbols + exact error or desired 
 Run it again after discovery, when scope or hypothesis changes, or when a new failure appears.
 Run `agentdb read-start` explicitly (no flag) only when you want the full weighted memory dump.
 
+### Learning graph + promotion (8.5.1)
+
+With embeddings present, `agentdb graph build` connects related learnings (semantic
+cosine + `[[links]]`) into a `learning_edges` table; `agentdb graph neighbors <id>` shows
+a learning's related lessons. `agentdb promote` clusters recurring failures and surfaces
+candidate doctrine themes for review (it never auto-writes doctrine). The edges are derived
+data — excluded from the JSON mirror and rebuilt by `graph build`, like the embeddings.
+
 KERNEL hooks can inspect repository state, run configured checks, and write these records.
 Claude Code runs the full declared lifecycle. Codex runs supported synchronous hook
 events, including the write guards and SessionStart context; it skips asynchronous

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -1164,7 +1164,10 @@ cmd_schema() {
 # repopulates _migrations). Used by both export-json and import-json.
 _is_snapshot_table() {
   case "$1" in
-    *_fts|*_fts_*|sqlite_*|_migrations) return 1 ;;
+    # Derived tables are NOT mirrored — they rebuild on restore. FTS shadow tables
+    # rebuild from content; learning_edges (migration 016) rebuilds via `graph build`
+    # from the embeddings + [[links]], so mirroring it would bloat the tracked JSON.
+    *_fts|*_fts_*|sqlite_*|_migrations|learning_edges) return 1 ;;
     *) return 0 ;;
   esac
 }
@@ -1909,6 +1912,16 @@ _embed_run() {
   "$py" "$script" "$@" 2>/dev/null
 }
 
+# Run graph.py (learning graph + promotion, migration 016). Uses the embed venv's
+# python if set (numpy = faster cosine), else python3 (struct fallback). Errors surface.
+_graph_run() {
+  local py script
+  py=$(_embed_python); script="$SCHEMA_DIR/graph.py"
+  [ -f "$script" ] || { echo "graph.py not found next to agentdb" >&2; return 3; }
+  command -v "$py" >/dev/null 2>&1 || py=python3
+  "$py" "$script" "$@"
+}
+
 # Emit _recall_emit-format rows for an explicit newline-list of ids (used to pull
 # display text for semantic-only hits that FTS did not match). Visibility/archived
 # filtered like _recall_emit. <origin> tags the rows for reinforcement routing.
@@ -1945,7 +1958,10 @@ _emit_rows_by_ids() {
 # A row missing from a ranker simply contributes 0 from that side. Small N -> an
 # O(n^2) selection sort is fine and keeps this dependency-free.
 _hybrid_rerank() {
-  awk -F'@@US@@' -v semf="$1" -v ftsf="$2" -v k=60 '
+  # RRF constant: lower k sharpens the top-rank contribution (better recall@1),
+  # higher k blends more evenly. 60 is the literature standard; AGENTDB_RRF_K tunes it.
+  local rrf_k="${AGENTDB_RRF_K:-60}"
+  awk -F'@@US@@' -v semf="$1" -v ftsf="$2" -v k="$rrf_k" '
     BEGIN{
       while((getline l < semf) > 0){ n=split(l,a,"\t"); if(n>=2) semr[a[1]]=a[2] }
       while((getline l < ftsf) > 0){ n=split(l,a,"\t"); if(n>=2) ftsr[a[1]]=a[2] }
@@ -2515,6 +2531,8 @@ case "${1:-help}" in
   embed-sync)  shift; _ensure_embedding_cols; _embed_run sync "$DB" ;;
   embed-status) shift; _embed_run backend || { echo "no embedding backend installed — recall is FTS-only (see: agentdb embed-init)"; exit 0; } ;;
   embed-init)  shift; cmd_embed_init "$@" ;;
+  graph)       shift; _graph_run "${1:-build}" "$DB" "${@:2}" ;;
+  promote)     shift; _graph_run promote "$DB" "$@" ;;
   export)      cmd_export ;;
   export-json) shift; cmd_export_json "$@" ;;
   import-json) shift; cmd_import_json "$@" ;;

--- a/orchestration/agentdb/eval/run_eval.py
+++ b/orchestration/agentdb/eval/run_eval.py
@@ -47,23 +47,42 @@ def recall_ids(db, query, env_extra, k):
     return [ln.strip() for ln in out.splitlines() if ln.strip()][:k]
 
 
+K_LIST = (1, 3, 5, 10)
+
+
+def _reciprocal_rank(got, relevant):
+    for i, gid in enumerate(got, 1):
+        if gid in relevant:
+            return 1.0 / i
+    return 0.0
+
+
 def score(gold, db, env_extra, k):
-    recalls, hits = [], []
+    # Retrieve top-max(K_LIST) once per query; score recall@k for every k + MRR.
+    retrieve_n = max(max(K_LIST), k)
+    per_k_recall = {kk: [] for kk in K_LIST}
+    rrs = []
+    primary_recall, primary_hits = [], []
     per_query = []
     for item in gold:
         relevant = set(item["relevant"])
         if not relevant:
             continue
-        got = recall_ids(db, item["query"], env_extra, k)
-        topk = set(got[:k])
-        inter = relevant & topk
-        r = len(inter) / len(relevant)
-        recalls.append(r)
-        hits.append(1.0 if inter else 0.0)
+        got = recall_ids(db, item["query"], env_extra, retrieve_n)
+        for kk in K_LIST:
+            inter = relevant & set(got[:kk])
+            per_k_recall[kk].append(len(inter) / len(relevant))
+        rrs.append(_reciprocal_rank(got, relevant))
+        inter_k = relevant & set(got[:k])
+        r = len(inter_k) / len(relevant)
+        primary_recall.append(r)
+        primary_hits.append(1.0 if inter_k else 0.0)
         per_query.append({"query": item["query"], "recall": r,
                           "got": got[:k], "relevant": sorted(relevant)})
     mean = lambda xs: (sum(xs) / len(xs)) if xs else 0.0
-    return mean(recalls), mean(hits), per_query
+    metrics = {"recall_at": {kk: round(mean(v), 4) for kk, v in per_k_recall.items()},
+               "mrr": round(mean(rrs), 4)}
+    return mean(primary_recall), mean(primary_hits), per_query, metrics
 
 
 def main(argv):
@@ -85,18 +104,22 @@ def main(argv):
     if args.embed_python:
         hyb_env["AGENTDB_EMBED_PYTHON"] = args.embed_python
 
-    r_base, h_base, pq_base = score(gold, args.db, base_env, args.k)
-    r_hyb, h_hyb, pq_hyb = score(gold, args.db, hyb_env, args.k)
+    r_base, h_base, pq_base, m_base = score(gold, args.db, base_env, args.k)
+    r_hyb, h_hyb, pq_hyb, m_hyb = score(gold, args.db, hyb_env, args.k)
 
     if not args.quiet:
-        print("=" * 60)
-        print("agentdb recall eval  (k=%d, %d gold queries)" % (args.k, len(gold)))
-        print("  backend: %s" % (args.backend or "auto"))
-        print("-" * 60)
-        print("  FTS-only   recall@%d = %.3f   hit@%d = %.3f" % (args.k, r_base, args.k, h_base))
-        print("  HYBRID     recall@%d = %.3f   hit@%d = %.3f" % (args.k, r_hyb, args.k, h_hyb))
-        print("  delta      recall    = %+.3f            hit    = %+.3f" % (r_hyb - r_base, h_hyb - h_base))
-        print("=" * 60)
+        print("=" * 64)
+        print("agentdb recall eval  (%d gold queries, backend: %s)" % (len(gold), args.backend or "auto"))
+        print("-" * 64)
+        print("  %-10s %8s %8s %8s %8s %8s" % ("arm", "r@1", "r@3", "r@5", "r@10", "MRR"))
+        for label, m in (("FTS-only", m_base), ("HYBRID", m_hyb)):
+            ra = m["recall_at"]
+            print("  %-10s %8.3f %8.3f %8.3f %8.3f %8.3f" % (
+                label, ra[1], ra[3], ra[5], ra[10], m["mrr"]))
+        dra = {kk: m_hyb["recall_at"][kk] - m_base["recall_at"][kk] for kk in K_LIST}
+        print("  %-10s %+8.3f %+8.3f %+8.3f %+8.3f %+8.3f" % (
+            "delta", dra[1], dra[3], dra[5], dra[10], m_hyb["mrr"] - m_base["mrr"]))
+        print("=" * 64)
         # show queries where hybrid changed the outcome
         for b, hq in zip(pq_base, pq_hyb):
             if abs(hq["recall"] - b["recall"]) > 1e-9:
@@ -108,6 +131,7 @@ def main(argv):
         "recall_baseline": round(r_base, 4), "recall_hybrid": round(r_hyb, 4),
         "hit_baseline": round(h_base, 4), "hit_hybrid": round(h_hyb, 4),
         "delta_recall": round(r_hyb - r_base, 4),
+        "baseline_metrics": m_base, "hybrid_metrics": m_hyb,
     }))
     return 0
 

--- a/orchestration/agentdb/graph.py
+++ b/orchestration/agentdb/graph.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""agentdb learning graph + promotion — derived from embeddings, no external deps.
+
+Builds a knowledge graph OVER the learnings (distinct from the context-load telemetry
+in the `nodes`/`edges` tables, migration 002): edges connect learnings that are
+semantically related (cosine over the migration-015 embeddings) or explicitly linked
+(`[[double-bracket]]` references in insight/evidence). On top of that, a promotion
+detector clusters recurring failures — the "a failure seen 3x becomes doctrine" idea —
+and surfaces candidates for human/agent review (never auto-writes doctrine).
+
+Everything here is DERIVED data: the `learning_edges` table rebuilds from embeddings +
+learning text via `agentdb graph build`, so it is excluded from the JSON mirror like the
+embedding BLOBs. Degrades gracefully: with no embeddings, only `[[link]]` edges are built.
+
+Subcommands:
+  build   <db>            (re)build learning_edges from cosine + [[links]]; print counts
+  neighbors <db> <id>     list a learning's edges (traversal / debugging)
+  promote <db> [--min N]  cluster recurring failures (default >=3) -> promotion candidates
+  stats   <db>            edge/cluster summary
+
+Thresholds (tunable via env): AGENTDB_SIM_EDGE (default 0.45) links "similar";
+AGENTDB_SIM_DUP (default 0.80) marks "near_duplicate".
+"""
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import sys
+
+SIM_EDGE = float(os.environ.get("AGENTDB_SIM_EDGE", "0.45"))
+SIM_DUP = float(os.environ.get("AGENTDB_SIM_DUP", "0.80"))
+
+try:
+    import numpy as _np
+except Exception:
+    _np = None
+
+DDL = """
+CREATE TABLE IF NOT EXISTS learning_edges (
+  src      TEXT NOT NULL,
+  dst      TEXT NOT NULL,
+  relation TEXT NOT NULL,          -- 'similar' | 'near_duplicate' | 'references'
+  weight   REAL DEFAULT 1.0,
+  ts       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY (src, dst, relation)
+);
+CREATE INDEX IF NOT EXISTS idx_ledges_src ON learning_edges(src);
+CREATE INDEX IF NOT EXISTS idx_ledges_rel ON learning_edges(relation);
+"""
+
+
+def _ensure(con):
+    con.executescript(DDL)
+
+
+def _unpack(blob):
+    n = len(blob) // 4
+    if _np is not None:
+        return _np.frombuffer(blob, dtype="<f4", count=n)
+    import struct
+    return list(struct.unpack("<%df" % n, blob))
+
+
+def _cos(a, b):
+    # vectors are L2-normalized at embed time -> cosine is the dot product
+    if _np is not None:
+        return float(a.dot(b)) if a.shape == b.shape else -1.0
+    if len(a) != len(b):
+        return -1.0
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _load(con):
+    cols = {r[1] for r in con.execute("PRAGMA table_info(learnings)")}
+    arch = "AND archived_at IS NULL" if "archived_at" in cols else ""
+    rows = con.execute(
+        "SELECT id, type, insight, COALESCE(evidence,''), embedding FROM learnings "
+        "WHERE 1=1 %s" % arch
+    ).fetchall()
+    items = []
+    for rid, typ, insight, evidence, emb in rows:
+        items.append({"id": rid, "type": typ, "insight": insight,
+                      "text": insight + " " + evidence,
+                      "vec": _unpack(emb) if emb else None})
+    return items
+
+
+_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def cmd_build(db):
+    con = sqlite3.connect(db)
+    _ensure(con)
+    con.execute("DELETE FROM learning_edges")  # full rebuild (idempotent)
+    items = _load(con)
+    by_id = {it["id"]: it for it in items}
+
+    n_sim = n_dup = n_ref = 0
+    # 1) semantic edges (undirected, stored once with src<dst) — needs embeddings
+    embedded = [it for it in items if it["vec"] is not None]
+    for i in range(len(embedded)):
+        for j in range(i + 1, len(embedded)):
+            a, b = embedded[i], embedded[j]
+            s = _cos(a["vec"], b["vec"])
+            if s < SIM_EDGE:
+                continue
+            rel = "near_duplicate" if s >= SIM_DUP else "similar"
+            src, dst = sorted((a["id"], b["id"]))
+            con.execute(
+                "INSERT OR REPLACE INTO learning_edges(src,dst,relation,weight) VALUES(?,?,?,?)",
+                (src, dst, rel, round(s, 4)))
+            if rel == "near_duplicate":
+                n_dup += 1
+            else:
+                n_sim += 1
+    # 2) explicit [[link]] references (directed) — resolve link text against insights
+    for it in items:
+        for m in _LINK_RE.findall(it["text"]):
+            key = m.strip().lower()
+            for other in items:
+                if other["id"] == it["id"]:
+                    continue
+                if key in other["insight"].lower()[:60] or key in other["id"].lower():
+                    con.execute(
+                        "INSERT OR REPLACE INTO learning_edges(src,dst,relation,weight) VALUES(?,?,?,?)",
+                        (it["id"], other["id"], "references", 1.0))
+                    n_ref += 1
+                    break
+    con.commit()
+    con.close()
+    print("graph build: %d similar, %d near-duplicate, %d reference edge(s) over %d learnings (%d embedded)"
+          % (n_sim, n_dup, n_ref, len(items), len(embedded)))
+    return 0
+
+
+def _components(ids, edges):
+    """Union-find connected components over an edge list."""
+    parent = {i: i for i in ids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in edges:
+        if a in parent and b in parent:
+            parent[find(a)] = find(b)
+    comps = {}
+    for i in ids:
+        comps.setdefault(find(i), []).append(i)
+    return list(comps.values())
+
+
+# Promotion clusters use a TIGHTER similarity than graph edges: a recurring theme
+# worth a doctrine entry means genuinely cohesive failures, not the transitive
+# hairball that a loose threshold + single-linkage produces. hit_count is NOT used —
+# it measures recall relevance, not recurrence, and is inflated by surfacing.
+SIM_PROMOTE = float(os.environ.get("AGENTDB_SIM_PROMOTE", "0.55"))
+
+
+def cmd_promote(db, min_size=3):
+    con = sqlite3.connect(db)
+    _ensure(con)
+    cols = {r[1] for r in con.execute("PRAGMA table_info(learnings)")}
+    arch = "AND archived_at IS NULL" if "archived_at" in cols else ""
+    fails = con.execute(
+        "SELECT id, insight FROM learnings WHERE type IN ('failure','gotcha') %s" % arch
+    ).fetchall()
+    fail_ids = {r[0] for r in fails}
+    insight = {r[0]: r[1] for r in fails}
+    # cohesive edges among failures only: weight >= SIM_PROMOTE (tighter than graph build)
+    edges = [(s, d) for s, d, w in con.execute(
+        "SELECT src,dst,weight FROM learning_edges WHERE relation IN ('similar','near_duplicate')")
+        if s in fail_ids and d in fail_ids and (w or 0) >= SIM_PROMOTE]
+    con.close()
+
+    candidates = []
+    for comp in _components(list(fail_ids), edges):
+        if len(comp) >= min_size:
+            candidates.append({"reason": "%d cohesive recurring failures (sim>=%.2f) — candidate doctrine theme"
+                               % (len(comp), SIM_PROMOTE),
+                               "members": [(i, insight[i]) for i in comp]})
+    return candidates
+
+
+def cmd_neighbors(db, lid):
+    con = sqlite3.connect(db)
+    _ensure(con)
+    rows = con.execute(
+        "SELECT src,dst,relation,weight FROM learning_edges WHERE src=? OR dst=? ORDER BY weight DESC",
+        (lid, lid)).fetchall()
+    con.close()
+    if not rows:
+        print("no edges for %s (run: agentdb graph build)" % lid)
+        return 0
+    for s, d, rel, w in rows:
+        other = d if s == lid else s
+        print("  %-14s %s  (w=%.3f)" % (rel, other, w))
+    return 0
+
+
+def cmd_stats(db):
+    con = sqlite3.connect(db)
+    _ensure(con)
+    for rel in ("similar", "near_duplicate", "references"):
+        n = con.execute("SELECT COUNT(*) FROM learning_edges WHERE relation=?", (rel,)).fetchone()[0]
+        print("  %-14s %d" % (rel, n))
+    con.close()
+    return 0
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write("usage: graph.py {build|neighbors|promote|stats} <db> [args]\n")
+        return 2
+    cmd, db = argv[1], argv[2]
+    if cmd == "build":
+        return cmd_build(db)
+    if cmd == "stats":
+        return cmd_stats(db)
+    if cmd == "neighbors":
+        if len(argv) < 4:
+            sys.stderr.write("usage: graph.py neighbors <db> <learning-id>\n")
+            return 2
+        return cmd_neighbors(db, argv[3])
+    if cmd == "promote":
+        min_size = 3
+        if "--min" in argv:
+            min_size = int(argv[argv.index("--min") + 1])
+        cands = cmd_promote(db, min_size)
+        if not cands:
+            print("no promotion candidates (no failure cluster >= %d, no failure reinforced >= %dx)"
+                  % (min_size, min_size * 2))
+            return 0
+        print("## Promotion candidates (%d) — recurring failures worth hardening into doctrine\n" % len(cands))
+        for c in cands:
+            print("- **%s**" % c["reason"])
+            for lid, ins in c["members"]:
+                print("    - [%s] %s" % (lid, ins[:100]))
+            print()
+        return 0
+    sys.stderr.write("unknown subcommand: %s\n" % cmd)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/orchestration/agentdb/migrations/016_learning_graph.sql
+++ b/orchestration/agentdb/migrations/016_learning_graph.sql
@@ -1,0 +1,18 @@
+-- Migration 016: learning knowledge graph (edges + promotion).
+--
+-- WHY (agentdb rethink, 2026-07-16): after embeddings (015) gave semantic distance,
+-- the second lever is a graph OVER the learnings — edges connect semantically-related
+-- or [[link]]-referenced learnings, so you can traverse related lessons, dedup, and
+-- detect recurring-failure clusters worth promoting to doctrine. This is distinct from
+-- the context-load telemetry in `nodes`/`edges` (migration 002), which tracks which
+-- skill/file co-loads with which, not learning-to-learning meaning.
+--
+-- The `learning_edges` table is DERIVED: it rebuilds from the embeddings + learning
+-- text via `agentdb graph build`, so it is excluded from the JSON mirror (like the
+-- embedding BLOBs) and self-creates via graph.py's DDL. This marker records provenance;
+-- the CREATE lives in orchestration/agentdb/graph.py (CREATE TABLE IF NOT EXISTS) so a
+-- graph command works on any DB without a schema migration step.
+--   learning_edges(src, dst, relation IN ('similar','near_duplicate','references'), weight, ts)
+--
+-- Commands: `agentdb graph build|neighbors|stats`, `agentdb promote [--min N]`.
+INSERT OR IGNORE INTO _migrations (name) VALUES ('016_learning_graph');

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.5.0.
+Quick reference for KERNEL v8.5.1.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2828,6 +2828,61 @@ test_read_start_outputs_gotchas() {
   assert_contains "$output" "[gotcha] always escape SQL inputs"
 }
 
+# === migration 016: learning graph + promotion (CI-safe via hash backend) ===
+test_graph_build_creates_edges() {
+  agentdb init >/dev/null
+  agentdb learn failure "launchd scheduled job on macos failed permission denied" "a" >/dev/null
+  agentdb learn failure "launchd scheduled job on macos permission error tcc" "b" >/dev/null
+  agentdb learn failure "launchd scheduled job on macos denied full disk access" "c" >/dev/null
+  agentdb learn pattern "reticulate splines in the frobnicator widget" "z" >/dev/null
+  agentdb recall warmup >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
+  local out
+  out=$(env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb graph build 2>/dev/null)
+  echo "$out" | grep -qE 'similar' || { echo "graph build produced no summary: $out"; return 1; }
+  local n
+  n=$(sqlite3 "$CLAUDE_PROJECT_DIR/_meta/agentdb/agent.db" "SELECT COUNT(*) FROM learning_edges;" 2>/dev/null)
+  [ "${n:-0}" -ge 1 ] || { echo "expected >=1 edge, got $n"; return 1; }
+}
+
+test_graph_promote_finds_cluster() {
+  agentdb init >/dev/null
+  agentdb learn failure "launchd scheduled job on macos failed permission denied" "a" >/dev/null
+  agentdb learn failure "launchd scheduled job on macos permission error tcc" "b" >/dev/null
+  agentdb learn failure "launchd scheduled job on macos denied full disk access" "c" >/dev/null
+  agentdb recall warmup >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb graph build >/dev/null 2>&1
+  local out
+  out=$(env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 AGENTDB_SIM_PROMOTE=0.2 agentdb promote --min 3 2>/dev/null)
+  echo "$out" | grep -qiE 'cohesive|candidate' || { echo "expected a promotion candidate, got: $out"; return 1; }
+}
+
+test_graph_promote_empty_when_no_cluster() {
+  agentdb init >/dev/null
+  agentdb learn failure "totally unrelated alpha beta gamma" "a" >/dev/null
+  agentdb learn failure "completely different delta epsilon zeta" "b" >/dev/null
+  agentdb recall warmup >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb graph build >/dev/null 2>&1
+  local out
+  out=$(env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb promote --min 3 2>/dev/null)
+  echo "$out" | grep -qi "no promotion candidates" || { echo "expected no candidates, got: $out"; return 1; }
+}
+
+test_graph_edges_excluded_from_mirror() {
+  agentdb init >/dev/null
+  agentdb learn failure "launchd job permission denied macos" "a" >/dev/null
+  agentdb learn failure "launchd job permission error macos tcc" "b" >/dev/null
+  agentdb recall warmup >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb embed-sync >/dev/null 2>&1
+  env AGENTDB_EMBED_BACKEND=hash AGENTDB_EMBED_PYTHON=python3 agentdb graph build >/dev/null 2>&1
+  agentdb export-json >/dev/null 2>&1
+  grep -q "learning_edges" "$CLAUDE_PROJECT_DIR/_meta/agentdb/agent.db.json" \
+    && { echo "learning_edges must be excluded from the mirror (derived data)"; return 1; }
+  return 0
+}
+
 test_read_start_lean_is_minimal() {
   # 8.4.0: --lean is the SessionStart surface. It emits a memory count + a recall
   # pointer + only the top failures, and SKIPS the full weighted dump, the recent-
@@ -5044,6 +5099,10 @@ run_test_suite() {
       run_test "read-start --lean is minimal (8.4.0)" test_read_start_lean_is_minimal
       run_test "session-start gives concrete recall recipe" test_session_start_has_concrete_recall_recipe
       run_test "read-start full keeps weighted + tail" test_read_start_full_still_has_weighted_and_tail
+      run_test "graph build creates edges (016)" test_graph_build_creates_edges
+      run_test "graph promote finds a cluster" test_graph_promote_finds_cluster
+      run_test "graph promote empty when no cluster" test_graph_promote_empty_when_no_cluster
+      run_test "graph edges excluded from mirror" test_graph_edges_excluded_from_mirror
       run_test "read-start bumps load_count not hit_count" test_read_start_bumps_load_count_not_hit_count
       ;;
     marketing)


### PR DESCRIPTION
## KERNEL 8.5.1 "learning graph"

The second AgentDB lever after embeddings (8.3.0): a knowledge graph OVER the learnings, plus a recurring-failure promotion detector. Built cleanly on top of 8.5.0 (marketing-recall) — file-disjoint, cherry-picked.

### What's new
- **`agentdb graph build | neighbors | stats`** — `learning_edges` connecting learnings by semantic cosine (over the 015 embeddings) + `[[link]]` references. Distinct from the context-load telemetry in `nodes`/`edges` (002).
- **`agentdb promote [--min N]`** — clusters recurring failures (cohesive edges, sim ≥ 0.55, min 3) into candidate doctrine themes for review. Never auto-writes doctrine. `hit_count` deliberately not used (it's recall relevance, not recurrence).
- **Recall eval** now reports recall@1/@3/@10 + MRR; RRF constant tunable via `AGENTDB_RRF_K` (default 60, confirmed optimal).

### Derived, not mirrored
`learning_edges` rebuilds from embeddings + `[[links]]` via `graph build`, so it's excluded from the JSON mirror like the embedding BLOBs.

### Verified
- Real 47-learning corpus: 29 edges; `promote` surfaces one coherent cluster (Codex-hooks-in-vault failures), nothing spurious.
- Widened gold set (48 queries): hybrid's real win is ranking precision — recall@1 +0.146, MRR +0.107.
- 4 new graph tests; full suite 426/426.