### PR TITLE
release(guard): 8.5.2 config guard exempts harness session data

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.5.1 adds a learning graph over AgentDB memory (semantic edges + recurring-failure promotion to doctrine candidates), on top of 8.5.0 marketing/frontend skills, 8.4.0 lean session start, 8.3.0 local semantic recall, and the 8.2.0 six-threat security guard.",
-      "version": "8.5.1"
+      "description": "Durable project memory, bounded JSON handoffs, engineering workflows, and independent verification for Claude Code and Codex. KERNEL 8.5.2 fixes the config guard misfiring on harness session data (~/.claude/projects). 8.5.1 adds a learning graph over AgentDB memory (semantic edges + recurring-failure promotion to doctrine candidates), on top of 8.5.0 marketing/frontend skills, 8.4.0 lean session start, 8.3.0 local semantic recall, and the 8.2.0 six-threat security guard.",
+      "version": "8.5.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.5.1",
+  "version": "8.5.2",
   "description": "Durable project memory, bounded JSON handoffs, 35 engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.5.0 adds context-led frontend and honest marketing-site methods, plus concrete repeatable AgentDB recall prompts.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 217e339d59806b5839c31d163a34b1dca2e8ad6e64888d2aaa1cd3705749c02f; adapter: codex -->
-<kernel version="8.5.1">
+<kernel version="8.5.2">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.5.2] - 2026-07-17 "harness-projects guard fix"
+
+### Fixed
+- **guard-config.sh no longer blocks harness session data.** The `.claude/` config guard
+  pattern-matched ANY path containing `.claude/`, which swept in `~/.claude/projects/`:
+  the harness's own machine-managed state (session transcripts, per-project memory,
+  workflow scripts, subagent state). This blocked Claude Code from editing its own
+  persisted workflow scripts mid-run. `$HOME/.claude/projects/` is now exempt from the
+  config allowlist. The exemption sits AFTER the dot-segment traversal check, so paths
+  like `~/.claude/projects/../settings.json` remain blocked. Repo-level `.claude/` dirs
+  and all 8.2.0 sensitive-path blocks are unchanged. Two regression tests added.
+
 ## [8.5.1] - 2026-07-17 "learning graph"
 
 The second AgentDB lever after embeddings: a knowledge graph OVER the learnings, plus a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 217e339d59806b5839c31d163a34b1dca2e8ad6e64888d2aaa1cd3705749c02f; adapter: claude -->
-<kernel version="8.5.1">
+<kernel version="8.5.2">
 
 
 <!-- ============================================ -->

--- a/hooks/scripts/guard-config.sh
+++ b/hooks/scripts/guard-config.sh
@@ -80,6 +80,15 @@ while IFS= read -r FILE_PATH; do
     exit 2
   fi
 
+  # Harness-managed session data (~/.claude/projects/): transcripts, per-project
+  # memory, workflow scripts, subagent state. Machine-owned state, not config --
+  # the config allowlist does not apply. Placed AFTER the dot-segment check so a
+  # traversal like ~/.claude/projects/../settings.json is still blocked. (8.5.2:
+  # the guard wrongly blocked the harness editing its own workflow scripts.)
+  case "$FILE_PATH" in
+    "$HOME/.claude/projects/"*) continue ;;
+  esac
+
   # Allow: CLAUDE.md, rules/*.md, commands/*.md, agents/*.md, skills/*.md, hooks/*.sh, settings*.json
   if echo "$FILE_PATH" | grep -qE '\.claude/(CLAUDE\.md|rules/.*\.md|commands/.*\.md|agents/.*\.md|skills/.*\.md|hooks/.*\.sh|settings.*\.json|projects/.*/memory/.*)$'; then
     continue

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.5.1.
+Quick reference for KERNEL v8.5.2.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1005,6 +1005,20 @@ test_guard_config_blocks_codex_dot_segment_bypass() {
   assert_exit_code 2 "$ec" "dot segments must not escape the .claude allowlist"
 }
 
+test_guard_config_allows_harness_session_data() {
+  local json
+  json=$(jq -n --arg fp "$HOME/.claude/projects/-Users-x-proj/abc123/workflows/scripts/audit.js" '{tool_input:{file_path:$fp}}')
+  printf '%s\n' "$json" | "$PLUGIN_ROOT/hooks/scripts/guard-config.sh" >/dev/null 2>&1
+  assert_exit_code 0 "$?" "harness session data under ~/.claude/projects/ must not be treated as config"
+}
+
+test_guard_config_blocks_harness_traversal_escape() {
+  local json ec=0
+  json=$(jq -n --arg fp "$HOME/.claude/projects/../settings.json" '{tool_input:{file_path:$fp}}')
+  printf '%s\n' "$json" | "$PLUGIN_ROOT/hooks/scripts/guard-config.sh" >/dev/null 2>&1 || ec=$?
+  assert_exit_code 2 "$ec" "dot-segment traversal must not ride the harness-projects exemption"
+}
+
 test_guard_config_fails_closed_on_malformed_json() {
   local ec=0
   printf '{malformed\n' | "$PLUGIN_ROOT/hooks/scripts/guard-config.sh" >/dev/null 2>&1 || ec=$?
@@ -1722,7 +1736,7 @@ test_critical_guard_scripts_unchanged_for_820() {
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
 16e5c6d2e357ed225f31c319c4af2a797afd4bcdb85b8cdd01fc874a14b0af18 guard-bash.sh
-8e8ff30a76fc4056ef5b3347e04ea7a1b44507baa89aa79a98b40fd23c334da3 guard-config.sh
+115785e567cecaa9292565c88e963911ff62e8802b4e2e99d676e71084aced6a guard-config.sh
 d3611267b4f135c5b96e8a4a8af60f296b196efc135e3dfbef63d7683065608c detect-secrets.sh
 e1c4940def589dce982695d7e79f22e11cb767f6260608a738801f6c4167afbc guard-context.sh
 EOF
@@ -4911,6 +4925,8 @@ run_test_suite() {
       run_test "guard-config blocks Codex apply_patch" test_guard_config_blocks_codex_apply_patch
       run_test "guard-config allows Codex apply_patch rule" test_guard_config_allows_codex_apply_patch_rule
       run_test "guard-config blocks Codex dot segment bypass" test_guard_config_blocks_codex_dot_segment_bypass
+      run_test "guard-config allows harness session data" test_guard_config_allows_harness_session_data
+      run_test "guard-config blocks harness traversal escape" test_guard_config_blocks_harness_traversal_escape
       run_test "guard-config fails closed on malformed JSON" test_guard_config_fails_closed_on_malformed_json
       run_test "detect-secrets fails closed on malformed JSON" test_detect_secrets_fails_closed_on_malformed_json
       run_test "Codex risky skills are explicit-only" test_codex_explicit_only_skill_policies


### PR DESCRIPTION
guard-config.sh pattern-matched any path containing .claude/, which swept in ~/.claude/projects/ - the harness's own machine-managed session data (transcripts, per-project memory, persisted workflow scripts). This blocked Claude Code from editing its own workflow scripts mid-run (hit live 2026-07-17 during the intellectual-audit workflow).

Fix: exempt $HOME/.claude/projects/ from the config allowlist, placed after the dot-segment traversal check so ~/.claude/projects/../settings.json remains blocked. Repo-level .claude/ guarding and all 8.2.0 sensitive-path blocks unchanged.

Tests: 2 regressions added (allow harness session data, block traversal escape); 8.2.0 integrity pin updated deliberately. Full suite 428/428.