### PR TITLE
release(auto-orientation): 8.6.1 — inject graph spine at session start

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness. 8.5.x: config-guard fix, learning graph, semantic recall, six-threat security guard.",
-      "version": "8.6.0"
+      "version": "8.6.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: codex -->
-<kernel version="8.6.0">
+<kernel version="8.6.1">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.6.1] - 2026-07-22 "auto-orientation"
+
+Makes 8.6.0's knowledge-graph actually pay off without anyone remembering to use it. A skill
+that tells the agent to reach for the graph is opt-in cognition — it mostly won't happen. The
+automatic half is ambient: inject the graph's architectural spine into session-start context so
+the agent boots ALREADY oriented instead of file-crawling to rebuild the map every session.
+
+### Added
+- **`session-start.sh` auto-orientation** — if the working repo has a `graphify-out/graph.json`
+  (root or `_meta/`), the session-start hook emits a compact "Code map" block: the top god-nodes
+  (architectural hubs) + the `graphify query`/`path`/`affected` commands to navigate without
+  reading files. **Self-gating**: silent when no graph exists, so users without graphs see no
+  change. This is the automatic layer; the MCP/CLI deep-query tools remain available for on-demand
+  traversal. Regression test added.
+
 ## [8.6.0] - 2026-07-22 "knowledge-graph"
 
 A new methodology skill and an opt-in freshness hook. Fully additive; no change to existing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: claude -->
-<kernel version="8.6.0">
+<kernel version="8.6.1">
 
 
 <!-- ============================================ -->

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -239,6 +239,27 @@ else
   echo ""
 fi
 
+# --- Knowledge-graph auto-orientation (8.6.1) ---
+# If this repo has a code graph, inject its architectural spine so the agent boots ALREADY
+# oriented instead of file-crawling to rebuild the map every session. This is the automatic
+# half of the knowledge-graph capability: ambient context, not a tool the agent must remember
+# to call. Self-gating: silent when no graph exists, so users without graphs see no change.
+if command -v graphify >/dev/null 2>&1; then
+  for _gj in "$PROJECT_ROOT/graphify-out/graph.json" "$PROJECT_ROOT/_meta/graphify-out/graph.json"; do
+    [ -f "$_gj" ] || continue
+    _hubs="$(graphify god-nodes --top 8 --graph "$_gj" 2>/dev/null | grep -E '^[[:space:]]*[0-9]+\.' | sed 's/^[[:space:]]*/  /')"
+    [ -n "$_hubs" ] || continue
+    echo "## Code map (auto-orientation)"
+    echo "This repo has a knowledge graph — these are its architectural hubs. Consult the graph"
+    echo "BEFORE crawling files to find where something lives:"
+    echo "$_hubs"
+    echo "Query without reading files: \`graphify query \"<question>\"\` · \`graphify path A B\` · \`graphify affected X\`"
+    echo ""
+    break
+  done
+fi
+# --- end auto-orientation ---
+
 # Emit session start event
 "$AGENTDB" emit session "session:start" "" "{\"branch\":\"$(git branch --show-current 2>/dev/null || echo none)\",\"profile\":\"$PROFILE\",\"project\":\"$PROJECT_ROOT\"}" "" "$KERNEL_SESSION_ID" 2>/dev/null &
 _kernel_hook_end "session-start" 0

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.6.0.
+Quick reference for KERNEL v8.6.1.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/skills/knowledge-graph/SKILL.md
+++ b/skills/knowledge-graph/SKILL.md
@@ -56,6 +56,15 @@ never-linked nodes are dead-code / consolidation candidates. Also available as a
 (`query_graph`, `shortest_path`, `get_neighbors`) for repeated structured access.
 </query>
 
+<automatic>
+The graph pays off only if it is CONSULTED. A skill telling the agent to reach for it is opt-in
+and unreliable, so the orientation layer is AMBIENT: when the working repo has a graph, the
+session-start hook injects its architectural spine (top god-nodes + the query commands) directly
+into context — the agent boots already oriented, no tool call, no human ask. Deep on-demand
+queries ("what calls this exact function") still go through `graphify query`/`path`/`affected`
+or the MCP tools; those are available + steered, but the baseline map arrives for free.
+</automatic>
+
 <continuous>
 A stale graph is worse than none. Keep it fresh, cheaply:
 - **Code layer (free):** `graphify extract <path> --code-only` is incremental via its AST cache

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -3508,6 +3508,19 @@ test_knowledge_graph_installer_optin_installs() {
   assert_contains "$content" "code-only" "hook must extract code-only (never graphify update)"
 }
 
+test_knowledge_graph_session_start_auto_orientation() {
+  # session-start.sh must contain the ambient auto-orientation block (god-nodes injection)
+  local content; content=$(cat "$PLUGIN_ROOT/hooks/scripts/session-start.sh")
+  assert_contains "$content" "auto-orientation" "session-start must inject graph orientation" || return 1
+  assert_contains "$content" "god-nodes" "auto-orientation must emit god-nodes (architectural hubs)"
+}
+
+test_knowledge_graph_auto_orientation_self_gates() {
+  # the block must be guarded by a graph-exists check (silent when no graph)
+  local content; content=$(cat "$PLUGIN_ROOT/hooks/scripts/session-start.sh")
+  assert_contains "$content" 'graphify-out/graph.json' "auto-orientation must gate on graph.json existing"
+}
+
 test_knowledge_graph_installer_preserves_foreign_hook() {
   # must NEVER clobber a foreign post-commit
   git init -q "$TEST_PROJECT" 2>/dev/null
@@ -4756,6 +4769,8 @@ run_test_suite() {
       run_test "installer is opt-in (no stamp without KERNEL_GRAPH_ON)" test_knowledge_graph_installer_is_optin
       run_test "installer stamps marked hook with KERNEL_GRAPH_ON=1" test_knowledge_graph_installer_optin_installs
       run_test "installer preserves a foreign post-commit" test_knowledge_graph_installer_preserves_foreign_hook
+      run_test "session-start injects auto-orientation (god-nodes)" test_knowledge_graph_session_start_auto_orientation
+      run_test "auto-orientation self-gates on graph existence" test_knowledge_graph_auto_orientation_self_gates
       ;;
     manifest)
       run_test "schemas parse as JSON" test_manifest_schemas_parse_as_json


### PR DESCRIPTION
Makes 8.6.0 pay off automatically. session-start.sh now injects the working repo's graph spine (god-nodes + query commands) into context when a graph exists — agent boots oriented, no tool call, no human ask. Self-gating. 2 tests, full suite 436/436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)