### PR TITLE
release(agentdb): 8.6.2 recall reliability — SIGPIPE fix + FTS-first default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness. 8.5.x: config-guard fix, learning graph, semantic recall, six-threat security guard.",
-      "version": "8.6.1"
+      "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.2 hardens recall: fixes a SIGPIPE-under-pipefail bug that silently zeroed 76% of results, and makes pure-FTS the eval-proven default (semantic-embed hybrid now opt-in via AGENTDB_EMBED=1). 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness.",
+      "version": "8.6.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: codex -->
-<kernel version="8.6.1">
+<kernel version="8.6.2">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.6.2] - 2026-07-24 "recall reliability"
+
+Two recall fixes that together take `agentdb recall` from silently-broken-and-slower to
+deterministic-and-better. Fully backward compatible: every prior behavior path is preserved,
+the semantic-embed hybrid is still available (now opt-in).
+
+### Fixed
+- **Recall SIGPIPE under `pipefail`** — the migration-015 hybrid re-rank and the main dedup
+  step piped into `head -n N`. Under `set -euo pipefail`, when `head` closed the pipe early
+  while upstream was still writing, upstream took SIGPIPE, `pipefail` propagated exit 141, and
+  `set -e` aborted recall after printing only the `## Recall:` header. This silently truncated
+  live recall to a **76% zero-result rate** (recall@5 0.238) undetected, and made results flaky
+  run-to-run. Replaced the two early-closing `| head -n N` with `| awk -v n=N 'NR<=n'` (a
+  full-read limiter that never closes the pipe early; identical output). Verified on
+  `_meta/evals/recall`: zero-result rate **76% -> 0%**, now deterministic.
+
+### Changed
+- **Recall defaults to pure FTS; the semantic-embed hybrid is now opt-in** — a controlled
+  re-run of the recall eval (both arms, live DB) showed the pure keyword/bm25 arm beats the
+  embed hybrid on **every** metric: recall@5 **0.857 vs 0.809**, MRR **0.786 vs 0.746**,
+  precision@5 **0.190 vs 0.171**, and negative correctness **2/2 vs 0/2** (the hybrid dragged
+  in two semantically-adjacent but off-domain false hits). So `recall` now runs pure FTS by
+  default. Opt into the hybrid with **`AGENTDB_EMBED=1`** (a backend must still be installed via
+  `agentdb embed-init`). `AGENTDB_NO_EMBED=1` still forces pure FTS (now redundant-but-honored).
+  No change to `embed-sync`, `graph build`, or `promote`, which use embeddings directly.
+  Documented in CLI help + `embed-init` output. Regression test added
+  (`recall defaults to pure FTS`); full suite 437/437.
+
 ## [8.6.1] - 2026-07-22 "auto-orientation"
 
 Makes 8.6.0's knowledge-graph actually pay off without anyone remembering to use it. A skill

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: claude -->
-<kernel version="8.6.1">
+<kernel version="8.6.2">
 
 
 <!-- ============================================ -->

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -1993,7 +1993,7 @@ _maybe_hybrid() {
   semf=$(mktemp); ftsf=$(mktemp)
   # sem-rank: id<TAB>rank (cosine order). Cap the semantic pool at limit*3.
   printf '%s\n' "$sem_pairs" | awk -F'\t' 'NF>=1 && $1!=""{print $1"\t"NR}' \
-    | head -n $((limit * 3)) > "$semf"
+    | awk -v n=$((limit * 3)) 'NR<=n' > "$semf"
   # fts-rank: id<TAB>rank from the raw FTS candidate order (field 3 = id).
   printf '%s\n' "$raw" | awk -F'@@US@@' 'NF>=4 && $3!=""{print $3"\t"(++n)}' > "$ftsf"
   # Pull display rows for semantic ids that FTS missed, so semantic can surface them.
@@ -2108,7 +2108,7 @@ cmd_recall() {
   raw_global=""
   [ -n "$global_db" ] && raw_global=$(_recall_emit "$global_db" "$fts_query" "$like_clause" " [global]" "$limit" 0 "global")
   dedup=$(printf '%s\n%s\n' "$raw_local" "$raw_global" | grep -v '^[[:space:]]*$' \
-        | awk -F'@@US@@' '!seen[$1]++' | head -n "$limit")
+        | awk -F'@@US@@' '!seen[$1]++' | awk -v n="$limit" 'NR<=n')
 
   # Eval mode: emit the surfaced ids only, in ranked order, with ZERO side effects
   # (no events, no hit_count bumps) so repeated eval runs never mutate the corpus.

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -1983,8 +1983,13 @@ _hybrid_rerank() {
 # failure echoes $raw unchanged (pure FTS — the exact pre-015 behavior).
 _maybe_hybrid() {
   local db="$1" query="$2" raw="$3" limit="$4"
-  # Escape hatch: force pure FTS (used by the eval's baseline arm, and any user who
-  # wants to pin keyword-only behavior even with a backend installed).
+  # DEFAULT: pure FTS (keyword/bm25). Eval-proven on _meta/evals/recall to beat the embed
+  # hybrid on every metric — recall@5 0.857 vs 0.809, MRR 0.786 vs 0.746, precision@5 0.190
+  # vs 0.171, and 0 vs 2 off-domain false hits (the hybrid drags in semantically-adjacent
+  # but wrong learnings). See CHANGELOG 8.6.2. The semantic-embed hybrid is OPT-IN via
+  # AGENTDB_EMBED=1 (kept available; a backend must still be installed via `embed-init`).
+  [ "${AGENTDB_EMBED:-0}" = "1" ] || { printf '%s' "$raw"; return 0; }
+  # Legacy hard override, still honored: pin pure FTS even if AGENTDB_EMBED=1 is also set.
   [ "${AGENTDB_NO_EMBED:-0}" = "1" ] && { printf '%s' "$raw"; return 0; }
   local sem_pairs
   sem_pairs=$(_embed_run query "$db" "$query") || { printf '%s' "$raw"; return 0; }
@@ -2029,6 +2034,8 @@ cmd_embed_init() {
   _ensure_embedding_cols
   AGENTDB_EMBED_PYTHON="$py" _embed_run sync "$DB"
   echo "Done. Add AGENTDB_EMBED_PYTHON to your shell profile to make it permanent."
+  echo "Note: recall defaults to pure FTS (the eval-proven best arm). To actually route"
+  echo "recall through this semantic-embed hybrid, also export AGENTDB_EMBED=1."
 }
 
 cmd_recall() {
@@ -2547,6 +2554,9 @@ case "${1:-help}" in
     echo "  init                    Initialize DB + apply migrations"
     echo "  preflight               Validate schema + environment health"
     echo "  recall <keywords> [--global]  Task context; rerun as files/scope/failure change"
+    echo "                          Retrieval is pure FTS (keyword/bm25) by default — the"
+    echo "                          eval-proven best arm. Opt into the semantic-embed hybrid"
+    echo "                          with AGENTDB_EMBED=1 (needs a backend: see embed-init)."
     echo "  read-start              Full generic context for audit/resume"
     echo "  write-end <json>        Checkpoint before stopping"
     echo "  learn <type> <insight>  Record learning (failure|pattern|gotcha|preference)"

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.6.1.
+Quick reference for KERNEL v8.6.2.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -268,6 +268,23 @@ test_agentdb_error() {
   assert_contains "$output" "file not found"
 }
 
+test_agentdb_recall_defaults_to_pure_fts() {
+  # 8.6.2: recall is pure FTS by default (eval-proven best arm); the semantic-embed
+  # hybrid is opt-in via AGENTDB_EMBED=1. Guards against a silent re-flip of the default.
+  # 1) Source-level: the fusion gate must default OFF (opt-in), not ON.
+  assert_contains "$(cat "$PLUGIN_ROOT/orchestration/agentdb/agentdb")" \
+    '[ "${AGENTDB_EMBED:-0}" = "1" ] || { printf '"'"'%s'"'"' "$raw"; return 0; }'
+  # 2) Behavioral: recall works with NO backend and NO opt-in (pure FTS standalone),
+  #    and setting AGENTDB_EMBED=1 without a backend still returns results (graceful).
+  agentdb init >/dev/null
+  agentdb learn pattern "rate limiter uses a token bucket" "src/limit.ts" >/dev/null
+  local def opt
+  def=$(agentdb recall "token bucket rate limiter")
+  assert_contains "$def" "token bucket"
+  opt=$(AGENTDB_EMBED=1 agentdb recall "token bucket rate limiter")
+  assert_contains "$opt" "token bucket"
+}
+
 # === Edge Case Tests ===
 
 test_agentdb_special_chars_in_insight() {
@@ -4870,6 +4887,7 @@ run_test_suite() {
       run_test "query works" test_agentdb_query
       run_test "recent shows checkpoints" test_agentdb_recent
       run_test "error records tool errors" test_agentdb_error
+      run_test "recall defaults to pure FTS (embed opt-in)" test_agentdb_recall_defaults_to_pure_fts
       ;;
     edge)
       run_test "special chars (SQL injection)" test_agentdb_special_chars_in_insight


### PR DESCRIPTION
## What ships

Two recall fixes that together take `agentdb recall` from silently-broken-and-slower to deterministic-and-better. Fully backward compatible — every prior behavior path is preserved; the semantic-embed hybrid is still available, now opt-in.

### Fixed — recall SIGPIPE under `pipefail`
The migration-015 hybrid re-rank and the main dedup step piped into `head -n N`. Under `set -euo pipefail`, `head` closing the pipe early made upstream take SIGPIPE, `pipefail` propagated exit 141, and `set -e` aborted recall after printing only the `## Recall:` header. This silently truncated live recall to a **76% zero-result rate** (recall@5 0.238), flaky run-to-run. Replaced the two early-closing `| head -n N` with `| awk -v n=N 'NR<=n'` (full-read limiter, identical output). **Zero-result rate 76% → 0%, deterministic.**

### Changed — FTS-first default (hybrid now opt-in)
A controlled re-run of `_meta/evals/recall` (both arms, live DB) showed pure FTS beats the embed hybrid on **every** metric:

| metric | pure FTS (new default) | embed hybrid (`AGENTDB_EMBED=1`) |
|---|---|---|
| recall@5 | **0.857** | 0.809 |
| MRR | **0.786** | 0.746 |
| precision@5 | **0.190** | 0.171 |
| negatives correct | **2/2** | 0/2 |

The hybrid dragged in two semantically-adjacent but off-domain false hits. `recall` now runs pure FTS by default; opt into the hybrid with `AGENTDB_EMBED=1` (a backend must still be installed via `agentdb embed-init`). `AGENTDB_NO_EMBED=1` still forces pure FTS. No change to `embed-sync`, `graph build`, or `promote`. Documented in CLI help + `embed-init` output.

## Tests
- Full suite **437/437** (added `recall defaults to pure FTS` regression test)
- Recall eval gate passes (baseline re-frozen to the new FTS default: recall@5 0.857, zero-rate 0.0)
- Smoke: recall (default + `AGENTDB_EMBED=1`), learn, wtf all green from the Vaults root

🤖 Generated with [Claude Code](https://claude.com/claude-code)