### PR TITLE
feat(agentdb): 8.7.0 recall alias expansion (migration 017)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.2 hardens recall: fixes a SIGPIPE-under-pipefail bug that silently zeroed 76% of results, and makes pure-FTS the eval-proven default (semantic-embed hybrid now opt-in via AGENTDB_EMBED=1). 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness.",
-      "version": "8.6.2"
+      "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.0 adds recall alias expansion: a curated synonym table (agentdb alias add|list|rm, migration 017) applied at query time, taking the recall eval from 0.724 to 1.000 recall@5 on zero-lexical-overlap paraphrase queries. 8.6.2 hardened recall (SIGPIPE fix, pure-FTS default).",
+      "version": "8.7.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "8.6.2",
-  "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.6.0 adds the knowledge-graph skill: a deterministic, local, free code graph (graphify) that cuts agent orientation-token cost, with opt-in post-commit freshness.",
+  "version": "8.7.0",
+  "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.0 adds recall alias expansion: a curated synonym table (agentdb alias add|list|rm, migration 017) applied at query time, taking the recall eval from 0.724 to 1.000 recall@5 on zero-lexical-overlap paraphrase queries. 8.6.2 hardened recall (SIGPIPE fix, pure-FTS default).",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: codex -->
-<kernel version="8.6.2">
+<kernel version="8.7.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.7.0] - 2026-07-24 "recall reach"
+
+Attacks the one recall class 8.6.2 could not: **zero-lexical-overlap paraphrases** ("switched
+laptops" vs "machine move"; "memory lookup comes back empty" vs "recall returned no matching
+learnings"). Keyword FTS cannot reach these by construction, and the semantic-embed hybrid
+already lost to FTS on every metric (8.6.2). The eval-proven winner is the cheapest mechanism:
+a curated synonym table applied to recall terms at query time.
+
+### Added
+- **`agentdb alias add|list|rm`** — curated recall alias mappings (`recall_aliases`, migration
+  017; also self-heals via code on any pre-017 DB). Directed `query-term -> corpus-term` rows;
+  `recall` expands its normalized terms through the table before building the FTS query.
+  Kill-switch per call: **`AGENTDB_NO_ALIAS=1`**. Alias rows are curated source data and ARE
+  included in the `agent.db.json` mirror (unlike derived tables).
+- Eval evidence (extended 32-case golden set, `_meta/evals/recall`, 10 hard paraphrase cases):
+  recall@5 **0.724 -> 1.000**, recall@1 0.621 -> 0.828, MRR 0.664 -> 0.899, negatives unchanged.
+  Alternatives measured and rejected: porter-stemming FTS tokenizer (recovered 0 hard cases,
+  broke a negative via "topping"->"top" stem collision), entity-co-occurrence graph 1-hop
+  expansion (made only 3/8 unreachable cases *reachable*, unranked — strictly dominated).
+- Regression test `recall alias expansion (migration 017)`; suite 438/438.
+
 ## [8.6.2] - 2026-07-24 "recall reliability"
 
 Two recall fixes that together take `agentdb recall` from silently-broken-and-slower to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: claude -->
-<kernel version="8.6.2">
+<kernel version="8.7.0">
 
 
 <!-- ============================================ -->

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -139,6 +139,21 @@ _ensure_embedding_cols() {
   return 0
 }
 
+# Migration 017: recall alias table, delegated to code (idempotent, self-heals
+# any DB that predates the migration). Curated query-side term -> corpus-side
+# alias mappings; inert until rows exist. See migrations/017_recall_aliases.sql.
+_ensure_alias_table() {
+  [ -f "$DB" ] || return 0
+  local has
+  has=$(db_exec "SELECT 1 FROM sqlite_master WHERE type='table' AND name='recall_aliases' LIMIT 1;" 2>/dev/null || echo "")
+  if [ -z "$has" ]; then
+    db_exec "CREATE TABLE IF NOT EXISTS recall_aliases (term TEXT NOT NULL, alias TEXT NOT NULL, note TEXT, ts TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')), PRIMARY KEY (term, alias));" 2>/dev/null || true
+    db_exec "CREATE INDEX IF NOT EXISTS idx_recall_aliases_term ON recall_aliases(term);" 2>/dev/null || true
+    db_exec "INSERT OR IGNORE INTO _migrations (name) VALUES ('017_recall_aliases');" 2>/dev/null || true
+  fi
+  return 0
+}
+
 # Return a SQL literal for a text value: '<escaped>' for a non-empty string, or
 # bare NULL for an empty one (absence = UNKNOWN, never an empty-string fact; the
 # null-semantics contract, design 5.2).
@@ -2038,6 +2053,47 @@ cmd_embed_init() {
   echo "recall through this semantic-embed hybrid, also export AGENTDB_EMBED=1."
 }
 
+# Manage recall alias expansion mappings (migration 017). Directed mappings:
+# <term> is the query-side word an agent might type, <alias> the corpus-side word
+# that actually appears in learnings. Curate BOTH directions explicitly if needed.
+cmd_alias() {
+  local sub="${1:-list}"
+  [ $# -gt 0 ] && shift
+  [ ! -f "$DB" ] && { echo "No DB"; exit 1; }
+  _ensure_alias_table
+  _norm_tok() { printf '%s' "$1" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9'; }
+  case "$sub" in
+    add)
+      local term="${1:-}"
+      [ $# -gt 0 ] && shift
+      term=$(_norm_tok "$term")
+      [ -z "$term" ] || [ $# -eq 0 ] && { echo "Usage: agentdb alias add <term> <alias...>"; exit 1; }
+      local a n added=0
+      for a in "$@"; do
+        n=$(_norm_tok "$a")
+        [ -z "$n" ] || [ "$n" = "$term" ] && continue
+        db_exec "INSERT OR IGNORE INTO recall_aliases (term, alias) VALUES ('$term','$n');"
+        added=$((added+1))
+      done
+      echo "alias: $term -> $added mapping(s) stored"
+      ;;
+    rm)
+      local term="${1:-}" al="${2:-}"
+      term=$(_norm_tok "$term")
+      [ -z "$term" ] && { echo "Usage: agentdb alias rm <term> [alias]"; exit 1; }
+      if [ -n "$al" ]; then
+        db_exec "DELETE FROM recall_aliases WHERE term='$term' AND alias='$(_norm_tok "$al")';"
+      else
+        db_exec "DELETE FROM recall_aliases WHERE term='$term';"
+      fi
+      echo "alias: removed"
+      ;;
+    list|*)
+      db_exec "SELECT term || ' -> ' || group_concat(alias, ', ') FROM recall_aliases GROUP BY term ORDER BY term;" 2>/dev/null
+      ;;
+  esac
+}
+
 cmd_recall() {
   # Parse --global (cross-project) out of the args; the rest is the query.
   local use_global=0
@@ -2063,6 +2119,25 @@ cmd_recall() {
   # Fallback: if hygiene stripped everything (all stopwords), keep raw alnum terms.
   [ -z "$terms" ] && terms=$(printf '%s' "$query" | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' ' ' | tr ' ' '\n' | awk 'NF')
   [ -z "$terms" ] && { echo "No searchable terms in: $query"; exit 1; }
+
+  # Migration 017: curated alias expansion. Each normalized query term pulls its
+  # corpus-side aliases (recall_aliases) into the term set, so paraphrase queries
+  # with ZERO lexical overlap can still reach the right learning ("switched
+  # laptops" -> machine/move -> the launchd-plist-rot lesson). Table-gated (a DB
+  # without migration 017 skips cleanly); kill-switch AGENTDB_NO_ALIAS=1.
+  # Eval-gated in _meta/evals/recall (hard-paraphrase cases C17/C18 class).
+  if [ "${AGENTDB_NO_ALIAS:-0}" != "1" ] && \
+     db_exec "SELECT 1 FROM sqlite_master WHERE type='table' AND name='recall_aliases' LIMIT 1;" 2>/dev/null | grep -q 1; then
+    local _t _in_list="" alias_terms
+    while IFS= read -r _t; do
+      [ -z "$_t" ] && continue
+      _in_list="${_in_list:+$_in_list,}'$_t'"   # terms are [a-z0-9]-only -> quote-safe
+    done <<< "$terms"
+    alias_terms=""
+    [ -n "$_in_list" ] && alias_terms=$(db_exec "SELECT DISTINCT alias FROM recall_aliases WHERE term IN ($_in_list);" 2>/dev/null \
+      | tr 'A-Z' 'a-z' | tr -c 'a-z0-9\n' ' ' | tr ' ' '\n' | awk 'length($0)>=2' || true)
+    [ -n "$alias_terms" ] && terms=$(printf '%s\n%s\n' "$terms" "$alias_terms" | awk 'NF && !seen[$0]++')
+  fi
 
   # Build the FTS query (phrase-quoted OR — injection-safe, no quotes survive) and a
   # LIKE clause (for DBs without an FTS index). Terms are [a-z0-9] only → quote-safe.
@@ -2535,6 +2610,7 @@ case "${1:-help}" in
   resurrect)   shift; cmd_resurrect "$@" ;;
   antibody)    shift; cmd_antibody "$@" ;;
   recall)      shift; cmd_recall "$@" ;;
+  alias)       shift; cmd_alias "$@" ;;
   embed-sync)  shift; _ensure_embedding_cols; _embed_run sync "$DB" ;;
   embed-status) shift; _embed_run backend || { echo "no embedding backend installed — recall is FTS-only (see: agentdb embed-init)"; exit 0; } ;;
   embed-init)  shift; cmd_embed_init "$@" ;;
@@ -2557,6 +2633,9 @@ case "${1:-help}" in
     echo "                          Retrieval is pure FTS (keyword/bm25) by default — the"
     echo "                          eval-proven best arm. Opt into the semantic-embed hybrid"
     echo "                          with AGENTDB_EMBED=1 (needs a backend: see embed-init)."
+    echo "  alias add|list|rm       Curated recall synonym mappings (query-term -> corpus-term)."
+    echo "                          Recovers zero-lexical-overlap paraphrase queries; expansion"
+    echo "                          is on by default, disable per-call with AGENTDB_NO_ALIAS=1."
     echo "  read-start              Full generic context for audit/resume"
     echo "  write-end <json>        Checkpoint before stopping"
     echo "  learn <type> <insight>  Record learning (failure|pattern|gotcha|preference)"

--- a/orchestration/agentdb/migrations/017_recall_aliases.sql
+++ b/orchestration/agentdb/migrations/017_recall_aliases.sql
@@ -1,0 +1,24 @@
+-- Migration 017: recall alias expansion (query-time synonym table).
+--
+-- WHY (agentdb hardening lane, 2026-07-24): the recall eval harness
+-- (_meta/evals/recall) proved a class of unreachable queries: zero-lexical-overlap
+-- paraphrases ("switched laptops" vs "machine move", "memory lookup comes back
+-- empty" vs "recall returned no matching learnings"). Pure FTS cannot reach them;
+-- the semantic-embed hybrid LOST to FTS on every metric (8.6.2 eval). The cheapest
+-- mechanism that wins is a CURATED alias table applied to recall query terms
+-- before the FTS match: term (query-side word) -> alias (corpus-side word).
+--
+-- Data is curated per-vault (like learnings themselves) and IS mirrored to
+-- agent.db.json (it is source data, not derived). Directed: add both directions
+-- explicitly if you want them. Managed via `agentdb alias add|list|rm`.
+-- Kill-switch at query time: AGENTDB_NO_ALIAS=1.
+CREATE TABLE IF NOT EXISTS recall_aliases (
+  term  TEXT NOT NULL,               -- normalized query-side token ([a-z0-9]+)
+  alias TEXT NOT NULL,               -- corpus-side token added to the FTS query
+  note  TEXT,                        -- optional provenance / why this mapping exists
+  ts    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY (term, alias)
+);
+CREATE INDEX IF NOT EXISTS idx_recall_aliases_term ON recall_aliases(term);
+
+INSERT OR IGNORE INTO _migrations (name) VALUES ('017_recall_aliases');

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.6.2.
+Quick reference for KERNEL v8.7.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -285,6 +285,32 @@ test_agentdb_recall_defaults_to_pure_fts() {
   assert_contains "$opt" "token bucket"
 }
 
+test_agentdb_recall_alias_expansion() {
+  # 8.7.0: curated recall alias expansion (migration 017). A paraphrase query whose
+  # words never appear in a learning must surface it once aliases map query-side
+  # terms to corpus vocabulary; AGENTDB_NO_ALIAS=1 must restore pure-term recall.
+  agentdb init >/dev/null
+  agentdb learn gotcha "launchd plists rot on machine move" "render from HOME" >/dev/null
+  local before after off
+  # zero-lexical-overlap paraphrase: no shared term with the insight
+  before=$(agentdb recall "swapped laptops broke scheduler" 2>/dev/null || true)
+  if [[ "$before" == *"machine move"* ]]; then
+    echo "  FAIL: paraphrase matched WITHOUT aliases (test premise broken)"
+    return 1
+  fi
+  agentdb alias add laptops machine >/dev/null
+  agentdb alias add swapped move >/dev/null
+  agentdb alias add scheduler launchd >/dev/null
+  after=$(agentdb recall "swapped laptops broke scheduler")
+  assert_contains "$after" "machine move" "alias expansion should reach the learning"
+  off=$(AGENTDB_NO_ALIAS=1 agentdb recall "swapped laptops broke scheduler" 2>/dev/null || true)
+  if [[ "$off" == *"machine move"* ]]; then
+    echo "  FAIL: AGENTDB_NO_ALIAS=1 did not disable alias expansion"
+    return 1
+  fi
+  assert_contains "$(agentdb alias list)" "laptops -> machine"
+}
+
 # === Edge Case Tests ===
 
 test_agentdb_special_chars_in_insight() {
@@ -4888,6 +4914,7 @@ run_test_suite() {
       run_test "recent shows checkpoints" test_agentdb_recent
       run_test "error records tool errors" test_agentdb_error
       run_test "recall defaults to pure FTS (embed opt-in)" test_agentdb_recall_defaults_to_pure_fts
+      run_test "recall alias expansion (migration 017)" test_agentdb_recall_alias_expansion
       ;;
     edge)
       run_test "special chars (SQL injection)" test_agentdb_special_chars_in_insight


### PR DESCRIPTION
Attacks the unreachable-paraphrase recall class left open by 8.6.2: zero-lexical-overlap queries that keyword FTS cannot reach and that the embed hybrid (eval-proven loser) cannot fix.

## What
- New `recall_aliases` table (migration 017, additive; code self-heal for pre-017 DBs)
- New verb `agentdb alias add|list|rm` — curated directed query-term -> corpus-term mappings
- `recall` expands normalized terms through the table before the FTS match; kill-switch `AGENTDB_NO_ALIAS=1`
- Alias rows are curated source data -> included in the agent.db.json mirror

## Evidence (extended 32-case golden set, _meta/evals/recall)
| arm | recall@1 | recall@5 | MRR |
|---|---|---|---|
| pure FTS (8.6.2 default) | 0.621 | 0.724 | 0.664 |
| FTS + aliases (this PR) | 0.828 | **1.000** | 0.899 |

Rejected by experiment: porter tokenizer (0 hard cases recovered, stem-collision false hit on a negative), entity-co-occurrence graph 1-hop (3/8 merely reachable, unranked — strictly dominated).

Suite: 438/438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEn7mp1rnGaZR1o3AKArwR