### PR TITLE
fix(agentdb): 8.7.1 recall ids survive sentinel-in-content

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.0 adds recall alias expansion: a curated synonym table (agentdb alias add|list|rm, migration 017) applied at query time, taking the recall eval from 0.724 to 1.000 recall@5 on zero-lexical-overlap paraphrase queries. 8.6.2 hardened recall (SIGPIPE fix, pure-FTS default).",
-      "version": "8.7.0"
+      "version": "8.7.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.0 adds recall alias expansion: a curated synonym table (agentdb alias add|list|rm, migration 017) applied at query time, taking the recall eval from 0.724 to 1.000 recall@5 on zero-lexical-overlap paraphrase queries. 8.6.2 hardened recall (SIGPIPE fix, pure-FTS default).",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: codex -->
-<kernel version="8.7.0">
+<kernel version="8.7.1">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.7.1] - 2026-07-24 "sentinel in content"
+
+### Fixed
+- **Recall row-splitting corrupted by content containing the `@@US@@` sentinel** — the canon
+  delimiter-bug learning literally documents the sentinel, so its own text shifted the awk
+  fields: `recall --ids` emitted an insight fragment instead of the id, and the reinforcement
+  path bumped hit_count / emitted memory_events against junk ids for ANY learning whose
+  insight or evidence contains `@@US@@`. Fix: `replace()` folds an in-content sentinel to
+  lowercase (`@@us@@`) in the display segment at emit time (display-harmless, never split
+  on); the dedup key is `lower()`ed and could never carry the uppercase sentinel. Regression
+  test `recall ids survive sentinel-in-content`; suite 439/439.
+
 ## [8.7.0] - 2026-07-24 "recall reach"
 
 Attacks the one recall class 8.6.2 could not: **zero-lexical-overlap paraphrases** ("switched

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: claude -->
-<kernel version="8.7.0">
+<kernel version="8.7.1">
 
 
 <!-- ============================================ -->

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -1878,11 +1878,18 @@ _recall_emit() {
   has_fts=$(sqlite3 "$db" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='learnings_fts' LIMIT 1;" 2>/dev/null || echo "")
   if [ -n "$has_fts" ]; then
     [ "$writable" = "1" ] && sqlite3 "$db" "INSERT INTO learnings_fts(learnings_fts) VALUES('rebuild');" 2>/dev/null || true
+    # The display segment is content and may itself CONTAIN the @@US@@ sentinel
+    # (the canon delimiter-bug learning literally documents it) — that shifted
+    # awk fields so \$3 stopped being the id: --ids emitted a text fragment and
+    # reinforcement bumped junk ids. replace() folds any in-content sentinel to
+    # lowercase (display-harmless, never split on). The dedup key is lower()ed
+    # so it can never contain the uppercase sentinel.
     sqlite3 "$db" "
       SELECT lower(substr(l.insight,1,200)) || '@@US@@' ||
-             '- [' || l.type || '] ' || l.insight || '$tag' ||
+             replace('- [' || l.type || '] ' || l.insight || '$tag' ||
              CASE WHEN l.evidence IS NOT NULL AND l.evidence != ''
-                  THEN '  ↳ ' || substr(l.evidence,1,90) ELSE '' END
+                  THEN '  ↳ ' || substr(l.evidence,1,90) ELSE '' END,
+             '@@US@@', '@@us@@')
              || '@@US@@' || l.id || '@@US@@' || '$origin'
       FROM learnings l JOIN learnings_fts f ON f.rowid = l.rowid
       WHERE learnings_fts MATCH '$fts_query'
@@ -1898,9 +1905,10 @@ _recall_emit() {
   elif [ -n "$like_clause" ]; then
     sqlite3 "$db" "
       SELECT lower(substr(insight,1,200)) || '@@US@@' ||
-             '- [' || type || '] ' || insight || '$tag' ||
+             replace('- [' || type || '] ' || insight || '$tag' ||
              CASE WHEN evidence IS NOT NULL AND evidence != ''
-                  THEN '  ↳ ' || substr(evidence,1,90) ELSE '' END
+                  THEN '  ↳ ' || substr(evidence,1,90) ELSE '' END,
+             '@@US@@', '@@us@@')
              || '@@US@@' || id || '@@US@@' || '$origin'
       FROM learnings
       WHERE ($like_clause)
@@ -1957,9 +1965,10 @@ _emit_rows_by_ids() {
   fi
   sqlite3 "$db" "
     SELECT lower(substr(insight,1,200)) || '@@US@@' ||
-           '- [' || type || '] ' || insight || '$tag' ||
+           replace('- [' || type || '] ' || insight || '$tag' ||
            CASE WHEN evidence IS NOT NULL AND evidence != ''
-                THEN '  ↳ ' || substr(evidence,1,90) ELSE '' END
+                THEN '  ↳ ' || substr(evidence,1,90) ELSE '' END,
+           '@@US@@', '@@us@@')
            || '@@US@@' || id || '@@US@@' || '$origin'
     FROM learnings
     WHERE id IN ($in_list)

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.7.0.
+Quick reference for KERNEL v8.7.1.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -311,6 +311,24 @@ test_agentdb_recall_alias_expansion() {
   assert_contains "$(agentdb alias list)" "laptops -> machine"
 }
 
+test_agentdb_recall_sentinel_in_content() {
+  # 8.7.1: a learning whose TEXT contains the literal @@US@@ row delimiter (the
+  # canon delimiter-bug learning documents it) must not corrupt field splitting:
+  # --ids must emit the real id, never a text fragment of the insight.
+  agentdb init >/dev/null
+  agentdb learn gotcha "delimiter arrived as literal; fixed with printable @@US@@ sentinel marker" "commit abc123" >/dev/null
+  local ids
+  ids=$(agentdb recall "printable sentinel marker delimiter" --ids)
+  assert_contains "$ids" "LRN-" "--ids must return a learning id"
+  if printf '%s\n' "$ids" | grep -qv '^LRN-'; then
+    echo "  FAIL: --ids emitted a non-id line (sentinel-in-content field corruption)"
+    printf '%s\n' "$ids"
+    return 1
+  fi
+  # display path still shows the insight (sentinel folded to lowercase is OK)
+  assert_contains "$(agentdb recall "printable sentinel marker delimiter")" "sentinel marker"
+}
+
 # === Edge Case Tests ===
 
 test_agentdb_special_chars_in_insight() {
@@ -4915,6 +4933,7 @@ run_test_suite() {
       run_test "error records tool errors" test_agentdb_error
       run_test "recall defaults to pure FTS (embed opt-in)" test_agentdb_recall_defaults_to_pure_fts
       run_test "recall alias expansion (migration 017)" test_agentdb_recall_alias_expansion
+      run_test "recall ids survive sentinel-in-content" test_agentdb_recall_sentinel_in_content
       ;;
     edge)
       run_test "special chars (SQL injection)" test_agentdb_special_chars_in_insight


### PR DESCRIPTION
Found while switching the recall eval harness to the side-effect-free --ids path: any learning whose text contains the literal @@US@@ row sentinel (the canon delimiter-bug learning documents it) shifts the awk fields — --ids emits a text fragment instead of the id, and reinforcement bumps junk ids. replace() folds in-content sentinels to lowercase in the display segment at emit time. Regression test added; suite 439/439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEn7mp1rnGaZR1o3AKArwR