### PR TITLE
release(agentdb): 8.7.2 recall relevance floor (min-matched-terms, default on)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.0 adds recall alias expansion: a curated synonym table (agentdb alias add|list|rm, migration 017) applied at query time, taking the recall eval from 0.724 to 1.000 recall@5 on zero-lexical-overlap paraphrase queries. 8.6.2 hardened recall (SIGPIPE fix, pure-FTS default).",
-      "version": "8.7.1"
+      "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.2 adds a recall relevance floor (min-matched-terms, on by default): a candidate must match >=2 distinct query terms, cutting OR-noise false hits 81% to 25% while keeping recall@5 at 1.000. 8.7.0 added curated recall alias expansion (0.724 to 1.000 recall@5 on paraphrase queries).",
+      "version": "8.7.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "8.7.1",
-  "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.0 adds recall alias expansion: a curated synonym table (agentdb alias add|list|rm, migration 017) applied at query time, taking the recall eval from 0.724 to 1.000 recall@5 on zero-lexical-overlap paraphrase queries. 8.6.2 hardened recall (SIGPIPE fix, pure-FTS default).",
+  "version": "8.7.2",
+  "description": "Durable project memory, bounded JSON handoffs, engineering skills, and independent verification for Claude Code and Codex. KERNEL 8.7.2 adds a recall relevance floor (min-matched-terms, on by default): a candidate must match >=2 distinct query terms, cutting OR-noise false hits 81% to 25% while keeping recall@5 at 1.000. 8.7.0 added curated recall alias expansion (0.724 to 1.000 recall@5 on paraphrase queries).",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: codex -->
-<kernel version="8.7.1">
+<kernel version="8.7.2">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [8.7.2] - 2026-07-24 "relevance floor"
+
+### Added
+- **Recall relevance floor (min-matched-terms), ON by default** — FTS ORs every query
+  term, so any query sharing even ONE common word with the corpus returned SOMETHING
+  (the OR-noise / relevance-floor problem: off-domain queries surfacing an incidental
+  single-word match). A candidate must now match at least **2 distinct query terms**
+  (whole-word) to survive; a lone-common-word hit goes silent while a real multi-term
+  match is untouched. Chosen over an absolute bm25 floor because matched-term count is
+  **scale-invariant** — bm25 magnitude grows with corpus size, so a bm25 floor tuned on
+  a large corpus would silently kill real hits on a small/new DB (the very recall-death
+  this system guards against). Word-boundary matching (not SQL `LIKE`, which can't reject
+  infix matches like "state" in "statement" or "re" in "render") is what makes the
+  separation clean. GUARD: queries with fewer than the minimum terms are exempt (a short
+  query is never silenced). Kill-switch `AGENTDB_NO_FLOOR=1`; tune `AGENTDB_RECALL_MIN_TERMS`.
+  Eval-proven on `_meta/evals/recall` (extended to 29 positives / 16 negatives): recall@5
+  stays **1.000** (29/29 positives kept, weakest real hit matches exactly 2 terms) while
+  the negative false-hit rate drops **81% → 25%** (12/16 OR-noise negatives now silent;
+  the 4 residual leaks share 2 genuine words — real overlap, not noise). Regression test
+  `recall relevance floor (bm25, default on)`; suite 440/440.
+
 ## [8.7.1] - 2026-07-24 "sentinel in content"
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4fbcc9b73bf3c2936a721491fe4c05eb2acf373cd190c710a2a69a1f61b61019; adapter: claude -->
-<kernel version="8.7.1">
+<kernel version="8.7.2">
 
 
 <!-- ============================================ -->

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -1891,6 +1891,9 @@ _recall_emit() {
                   THEN '  ↳ ' || substr(l.evidence,1,90) ELSE '' END,
              '@@US@@', '@@us@@')
              || '@@US@@' || l.id || '@@US@@' || '$origin'
+             || '@@US@@' || replace(replace(replace(
+                  lower(l.insight || ' ' || COALESCE(l.evidence,'')),
+                  char(10),' '), char(13),' '), char(9),' ')
       FROM learnings l JOIN learnings_fts f ON f.rowid = l.rowid
       WHERE learnings_fts MATCH '$fts_query'
         AND (l.visibility = 'agent' OR l.visibility IS NULL)
@@ -2109,9 +2112,11 @@ cmd_recall() {
   local -a qargs=()
   local a
   local ids_only=0
+  local scores_only=0
   for a in "$@"; do
     if [ "$a" = "--global" ]; then use_global=1
     elif [ "$a" = "--ids" ]; then ids_only=1      # eval mode: print surfaced ids, no side effects
+    elif [ "$a" = "--scores" ]; then scores_only=1; ids_only=1  # measurement mode: id<TAB>bm25, no side effects
     else qargs+=("$a"); fi
   done
   local query="${qargs[*]:-}"  # :- guards empty array under set -u on bash 3.2 (macOS)
@@ -2150,13 +2155,19 @@ cmd_recall() {
 
   # Build the FTS query (phrase-quoted OR — injection-safe, no quotes survive) and a
   # LIKE clause (for DBs without an FTS index). Terms are [a-z0-9] only → quote-safe.
-  local fts_query like_clause
+  local fts_query like_clause term_count terms_space
   fts_query=$(printf '%s\n' "$terms" | awk 'NF{printf (n++?" OR ":"")"\""$1"\""}')
   like_clause=""
+  term_count=0
   while IFS= read -r t; do
     [ -z "$t" ] && continue
     like_clause="${like_clause:+$like_clause OR }insight LIKE '%$t%' OR evidence LIKE '%$t%' OR domain LIKE '%$t%'"
+    term_count=$((term_count + 1))
   done <<< "$terms"
+  # Space-joined term list for the whole-word matched-term count used by the relevance
+  # floor below (word-boundary, in awk — SQL LIKE can't reject infix matches like
+  # "state" in "statement" or "re" in "render", which is exactly the OR-noise to kill).
+  terms_space=$(printf '%s' "$terms" | tr '\n' ' ')
 
   # Self-heal local FTS (build it if this DB predates migration 012 / hasn't run
   # preflight this session) so the local path uses bm25 ranking, not LIKE.
@@ -2198,8 +2209,62 @@ cmd_recall() {
   raw_local=$(_maybe_hybrid "$DB" "$query" "$raw_local" "$limit")
   raw_global=""
   [ -n "$global_db" ] && raw_global=$(_recall_emit "$global_db" "$fts_query" "$like_clause" " [global]" "$limit" 0 "global")
-  dedup=$(printf '%s\n%s\n' "$raw_local" "$raw_global" | grep -v '^[[:space:]]*$' \
+
+  # RELEVANCE FLOOR (2026-07-24, EXP-REC-016). FTS ORs every query term, so any query
+  # that shares even ONE common word with the corpus returns SOMETHING — the OR-noise
+  # problem (an off-domain query surfacing an incidental single-word match). _recall_emit
+  # emits $5 = the row's lowercased searchable text (insight+evidence); we stamp $5 with
+  # the WHOLE-WORD matched-term COUNT (how many distinct query terms actually appear as
+  # words in the row), then drop candidates matching FEWER than the minimum. A real
+  # multi-term hit survives; a lone-common-word hit goes silent.
+  #   Why matched-term count, not bm25: it is SCALE-INVARIANT. bm25 magnitude grows with
+  #   corpus size, so a bm25 floor calibrated on a large corpus silently kills real hits
+  #   on a small/new DB — reintroducing the very recall-death this harness exists to
+  #   catch. Word-boundary (awk, not SQL LIKE) is required: LIKE can't reject infix
+  #   matches ("state" in "statement", "re" in "render") that are exactly the OR-noise.
+  #   Calibrated on _meta/evals/recall (29 positives / 16 negatives): default min=2 keeps
+  #   29/29 positives (weakest real hit, C21, matches exactly 2 terms) and silences ~12/16
+  #   OR-noise negatives; residual leaks share 2 genuine words (real overlap, not noise).
+  # GUARD: applies only when the query itself has >= min terms — a legitimately short
+  # query can only ever match its few terms, so the floor is disabled for it (never
+  # silences a 1-term query). Rows with NO $5 (LIKE fallback / embed semantic-only rows)
+  # keep the count they had, or pass when non-numeric — the floor never degrades a
+  # non-FTS mode. Kill-switch AGENTDB_NO_FLOOR=1; tune via AGENTDB_RECALL_MIN_TERMS=<n>.
+  local scored
+  scored=$(printf '%s\n%s\n' "$raw_local" "$raw_global" \
+    | awk -F'@@US@@' -v OFS='@@US@@' -v terms="$terms_space" '
+        BEGIN { nt = split(terms, T, " ") }
+        NF < 5 { print; next }                          # fragment / no-text row: unchanged
+        {
+          txt = " " $5 " "; gsub(/[^a-z0-9]+/, " ", txt)
+          c = 0
+          for (i = 1; i <= nt; i++)
+            if (T[i] != "" && index(txt, " " T[i] " ") > 0) c++
+          $5 = c; print                                 # $5 now = matched-term count
+        }')
+
+  local min_terms="${AGENTDB_RECALL_MIN_TERMS:-2}"
+  local floored
+  if [ "${AGENTDB_NO_FLOOR:-0}" = "1" ] || [ "$term_count" -lt "$min_terms" ]; then
+    floored="$scored"
+  else
+    floored=$(printf '%s\n' "$scored" \
+      | awk -F'@@US@@' -v m="$min_terms" '
+          NF < 5 { print; next }                        # fragment row: keep
+          $5 !~ /^[0-9]+$/ { print; next }              # no count: keep (non-FTS mode)
+          ($5 + 0) >= m { print }                       # enough terms matched: keep
+        ')
+  fi
+  dedup=$(printf '%s\n' "$floored" | grep -v '^[[:space:]]*$' \
         | awk -F'@@US@@' '!seen[$1]++' | awk -v n="$limit" 'NR<=n')
+
+  # Measurement mode: dump id<TAB>matched-term-count for every surfaced candidate
+  # (ZERO side effects). Used by the relevance-floor calibration harness. $5 is the
+  # count of distinct query terms present in the row (FTS path only; blank on LIKE).
+  if [ "$scores_only" = "1" ]; then
+    printf '%s\n' "$dedup" | awk -F'@@US@@' 'NF>=4{print $3"\t"$5}'
+    return 0
+  fi
 
   # Eval mode: emit the surfaced ids only, in ranked order, with ZERO side effects
   # (no events, no hit_count bumps) so repeated eval runs never mutate the corpus.
@@ -2642,6 +2707,10 @@ case "${1:-help}" in
     echo "                          Retrieval is pure FTS (keyword/bm25) by default — the"
     echo "                          eval-proven best arm. Opt into the semantic-embed hybrid"
     echo "                          with AGENTDB_EMBED=1 (needs a backend: see embed-init)."
+    echo "                          A relevance floor drops incidental single-common-word"
+    echo "                          (OR-noise) hits: a candidate must match >=2 query terms."
+    echo "                          On by default; disable with AGENTDB_NO_FLOOR=1 or tune"
+    echo "                          AGENTDB_RECALL_MIN_TERMS=<n>."
     echo "  alias add|list|rm       Curated recall synonym mappings (query-term -> corpus-term)."
     echo "                          Recovers zero-lexical-overlap paraphrase queries; expansion"
     echo "                          is on by default, disable per-call with AGENTDB_NO_ALIAS=1."

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v8.7.1.
+Quick reference for KERNEL v8.7.2.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -329,6 +329,43 @@ test_agentdb_recall_sentinel_in_content() {
   assert_contains "$(agentdb recall "printable sentinel marker delimiter")" "sentinel marker"
 }
 
+test_agentdb_recall_relevance_floor() {
+  # 8.7.2: min-matched-terms relevance floor. FTS ORs every query term, so an off-domain
+  # query sharing even ONE common word with the corpus returns SOMETHING (the OR-noise
+  # problem). Rows matching FEWER than min distinct query terms are dropped. Default ON
+  # at min=2 (calibrated on _meta/evals/recall: 29 positives / 16 negatives — keeps
+  # 29/29 positives, silences 12/16 OR-noise negatives). Matched-term count is
+  # SCALE-INVARIANT (unlike an absolute bm25 floor, whose magnitude grows with corpus
+  # size and would silently kill real hits on a small/new DB). Kill-switch
+  # AGENTDB_NO_FLOOR=1; tunable AGENTDB_RECALL_MIN_TERMS. A query with < min terms is
+  # exempt (never silences a legitimately short query).
+  # 1) Source-level: default value present and kill-switch gated (no silent re-flip).
+  local src; src=$(cat "$PLUGIN_ROOT/orchestration/agentdb/agentdb")
+  assert_contains "$src" 'AGENTDB_RECALL_MIN_TERMS:-2'
+  assert_contains "$src" 'AGENTDB_NO_FLOOR:-0'
+  # 2) Behavioral: a real multi-term match survives the DEFAULT floor. --ids avoids the
+  #    echoed query header, so we test surfaced rows, never the header line.
+  agentdb init >/dev/null
+  agentdb learn pattern "quokka zephyr nimbus obsidian lattice" "src/floor.ts" >/dev/null
+  assert_contains "$(agentdb recall "quokka zephyr nimbus obsidian lattice" --ids)" "LRN-" \
+    "default floor must keep a genuine multi-term match"
+  # 3) OR-noise: a multi-word query that shares only ONE incidental word with the corpus
+  #    (count 1 < min 2) is silenced by default -> proves the floor is wired.
+  local noise
+  noise=$(agentdb recall "quokka salamander tornado helicopter" --ids 2>/dev/null || true)
+  if printf '%s\n' "$noise" | grep -q '^LRN-'; then
+    echo "  FAIL: single-common-word OR-noise query was NOT silenced (floor not wired)"
+    printf '%s\n' "$noise"
+    return 1
+  fi
+  # 4) Kill-switch restores the OR-noise hit (proves AGENTDB_NO_FLOOR=1 bypasses).
+  assert_contains "$(AGENTDB_NO_FLOOR=1 agentdb recall "quokka salamander tornado helicopter" --ids)" "LRN-" \
+    "AGENTDB_NO_FLOOR=1 must bypass the floor"
+  # 5) A legitimately SHORT (single-term) query is exempt — the floor never silences it.
+  assert_contains "$(agentdb recall "quokka" --ids)" "LRN-" \
+    "a 1-term query must be exempt from the min-2-terms floor"
+}
+
 # === Edge Case Tests ===
 
 test_agentdb_special_chars_in_insight() {
@@ -4933,6 +4970,7 @@ run_test_suite() {
       run_test "error records tool errors" test_agentdb_error
       run_test "recall defaults to pure FTS (embed opt-in)" test_agentdb_recall_defaults_to_pure_fts
       run_test "recall alias expansion (migration 017)" test_agentdb_recall_alias_expansion
+      run_test "recall relevance floor (bm25, default on)" test_agentdb_recall_relevance_floor
       run_test "recall ids survive sentinel-in-content" test_agentdb_recall_sentinel_in_content
       ;;
     edge)


### PR DESCRIPTION
## What

Closes the parked **C32 "OR-noise breadth"** problem. FTS ORs every query term, so any query sharing even one common word with the corpus returned SOMETHING. A recall candidate must now match **>=2 distinct whole-word query terms** or it is dropped as OR-noise. Default ON; kill-switch `AGENTDB_NO_FLOOR=1`; tune `AGENTDB_RECALL_MIN_TERMS`.

## Why min-matched-terms, not bm25

An absolute bm25 floor looked clean on the ~100-doc corpus (weakest true hit -6.8 vs strongest false hit -6.6) but is **corpus-scale-dependent**: a 1-doc corpus scored the same strong match ~-3, so a bm25 floor tuned on a large corpus silently kills real hits on a small/new DB — reintroducing the very silent-recall-death this system exists to catch. Matched-term count is **scale-invariant**. Word-boundary counting (awk) is required because SQL `LIKE` can't reject infix over-matches ("state" in "statement", "re" in "render").

## Evidence (`_meta/evals/recall`, extended to 29 positives / 16 negatives)

| arm | recall@5 | precision@5 | negatives correct |
|---|---|---|---|
| floor OFF | 1.000 | 0.207 | 3/16 (81% false-hit) |
| floor ON (default) | **1.000** | **0.259** | **12/16 (25% false-hit)** |

29/29 positives kept; the 4 residual leaks share 2 genuine words (real overlap, not noise). Migration-free. Regression test added; **suite 440/440**.