### PR TITLE
9.2: revive the spec-interview recipe

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -18,9 +18,34 @@ paths/symbols or the scope changes. Reference on demand: skills/build/reference/
 ## Goal first
 
 Before touching code, state: GOAL, CONSTRAINTS, INPUTS, OUTPUTS, DONE-WHEN. If any
-field is genuinely unknowable, the feature is underspecified; interview the user and
-write the spec to `_meta/plans/` before implementing. State the DONE-WHEN criteria at
-the start of the session, not the end.
+field is genuinely unknowable, the feature is underspecified; run the interview below
+and write the spec to `_meta/plans/` before implementing. State the DONE-WHEN criteria
+at the start of the session, not the end.
+
+## The interview
+
+When a feature is underspecified, interview the user with the AskUserQuestion tool
+rather than guessing or asking one vague open question. Cover, in order of leverage:
+
+1. Intent: which of 2-3 plausible readings of the request is meant.
+2. Implementation shape: the genuine forks (storage, framework, integration boundary)
+   where the user's answer changes the build.
+3. UI/UX: only the decisions the user would veto if guessed wrong.
+4. Edge cases and failure behavior: what should happen when input is empty, huge,
+   concurrent, or malicious.
+5. Tradeoffs: name the axis (speed vs completeness, flexibility vs simplicity) and let
+   the user place the slider.
+
+Rules, enforced by taste:
+- Interviews are for bounded choices with real options. Open-ended strategy and design
+  direction stay prose conversation, never option polls.
+- Every question must change what gets built; if all answers lead to the same code,
+  don't ask.
+- Offer a recommended option first when the evidence supports one.
+- Batch related questions (the tool takes up to 4); one interview beats five
+  interruptions.
+- The answers land in the spec at `_meta/plans/<feature>.md` (or the active commission),
+  quoted, so the authority behind each decision is traceable.
 
 ## Research cache
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -198,6 +198,13 @@ ambiguous: assume higher. File count is only a weak hint, never the trigger.
   Use AskUserQuestion when: tier classification is borderline (e.g., 2-3 files but complex coupling)
   Ask: "Scoped to {N} files — tier {X}. Confirm tier, or should I treat as tier {X+1}?"
   Options: confirm tier {X}, bump to tier {X+1}
+
+  When the request itself is underspecified (any GOAL/CONSTRAINTS/INPUTS/OUTPUTS/DONE-WHEN
+  field unknowable), run the structured interview from skills/build/SKILL.md "The
+  interview" BEFORE scoping: batched AskUserQuestion rounds over intent, implementation
+  forks, veto-risk UX, edge behavior, and tradeoffs. Bounded choices only; open-ended
+  direction stays prose. Answers are quoted into the spec/commission so each decision
+  carries its authority.
 </ask_user>
 </step>
 

--- a/skills/landing-page/SKILL.md
+++ b/skills/landing-page/SKILL.md
@@ -26,6 +26,12 @@ Load `skills/marketing-site/SKILL.md` and `skills/frontend/SKILL.md` before writ
 Use answers already present in the request/repository. Resolve only what materially changes
 the build: audience, desired action, offer/proof, brand/assets, required content/legal pages,
 real CTA destination, domain, and deploy target. Never invent brand facts or proof.
+
+For the unresolved inputs, run a structured interview with the AskUserQuestion tool
+(batched, up to 4 questions per round, recommended option first where evidence supports
+one) instead of guessing or asking loose prose questions. Bounded choices only; positioning
+and voice discussions stay prose. The interview method: skills/build/SKILL.md "The
+interview".
 </inputs>
 
 <scaffold>


### PR DESCRIPTION
Restores the v7 spec-interview pattern (lost in the v8 prose rewrite b61ff76) as a first-class method in skills/build, referenced from ingest and landing-page.

- Leverage-ordered question set: intent, implementation forks, veto-risk UX, edge cases, tradeoffs
- Bounded choices only; open-ended strategy stays prose
- Batched AskUserQuestion rounds, recommended option first
- Answers quoted into the spec/commission for traceable authority

Tests: 443/443 green locally.

Closes #168