### PR TITLE
fix: Codex hooks exit 127 - host-agnostic plugin root

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,18 +6,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
             "timeout": 30,
             "statusMessage": "Loading KERNEL context..."
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/autopush.sh install",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/autopush.sh install",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/knowledge-graph.sh install",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/knowledge-graph.sh install",
             "timeout": 15
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard-bash.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/guard-bash.sh",
             "timeout": 5
           }
         ]
@@ -39,22 +39,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard-config.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/guard-config.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/detect-secrets.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/detect-secrets.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-structure.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/validate-structure.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
             "timeout": 5
           }
         ]
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard-context.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/guard-context.sh",
             "timeout": 5
           }
         ]
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/auto-approve-safe.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/auto-approve-safe.sh",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/scan-output.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/scan-output.sh",
             "timeout": 10
           }
         ]
@@ -98,12 +98,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/log-write.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/log-write.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-json-schema.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/validate-json-schema.sh",
             "timeout": 5
           }
         ]
@@ -115,7 +115,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/capture-error.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/capture-error.sh",
             "timeout": 5
           }
         ]
@@ -127,12 +127,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/route-request.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/route-request.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post-compact-restore.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/post-compact-restore.sh",
             "timeout": 5
           }
         ]
@@ -144,7 +144,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-compact-commit.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/pre-compact-commit.sh",
             "timeout": 30,
             "statusMessage": "Saving context snapshot..."
           }
@@ -157,7 +157,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-end.sh",
+            "command": "${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/hooks/scripts/session-end.sh",
             "timeout": 210,
             "statusMessage": "Closing session..."
           }


### PR DESCRIPTION
hooks/hooks.json is read by both hosts but used CLAUDE_PLUGIN_ROOT only; Codex never sets it, so every hook died with exit 127 (latent since v9.0.0, surfaced when Codex began running hook events). Commands now use the shell fallback form, verified under both hosts' environments with env -i.

Built via index-only plumbing to avoid touching another session's uncommitted working-tree changes to the same file.

Closes #176