### PR TITLE
Process rules: encode what two pilots paid for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: a8737a0695f15b626b1dbbffa4e82f78a72bc4828425558991d9ad961df10c73; adapter: codex -->
+     source-sha256: 798915ed6a2971d02e6e12eb0639cdd3fca49cb686ed8a530f7bc45ec439d08c; adapter: codex -->
 <kernel version="9.1.2">
 
 
@@ -139,6 +139,49 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <rule>Never commit broken code to main. Never auto-resolve merge conflicts silently.</rule>
   <rule>Stash before risky ops. Tag milestones.</rule>
   <rule>Agent-authored and user-authored commits NEVER use --no-verify. If a gate fails, fix the gate or the change.</rule>
+  <cycle>
+    One issue, one PR, one cycle. A cycle ends SHIPPED (merged, verified live) or REVERTED
+    (tree clean, one line saying why). Never an ambiguous middle: a rejected cycle that left
+    43 files dirty poisoned the next cycle's measurements. This is a process rule, not a
+    harness -- any loop harness built later needs its own selftest and one watched run
+    before it is trusted, because three same-species harness bugs once burned 3.5 hours
+    inside correct-looking unverified control flow.
+    Accumulating requests split into separate issues, never one train of unrelated commits.
+    Stacked PRs merge parent-first, each only when green.
+  </cycle>
+  <wip>
+    One write cycle in flight on a shared tree. A second issue may exist only in verify or
+    PR-open state. Parallel work means file-disjoint BRANCHES with a single merge authority
+    and a landing pass, never worktrees: the record is 60 worktree branches and 949 commits
+    with zero merges, against ~50 lanes landed without them.
+  </wip>
+  <verification_budget>
+    Verifier recursion caps at 2 DISAGREEMENT rounds. Rounds where the verifier and builder
+    agree a defect is real -- repair, then a confirm-only delta -- do not count; capping
+    those forces pointless escalations, and one pilot ran three such rounds with zero
+    disagreements. Blind review is ONE adjudicated round per milestone, cadenced per
+    milestone or merge and never by calendar, because calendar triggers fire into empty
+    context and get snoozed. Loops churn while known defects sit: 7 defects on a real device
+    outlived 506 green tests.
+    Two consecutive cycles producing only tooling, receipts, or plans and zero landed
+    outcome: halt and re-bound. Apparatus outrunning outcomes is the churn signal.
+  </verification_budget>
+  <done>
+    Done means merged and verified live. Committed, pushed, deployed, and working are four
+    different states; name the one you checked. "Pushed" is a fresh remote read, never local
+    belief -- a remote once sat 51 commits behind for days while receipts tracked SHAs to
+    five decimals. CI green is the conclusion read at the cycle's head SHA: a watch command's
+    exit status is not a verdict, and trusting one merged a PR with a failing required check.
+    The ABSENCE of a CI run is a red state, not a pending one: a stacked PR whose base moved
+    can go CONFLICTING and silently produce no runs at all, where pushes and reruns do
+    nothing.
+  </done>
+  <receipts>
+    Receipts fire on state changes -- cycle verdict, QA verdict, merge, live proof -- and
+    land as comments on the cycle's issue. Never on cadence: 29 checkpoints a day rebinding
+    one frozen SHA recorded a stall without preventing it, and comments nobody reads are
+    rows in a table nobody queries.
+  </receipts>
   <hook_carve_outs>
     Two automated hooks call `git commit --no-verify` intentionally:
     - hooks/scripts/session-end.sh (SessionEnd batch commit)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to KERNEL are documented in this file.
   `fail-closed-when-armed`, `fail-abstain`. Detecting that a check could not run is not
   enough - the direction has to be a decision.
 
+- **Execution process rules** in the canonical governance template (#171): the cycle
+  primitive (shipped or reverted, never ambiguous), WIP 1 on a shared tree with
+  file-disjoint branches instead of worktrees, a verifier-recursion cap that counts
+  disagreement rounds only, one adjudicated blind round per milestone, the scaffolding
+  tripwire, done-means-merged-and-live with absence-of-a-CI-run as a red state, and
+  state-change receipts. Every rule carries the failure that paid for it. Validated by two
+  independent pilots before landing.
 - **Retirement ledger** (`governance/retirements.jsonl` + `governance/RETIREMENT.md`):
   removing a mechanism now requires an append-only verdict naming what died, why, what
   replaced it, and the evidence. Backfilled with the five real retirements the v7-v9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: a8737a0695f15b626b1dbbffa4e82f78a72bc4828425558991d9ad961df10c73; adapter: claude -->
+     source-sha256: 798915ed6a2971d02e6e12eb0639cdd3fca49cb686ed8a530f7bc45ec439d08c; adapter: claude -->
 <kernel version="9.1.2">
 
 
@@ -139,6 +139,49 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <rule>Never commit broken code to main. Never auto-resolve merge conflicts silently.</rule>
   <rule>Stash before risky ops. Tag milestones.</rule>
   <rule>Agent-authored and user-authored commits NEVER use --no-verify. If a gate fails, fix the gate or the change.</rule>
+  <cycle>
+    One issue, one PR, one cycle. A cycle ends SHIPPED (merged, verified live) or REVERTED
+    (tree clean, one line saying why). Never an ambiguous middle: a rejected cycle that left
+    43 files dirty poisoned the next cycle's measurements. This is a process rule, not a
+    harness -- any loop harness built later needs its own selftest and one watched run
+    before it is trusted, because three same-species harness bugs once burned 3.5 hours
+    inside correct-looking unverified control flow.
+    Accumulating requests split into separate issues, never one train of unrelated commits.
+    Stacked PRs merge parent-first, each only when green.
+  </cycle>
+  <wip>
+    One write cycle in flight on a shared tree. A second issue may exist only in verify or
+    PR-open state. Parallel work means file-disjoint BRANCHES with a single merge authority
+    and a landing pass, never worktrees: the record is 60 worktree branches and 949 commits
+    with zero merges, against ~50 lanes landed without them.
+  </wip>
+  <verification_budget>
+    Verifier recursion caps at 2 DISAGREEMENT rounds. Rounds where the verifier and builder
+    agree a defect is real -- repair, then a confirm-only delta -- do not count; capping
+    those forces pointless escalations, and one pilot ran three such rounds with zero
+    disagreements. Blind review is ONE adjudicated round per milestone, cadenced per
+    milestone or merge and never by calendar, because calendar triggers fire into empty
+    context and get snoozed. Loops churn while known defects sit: 7 defects on a real device
+    outlived 506 green tests.
+    Two consecutive cycles producing only tooling, receipts, or plans and zero landed
+    outcome: halt and re-bound. Apparatus outrunning outcomes is the churn signal.
+  </verification_budget>
+  <done>
+    Done means merged and verified live. Committed, pushed, deployed, and working are four
+    different states; name the one you checked. "Pushed" is a fresh remote read, never local
+    belief -- a remote once sat 51 commits behind for days while receipts tracked SHAs to
+    five decimals. CI green is the conclusion read at the cycle's head SHA: a watch command's
+    exit status is not a verdict, and trusting one merged a PR with a failing required check.
+    The ABSENCE of a CI run is a red state, not a pending one: a stacked PR whose base moved
+    can go CONFLICTING and silently produce no runs at all, where pushes and reruns do
+    nothing.
+  </done>
+  <receipts>
+    Receipts fire on state changes -- cycle verdict, QA verdict, merge, live proof -- and
+    land as comments on the cycle's issue. Never on cadence: 29 checkpoints a day rebinding
+    one frozen SHA recorded a stall without preventing it, and comments nobody reads are
+    rows in a table nobody queries.
+  </receipts>
   <hook_carve_outs>
     Two automated hooks call `git commit --no-verify` intentionally:
     - hooks/scripts/session-end.sh (SessionEnd batch commit)

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -155,6 +155,49 @@ Library: hooks/scripts/github-integration.sh. All functions profile-gated, fire-
   <rule>Never commit broken code to main. Never auto-resolve merge conflicts silently.</rule>
   <rule>Stash before risky ops. Tag milestones.</rule>
   <rule>Agent-authored and user-authored commits NEVER use --no-verify. If a gate fails, fix the gate or the change.</rule>
+  <cycle>
+    One issue, one PR, one cycle. A cycle ends SHIPPED (merged, verified live) or REVERTED
+    (tree clean, one line saying why). Never an ambiguous middle: a rejected cycle that left
+    43 files dirty poisoned the next cycle's measurements. This is a process rule, not a
+    harness -- any loop harness built later needs its own selftest and one watched run
+    before it is trusted, because three same-species harness bugs once burned 3.5 hours
+    inside correct-looking unverified control flow.
+    Accumulating requests split into separate issues, never one train of unrelated commits.
+    Stacked PRs merge parent-first, each only when green.
+  </cycle>
+  <wip>
+    One write cycle in flight on a shared tree. A second issue may exist only in verify or
+    PR-open state. Parallel work means file-disjoint BRANCHES with a single merge authority
+    and a landing pass, never worktrees: the record is 60 worktree branches and 949 commits
+    with zero merges, against ~50 lanes landed without them.
+  </wip>
+  <verification_budget>
+    Verifier recursion caps at 2 DISAGREEMENT rounds. Rounds where the verifier and builder
+    agree a defect is real -- repair, then a confirm-only delta -- do not count; capping
+    those forces pointless escalations, and one pilot ran three such rounds with zero
+    disagreements. Blind review is ONE adjudicated round per milestone, cadenced per
+    milestone or merge and never by calendar, because calendar triggers fire into empty
+    context and get snoozed. Loops churn while known defects sit: 7 defects on a real device
+    outlived 506 green tests.
+    Two consecutive cycles producing only tooling, receipts, or plans and zero landed
+    outcome: halt and re-bound. Apparatus outrunning outcomes is the churn signal.
+  </verification_budget>
+  <done>
+    Done means merged and verified live. Committed, pushed, deployed, and working are four
+    different states; name the one you checked. "Pushed" is a fresh remote read, never local
+    belief -- a remote once sat 51 commits behind for days while receipts tracked SHAs to
+    five decimals. CI green is the conclusion read at the cycle's head SHA: a watch command's
+    exit status is not a verdict, and trusting one merged a PR with a failing required check.
+    The ABSENCE of a CI run is a red state, not a pending one: a stacked PR whose base moved
+    can go CONFLICTING and silently produce no runs at all, where pushes and reruns do
+    nothing.
+  </done>
+  <receipts>
+    Receipts fire on state changes -- cycle verdict, QA verdict, merge, live proof -- and
+    land as comments on the cycle's issue. Never on cadence: 29 checkpoints a day rebinding
+    one frozen SHA recorded a stall without preventing it, and comments nobody reads are
+    rows in a table nobody queries.
+  </receipts>
   <hook_carve_outs>
     Two automated hooks call `git commit --no-verify` intentionally:
     - hooks/scripts/session-end.sh (SessionEnd batch commit)


### PR DESCRIPTION
Closes #171. Wave 1, cycle 3 — completes the foundations wave.

Text-only, into `governance/kernel.md.tmpl` (canonical source; both host adapters regenerate from it). Already ACCEPTED by both pilots per the signed commission's acceptance clause, so this is the landing, not the proposal.

Five new blocks, every rule carrying the failure that paid for it:
- **`<cycle>`** — one issue, one PR, one cycle; shipped or reverted, never ambiguous. Process rule, not a harness (any future harness needs its own selftest + one watched run).
- **`<wip>`** — 1 write cycle on a shared tree; parallel = file-disjoint branches + single merge authority + landing pass, never worktrees (60 branches / 949 commits / 0 merges).
- **`<verification_budget>`** — recursion cap 2 counting *disagreement* rounds only; one adjudicated blind round per milestone, cadenced by milestone not calendar; scaffolding tripwire.
- **`<done>`** — merged and verified live; "pushed" is a fresh remote read; CI green is the conclusion at the head SHA (a watch exit status is not a verdict); **absence of a CI run is a red state**.
- **`<receipts>`** — state changes only, as issue comments; never cadence.

Governance and version-sync suites green.