### PR TITLE
Chronicle Stop-gate: a gate, not a trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ All notable changes to KERNEL are documented in this file.
   `fail-closed-when-armed`, `fail-abstain`. Detecting that a check could not run is not
   enough - the direction has to be a decision.
 
+- **Chronicle Stop-gate** (`hooks/scripts/chronicle-gate.sh`, #170): a session that changed
+  source is asked once for an honest account before it ends, naming what was attempted,
+  what was verified live, and what failed. One small file per session, not an accumulating
+  apparatus. It refuses exactly once and always names an escape hatch
+  (`KERNEL_CHRONICLE_OK=1`), because a gate you cannot satisfy gets the whole hook chain
+  disabled. Records-only sessions pass untouched.
+- **Scaffolding tripwire**, in the same hook: two consecutive sessions producing only
+  tooling, docs, or tests and no landed outcome print a halt-and-re-bound warning.
+  Apparatus outrunning outcomes once cost a whole phase.
 - **Execution process rules** in the canonical governance template (#171): the cycle
   primitive (shipped or reverted, never ambiguous), WIP 1 on a shared tree with
   file-disjoint branches instead of worktrees, a verifier-recursion cap that counts

--- a/hooks.json
+++ b/hooks.json
@@ -126,6 +126,18 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/chronicle-gate.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "matcher": "",

--- a/hooks/gates.json
+++ b/hooks/gates.json
@@ -14,18 +14,191 @@
   },
   "hooks": [
     {
-      "id": "guard-bash",
-      "script": "hooks/scripts/guard-bash.sh",
-      "class": "gate",
+      "id": "autopush",
+      "script": "hooks/scripts/autopush.sh",
+      "class": "advisory",
+      "events": [
+        "SessionStart"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "capture-error",
+      "script": "hooks/scripts/capture-error.sh",
+      "class": "advisory",
+      "events": [
+        "PostToolUseFailure"
+      ],
+      "matcher": "Edit|Write|Bash",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "knowledge-graph",
+      "script": "hooks/scripts/knowledge-graph.sh",
+      "class": "advisory",
+      "events": [
+        "SessionStart"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "log-write",
+      "script": "hooks/scripts/log-write.sh",
+      "class": "advisory",
+      "events": [
+        "PostToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "post-compact-restore",
+      "script": "hooks/scripts/post-compact-restore.sh",
+      "class": "advisory",
+      "events": [
+        "UserPromptSubmit"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "sqlite3"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "pre-compact-commit",
+      "script": "hooks/scripts/pre-compact-commit.sh",
+      "class": "advisory",
+      "events": [
+        "PreCompact"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git",
+        "sqlite3"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "route-request",
+      "script": "hooks/scripts/route-request.sh",
+      "class": "advisory",
+      "events": [
+        "UserPromptSubmit"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "python3"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "session-end",
+      "script": "hooks/scripts/session-end.sh",
+      "class": "advisory",
+      "events": [
+        "SessionEnd"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git",
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "session-start",
+      "script": "hooks/scripts/session-start.sh",
+      "class": "advisory",
+      "events": [
+        "SessionStart"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git",
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "validate-json-schema",
+      "script": "hooks/scripts/validate-json-schema.sh",
+      "class": "advisory",
+      "events": [
+        "PostToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "validate-structure",
+      "script": "hooks/scripts/validate-structure.sh",
+      "class": "advisory",
       "events": [
         "PreToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "warn-hardcoded",
+      "script": "hooks/scripts/warn-hardcoded.sh",
+      "class": "advisory",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "auto-approve-safe",
+      "script": "hooks/scripts/auto-approve-safe.sh",
+      "class": "gate",
+      "events": [
+        "PermissionRequest"
       ],
       "matcher": "Bash",
       "external_deps": [
         "jq"
       ],
-      "degraded_mode": "fail-closed",
-      "rationale": "Destructive-command guard. Fails closed: without a parser it cannot tell a listing from a recursive delete. Escape hatch KERNEL_GUARD_BASH_DEGRADED_OK=1 is explicit and logged."
+      "degraded_mode": "fail-abstain",
+      "rationale": "Auto-approves demonstrably safe commands. Its dangerous direction is YES, so when it cannot evaluate it emits no decision and the human is asked."
+    },
+    {
+      "id": "chronicle-gate",
+      "script": "hooks/scripts/chronicle-gate.sh",
+      "class": "gate",
+      "events": [
+        "Stop"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git"
+      ],
+      "degraded_mode": "fail-open-loud",
+      "rationale": "Requires an honest account from a session that changed source. Refuses once and names an escape hatch, because a gate you cannot satisfy is worse than none: people disable the whole chain. Without git it cannot tell whether source changed, and blocking the end of a session on that would trap it."
     },
     {
       "id": "detect-secrets",
@@ -40,6 +213,20 @@
       ],
       "degraded_mode": "fail-closed",
       "rationale": "Secret scanner. Deliberately does not source circuit-breaker.sh: a security gate must never auto-disable itself."
+    },
+    {
+      "id": "guard-bash",
+      "script": "hooks/scripts/guard-bash.sh",
+      "class": "gate",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Bash",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-closed",
+      "rationale": "Destructive-command guard. Fails closed: without a parser it cannot tell a listing from a recursive delete. Escape hatch KERNEL_GUARD_BASH_DEGRADED_OK=1 is explicit and logged."
     },
     {
       "id": "guard-config",
@@ -85,175 +272,12 @@
       "rationale": "Prompt-injection tripwire over fetched content. Post-hoc, so refusing protects nothing; it must degrade loudly instead of silently."
     },
     {
-      "id": "auto-approve-safe",
-      "script": "hooks/scripts/auto-approve-safe.sh",
-      "class": "gate",
-      "events": [
-        "PermissionRequest"
-      ],
-      "matcher": "Bash",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-abstain",
-      "rationale": "Auto-approves demonstrably safe commands. Its dangerous direction is YES, so when it cannot evaluate it emits no decision and the human is asked."
-    },
-    {
-      "id": "validate-structure",
-      "script": "hooks/scripts/validate-structure.sh",
-      "class": "advisory",
-      "events": [
-        "PreToolUse"
-      ],
-      "matcher": "Write|Edit",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "warn-hardcoded",
-      "script": "hooks/scripts/warn-hardcoded.sh",
-      "class": "advisory",
-      "events": [
-        "PreToolUse"
-      ],
-      "matcher": "Write|Edit",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "log-write",
-      "script": "hooks/scripts/log-write.sh",
-      "class": "advisory",
-      "events": [
-        "PostToolUse"
-      ],
-      "matcher": "Write|Edit",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "validate-json-schema",
-      "script": "hooks/scripts/validate-json-schema.sh",
-      "class": "advisory",
-      "events": [
-        "PostToolUse"
-      ],
-      "matcher": "Write|Edit",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "capture-error",
-      "script": "hooks/scripts/capture-error.sh",
-      "class": "advisory",
-      "events": [
-        "PostToolUseFailure"
-      ],
-      "matcher": "Edit|Write|Bash",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "route-request",
-      "script": "hooks/scripts/route-request.sh",
-      "class": "advisory",
-      "events": [
-        "UserPromptSubmit"
-      ],
-      "matcher": "",
+      "id": "circuit-breaker",
+      "script": "hooks/scripts/circuit-breaker.sh",
+      "class": "library",
+      "events": [],
       "external_deps": [
         "python3"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "post-compact-restore",
-      "script": "hooks/scripts/post-compact-restore.sh",
-      "class": "advisory",
-      "events": [
-        "UserPromptSubmit"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "sqlite3"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "pre-compact-commit",
-      "script": "hooks/scripts/pre-compact-commit.sh",
-      "class": "advisory",
-      "events": [
-        "PreCompact"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "git",
-        "sqlite3"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "session-start",
-      "script": "hooks/scripts/session-start.sh",
-      "class": "advisory",
-      "events": [
-        "SessionStart"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "git",
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "session-end",
-      "script": "hooks/scripts/session-end.sh",
-      "class": "advisory",
-      "events": [
-        "SessionEnd"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "git",
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "autopush",
-      "script": "hooks/scripts/autopush.sh",
-      "class": "advisory",
-      "events": [
-        "SessionStart"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "git"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "knowledge-graph",
-      "script": "hooks/scripts/knowledge-graph.sh",
-      "class": "advisory",
-      "events": [
-        "SessionStart"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "git"
       ],
       "degraded_mode": "fail-open-loud"
     },
@@ -268,16 +292,6 @@
       "degraded_mode": "fail-open-loud"
     },
     {
-      "id": "circuit-breaker",
-      "script": "hooks/scripts/circuit-breaker.sh",
-      "class": "library",
-      "events": [],
-      "external_deps": [
-        "python3"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
       "id": "github-integration",
       "script": "hooks/scripts/github-integration.sh",
       "class": "library",
@@ -288,6 +302,14 @@
       "degraded_mode": "fail-open-loud"
     },
     {
+      "id": "scan-output-impl",
+      "script": "hooks/scripts/scan-output.py",
+      "class": "library",
+      "events": [],
+      "external_deps": [],
+      "degraded_mode": "not-applicable"
+    },
+    {
       "id": "test-gate",
       "script": "hooks/scripts/test-gate.sh",
       "class": "library",
@@ -296,14 +318,6 @@
         "git"
       ],
       "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "scan-output-impl",
-      "script": "hooks/scripts/scan-output.py",
-      "class": "library",
-      "events": [],
-      "external_deps": [],
-      "degraded_mode": "not-applicable"
     }
   ]
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -138,6 +138,18 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/chronicle-gate.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "matcher": "",

--- a/hooks/scripts/chronicle-gate.sh
+++ b/hooks/scripts/chronicle-gate.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Stop hook: a session that changed source owes an honest account of what happened.
+# Events: Stop
+#
+# Written as you go, a chronicle is a record. Reconstructed at the end, it is a
+# summary -- and a summary is where the failures quietly drop out. The rule that
+# produced this gate came from three parallel execution reviews finding the same
+# thing: the sessions that hurt later were the ones whose story was never written
+# down, so the next session started blind and rediscovered the same wall.
+#
+# Prose asking for a chronicle does not produce chronicles; roughly 40% of prose
+# rules are skipped under load. Hence a gate (I0.15).
+#
+# It is a gate, not a trap. It refuses ONCE per session, tells you exactly what to
+# write and where, and always names an escape hatch. A gate you cannot satisfy is
+# worse than no gate: people learn to disable the whole hook chain.
+#
+# Degraded mode: fail-open-loud. If jq or git is missing we cannot tell whether
+# source changed, and blocking the end of a session on a missing parser would trap
+# it. Warn instead.
+
+INPUT=$(cat)
+
+ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+STATE_DIR="$ROOT/_meta/.runtime"
+SEEN_MARKER="$STATE_DIR/chronicle-gate-asked"
+SCAFFOLD_COUNTER="$STATE_DIR/scaffolding-only-streak"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "chronicle-gate: warning -- git not found, cannot tell whether this session changed source." >&2
+  exit 0
+fi
+
+if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0  # not a repo; nothing to chronicle against
+fi
+
+# --- what changed, uncommitted and committed, in this working tree ---
+CHANGED=$(git -C "$ROOT" status --porcelain 2>/dev/null | awk '{ $1=""; sub(/^ +/,""); print }')
+[ -z "$CHANGED" ] && CHANGED=$(git -C "$ROOT" diff --name-only HEAD~1..HEAD 2>/dev/null)
+
+[ -z "$CHANGED" ] && exit 0  # nothing happened; nothing to record
+
+# Records and scaffolding are not the outcome; they are how the outcome is described.
+SOURCE_CHANGED=0
+SCAFFOLD_ONLY=1
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  case "$path" in
+    _meta/*|docs/*|*.md|tests/*|.github/*|governance/*) ;;
+    *) SOURCE_CHANGED=1; SCAFFOLD_ONLY=0 ;;
+  esac
+done <<CHANGES
+$CHANGED
+CHANGES
+
+# --- scaffolding tripwire (advisory): apparatus outrunning outcomes ---
+# Urban-atlas halted a whole phase over this: governance, scripts, manifests, and
+# proof scaffolding accumulating while nothing landed. Two consecutive sessions of
+# it is the signal to stop and re-bound, not to build a third instrument.
+mkdir -p "$STATE_DIR" 2>/dev/null
+if [ "$SCAFFOLD_ONLY" = "1" ]; then
+  STREAK=$(( $(cat "$SCAFFOLD_COUNTER" 2>/dev/null || echo 0) + 1 ))
+  echo "$STREAK" > "$SCAFFOLD_COUNTER" 2>/dev/null
+  if [ "$STREAK" -ge 2 ]; then
+    echo "chronicle-gate: $STREAK consecutive sessions produced only tooling, docs, or tests and no landed outcome." >&2
+    echo "  Halt and re-bound rather than building a third instrument. Apparatus outrunning outcomes is the churn signal." >&2
+  fi
+else
+  rm -f "$SCAFFOLD_COUNTER" 2>/dev/null
+fi
+
+[ "$SOURCE_CHANGED" = "0" ] && exit 0
+
+# --- does a chronicle exist for today? ---
+YEAR=$(date +%Y)
+TODAY=$(date +%Y-%m-%d)
+CHRONICLE_DIR="$ROOT/_meta/chronicles/$YEAR"
+if [ -d "$CHRONICLE_DIR" ] && ls "$CHRONICLE_DIR"/"$TODAY"*.md >/dev/null 2>&1; then
+  rm -f "$SEEN_MARKER" 2>/dev/null
+  exit 0
+fi
+
+if [ "${KERNEL_CHRONICLE_OK:-0}" = "1" ]; then
+  echo "chronicle-gate: source changed with no chronicle; proceeding because KERNEL_CHRONICLE_OK=1." >&2
+  exit 0
+fi
+
+# Refuse once. A second Stop proceeds, so this can never trap a session.
+if [ -f "$SEEN_MARKER" ]; then
+  echo "chronicle-gate: still no chronicle. Proceeding -- this gate refuses once, never twice." >&2
+  rm -f "$SEEN_MARKER" 2>/dev/null
+  exit 0
+fi
+touch "$SEEN_MARKER" 2>/dev/null
+
+cat >&2 <<EOF
+This session changed source and has no chronicle.
+
+Write one small file at _meta/chronicles/$YEAR/$TODAY-<slug>.md covering:
+  - what was attempted, and what actually changed
+  - what was verified LIVE, with the command that proved it
+  - what failed, what was deferred, and any disagreement worth inheriting
+
+One file per session, rewritten rather than accumulated. Honest beats complete:
+the failures are the part the next session cannot reconstruct on its own.
+
+Skip deliberately with KERNEL_CHRONICLE_OK=1.
+EOF
+exit 2

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -59,6 +59,7 @@ HOOK_BINDINGS = [
     {"event": "PostToolUseFailure", "matcher": "Edit|Write|Bash", "script": "capture-error.sh", "timeout": 5},
     {"event": "UserPromptSubmit", "matcher": "", "script": "route-request.sh", "timeout": 5},
     {"event": "UserPromptSubmit", "matcher": "", "script": "post-compact-restore.sh", "timeout": 5},
+    {"event": "Stop", "matcher": "", "script": "chronicle-gate.sh", "timeout": 15},
     {"event": "PreCompact", "matcher": "", "script": "pre-compact-commit.sh", "timeout": 30,
      "statusMessage": "Saving context snapshot..."},
     {"event": "SessionEnd", "matcher": "", "script": "session-end.sh", "timeout": 210,

--- a/tests/corpus/cases.json
+++ b/tests/corpus/cases.json
@@ -300,6 +300,30 @@
           "command": "{{HEREDOC_TO_SHELL}}"
         }
       }
+    },
+    {
+      "id": "chronicle-gate/blocks-source-change-with-no-chronicle",
+      "gate": "chronicle-gate",
+      "expect": "block",
+      "why": "The founding case: a session that changed source and wrote no account of it. Prose asking for a chronicle does not produce chronicles.",
+      "arms": {
+        "src/feature.ts": "export const shipped = true;\n"
+      },
+      "input": {
+        "hook_event_name": "Stop"
+      }
+    },
+    {
+      "id": "chronicle-gate/allows-records-only-session",
+      "gate": "chronicle-gate",
+      "expect": "allow",
+      "why": "A session that only touched records and scaffolding has no source story to tell, and must not be held hostage for one.",
+      "arms": {
+        "docs/notes.md": "# notes\n"
+      },
+      "input": {
+        "hook_event_name": "Stop"
+      }
     }
   ]
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1668,7 +1668,11 @@ test_hooks_json_schema_valid() {
   [ -f "$hooks_file" ] || { echo "FAIL: hooks.json not found"; return 1; }
 
   # Valid Claude Code hook event names
-  local valid_events="SessionStart PreToolUse PostToolUse PermissionRequest PreCompact SessionEnd PostToolUseFailure Notification UserPromptSubmit"
+  # Stop and SubagentStop were missing here until the chronicle gate needed Stop: the
+  # allowlist had drifted from the events both hosts actually dispatch, so a valid
+  # binding read as invalid. A gate that only covers some of what it claims to cover
+  # is a gap, not a guard.
+  local valid_events="SessionStart PreToolUse PostToolUse PermissionRequest PreCompact SessionEnd PostToolUseFailure Notification UserPromptSubmit Stop SubagentStop"
 
   # Extract all event names from hooks.json
   local events


### PR DESCRIPTION
Closes #170, in its amended scope: the commission schema was cut after both peer sessions attacked it with receipts, and what survives is the chronicle gate plus the tripwire that keeps it from becoming apparatus.

## Why a gate and not a reminder

Written as you go, a chronicle is a record. Reconstructed at the end, it is a summary — and a summary is where the failures quietly drop out. The sessions that hurt later were the ones whose story was never written, so the next session started blind and hit the same wall. Prose asking for chronicles does not produce chronicles.

## A gate, not a trap

This is the load-bearing design decision:

- refuses **exactly once** per session, printing what to write and where
- a second Stop proceeds regardless
- always names the escape hatch (`KERNEL_CHRONICLE_OK=1`)

A gate that can hold a session hostage gets the whole hook chain disabled — and every other fence goes with it.

Sessions touching only records, docs, or tests pass untouched; they have no source story to tell.

## Scaffolding tripwire

Same classification, same hook: two consecutive sessions of pure apparatus with nothing landed print a halt-and-re-bound warning. That pattern once cost an entire phase.

## Verification

By hand, all five behaviors:

| scenario | result |
|---|---|
| source changed, no chronicle | refuses (rc=2) |
| second Stop | proceeds |
| `KERNEL_CHRONICLE_OK=1` | proceeds |
| chronicle present | proceeds |
| second scaffolding-only cycle | tripwire fires |

The #173 corpus registered the new gate automatically — divergence caught that it needed a registry row, coverage refused to go green until it had both a must-block and a must-allow case. 22 cases over 7 gates. Corpus, hooks, and kernel9 suites green locally.
