### PR TITLE
human-pass: design the half hour only a person can run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: 098a02b0b0709d9b813d5791d9b2ca79ccb3af642182e06e4fc5d6badbdee936; adapter: codex -->
+     source-sha256: b72f6ff7d3e7a9e1f62840c1a1b9edfc0deb1ac3d65e92ebf701f188ec287ee4; adapter: codex -->
 <kernel version="9.1.2">
 
 
@@ -271,6 +271,7 @@ reviewed the claim.</rule>
 
   <skill id="frontend" triggers="UI, frontend, styling, visual">Context-led interface design. Derive art direction from product, audience, brand, content, and the existing design system; mood variants are optional lenses.</skill>
   <skill id="marketing-site" triggers="marketing site, landing page, company website, client website, conversion, positioning, CTA">Honest marketing-site strategy: audience, offer, proof, objections, action, privacy, art direction, and client handoff.</skill>
+  <skill id="human-pass" triggers="testflight, human pass, acceptance test, device test, before we ship, what should I test">Guided acceptance passes for the only verifier that cannot be automated: literal controls, paste-ready inputs, expected outcome per step, worst case first, bundled to one sitting. The recorded verdict is part of done.</skill>
   <skill id="app-dev" triggers="app, mobile, store submission, build, deploy, fastlane">Mobile/web build pipeline: fastlane-first local builds, store submission, pre-submission checklists. EAS only as a stated exception.</skill>
 
   <!-- EXPERIMENTATION -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: 098a02b0b0709d9b813d5791d9b2ca79ccb3af642182e06e4fc5d6badbdee936; adapter: claude -->
+     source-sha256: b72f6ff7d3e7a9e1f62840c1a1b9edfc0deb1ac3d65e92ebf701f188ec287ee4; adapter: claude -->
 <kernel version="9.1.2">
 
 
@@ -271,6 +271,7 @@ reviewed the claim.</rule>
 
   <skill id="frontend" triggers="UI, frontend, styling, visual">Context-led interface design. Derive art direction from product, audience, brand, content, and the existing design system; mood variants are optional lenses.</skill>
   <skill id="marketing-site" triggers="marketing site, landing page, company website, client website, conversion, positioning, CTA">Honest marketing-site strategy: audience, offer, proof, objections, action, privacy, art direction, and client handoff.</skill>
+  <skill id="human-pass" triggers="testflight, human pass, acceptance test, device test, before we ship, what should I test">Guided acceptance passes for the only verifier that cannot be automated: literal controls, paste-ready inputs, expected outcome per step, worst case first, bundled to one sitting. The recorded verdict is part of done.</skill>
   <skill id="app-dev" triggers="app, mobile, store submission, build, deploy, fastlane">Mobile/web build pipeline: fastlane-first local builds, store submission, pre-submission checklists. EAS only as a stated exception.</skill>
 
   <!-- EXPERIMENTATION -->

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -119,7 +119,7 @@ was removed.
 
 ## Codex behavior boundaries
 
-Codex loads all 26 KERNEL skills, with explicit calls written as `$kernel:<name>`.
+Codex loads all 27 KERNEL skills, with explicit calls written as `$kernel:<name>`.
 Use `$kernel:governance-sync` (or Claude's `/kernel:governance-sync`) to audit native
 instruction coverage. Writes require explicit confirmation and a backup directory.
 Explicit-only skills (5): `experiment`, `forge`, `governance-sync`, `init`,

--- a/docs/daily-use.md
+++ b/docs/daily-use.md
@@ -18,7 +18,7 @@ In Codex, replace the leading `/` with `$`, for example `$kernel:validate`.
   `marketing-site`, and more
 - Setup/reference: `init`, `help`, `landing-page`
 
-There are 26 skills and 10 specialized Claude Code agent definitions in this release. Use
+There are 27 skills and 10 specialized Claude Code agent definitions in this release. Use
 `/kernel:help` in Claude Code or `$kernel:help` in Codex for the live index and plugin
 status.
 

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -287,6 +287,7 @@ reviewed the claim.</rule>
 
   <skill id="frontend" triggers="UI, frontend, styling, visual">Context-led interface design. Derive art direction from product, audience, brand, content, and the existing design system; mood variants are optional lenses.</skill>
   <skill id="marketing-site" triggers="marketing site, landing page, company website, client website, conversion, positioning, CTA">Honest marketing-site strategy: audience, offer, proof, objections, action, privacy, art direction, and client handoff.</skill>
+  <skill id="human-pass" triggers="testflight, human pass, acceptance test, device test, before we ship, what should I test">Guided acceptance passes for the only verifier that cannot be automated: literal controls, paste-ready inputs, expected outcome per step, worst case first, bundled to one sitting. The recorded verdict is part of done.</skill>
   <skill id="app-dev" triggers="app, mobile, store submission, build, deploy, fastlane">Mobile/web build pipeline: fastlane-first local builds, store submission, pre-submission checklists. EAS only as a stated exception.</skill>
 
   <!-- EXPERIMENTATION -->

--- a/skills/human-pass/SKILL.md
+++ b/skills/human-pass/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: human-pass
+description: "Write the guided acceptance pass a human runs against a real build: literal taps, real inputs, expected outcome per step, worst case first, bundled to cost one sitting. Triggers: testflight, human pass, acceptance test, before we ship, hand it to the user, what should I test, release checklist, device test."
+allowed-tools: Read, Bash, Grep, Glob, Write, Edit
+kernel:
+  kind: methodology
+  version: 1
+  side_effects: none
+  confirmation: none
+---
+
+<skill id="human-pass">
+
+<purpose>
+A release that only machines have checked has not been checked. The human is the
+only instrument that can see whether the thing FEELS broken, whether an upgrade
+ate real data, and whether an error message is honest. This skill turns that
+irreplaceable half hour into a designed pass instead of random clicking.
+</purpose>
+
+<why>
+A 15-minute guided pass on a real device found a false paywall, a broken
+selection interaction, reversed ordering, and two dead source paths. None were
+visible to CI. In a parallel project, 7 defects found on a phone had been sitting
+under 506 green tests. The gap is not test coverage; it is that some properties
+only exist on the far side of a real screen and real data.
+</why>
+
+<scope>
+Only what the human alone can verify:
+- upgrade survival against THEIR real data, before anything else
+- rendering, motion, and feel on the actual device
+- whether failure states are honest (a fake success is worse than an error)
+- flows that cross apps, accounts, or hardware
+Everything a machine can check stays in CI. A pass that spends the human's
+attention on something a test could have caught has wasted the only instrument
+that cannot be automated.
+</scope>
+
+<form>
+Literal or it does not count. The first draft of the founding example was
+rejected in four words: "not a script, literally what to tap."
+
+Each step gives:
+1. The exact control, named as it appears on screen. Mine the real labels from
+   the UI source; never invent or paraphrase them.
+2. The exact input, paste-ready. Real URLs, real ids, real values, one per line.
+3. What should happen, in one sentence.
+4. What counts as a bug, when that is not obvious. Known rough edges get named so
+   the human does not go hunting for something already on the board.
+</form>
+
+<ordering>
+Worst case first. Data survival before features: if an upgrade ate the library,
+the pass stops there and nothing else matters. Then the paths the release
+actually touched, drawn from the diff, not from a generic checklist. Then the
+cheap wide sweep for feel. Destructive or irreversible actions come last and are
+usually skipped outright: never ask a human to gamble production data to test a
+restore path.
+</ordering>
+
+<bundling>
+Attention is the scarce resource, so the count of passes matters as much as
+coverage. State the time cost up front and design to ONE sitting. Batch every
+question that needs the same build, the same device, and the same state, so the
+human is never called back for something that could have ridden along.
+
+The tension is real and worth naming when it bites: more coverage per pass, or
+more passes. Prefer one thorough pass over three thin ones. When a finding will
+obviously force a rebuild, say so in the same breath, so the next pass is
+expected rather than a surprise.
+</bundling>
+
+<close>
+The pass ends with a verdict, not a vibe: a thumbs-up, or findings. Findings come
+back as prose and screenshots; converting them into issues is the agent's job,
+not the human's. Record the verdict as a state-change receipt on the release
+issue, and say plainly what the thumbs-up unlocks (the next build, the
+submission, the deploy promotion).
+
+Until that verdict exists, the release is not done, whatever CI says.
+</close>
+
+<anti-patterns>
+- Generic checklists ("test the main flows"). If it could have been written
+  without reading this diff, it is not a pass.
+- Steps whose outcome is unstated, so any result looks like a result.
+- Asking for something CI already proves.
+- Silent scope: if the pass skips an area, say which and why.
+- Assuming the human will improvise around a broken step. They will report it as
+  a bug in the pass, and they will be right.
+</anti-patterns>
+
+<on_complete>
+Report where the guide is, the time it should cost, the single worst-case check
+it opens with, and what the verdict unlocks.
+</on_complete>
+
+</skill>

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -60,9 +60,30 @@ kernel:
      manifest until both schemas can be satisfied.
    - Tag (only if user requested a tagged release): `git tag -l` to avoid clobber → `git tag -a v{X.Y.Z} -m "{summary}"` → `git push origin v{X.Y.Z}`.
 
-6. **Checkpoint**
+6. **Human pass** *(any user-facing release: app build, deploy, anything a person will touch)*
+   - Load `skills/human-pass/SKILL.md` and write the guide for THIS build: literal
+     controls, paste-ready inputs, expected outcome per step, worst case first,
+     bundled to one sitting with the time cost stated.
+   - Hand it over and wait. The build is not shipped, it is awaiting verdict.
+   - (gate: no guide, or no recorded verdict → the release is NOT done. Say
+     "awaiting your pass on <build>", never "shipped". A green pipeline is not a
+     person having used the thing.)
+   - Findings come back as prose; YOU convert them into issues, not the human.
+   - Record the verdict as a state-change receipt on the release issue, naming
+     what it unlocks (next build, submission, deploy promotion).
+
+7. **Checkpoint**
    - `agentdb learn pattern "ship: {branch} {commit_range} {sha_pushed}" "validate=pass review=pass push=ok"`
    - Profile-gated: github-oss/github-production → post PR or release note via gh CLI.
+
+## The verdict is part of done
+
+For anything a person will use, the completion states are ordered: validated,
+merged, deployed, **accepted**. CI proves the first three. Only a human who used
+the build proves the fourth, and only that one predicts whether the release was
+any good: a 15-minute guided pass found five defects that 500+ green tests had
+not, because some properties only exist on the far side of a real screen with
+real data. Report the state you actually reached, by name.
 
 ## Ask-user gates (mandatory pause points)
 


### PR DESCRIPTION
Closes #179. The last open 9.2 issue.

## Why
A release only machines have checked has not been checked. Some properties exist only on the far side of a real screen with real data — whether an upgrade ate the library, whether it *feels* broken, whether a failure message is honest or a fake success. Founding evidence: a 15-minute guided device pass found a false paywall, a broken selection interaction, reversed ordering, and two dead source paths. None visible to CI. In a parallel project, 7 phone defects sat under 506 green tests.

## The skill
- **Literal or it doesn't count.** The founding draft was rejected in four words — *"not a script, literally what to tap"* — and the version that worked named real controls mined from the UI source, with paste-ready inputs and an expected outcome per step.
- **Only what the human alone can verify.** A pass that spends their attention on something a test could catch has wasted the one instrument that can't be automated.
- **Worst case first.** Data survival before features; if the upgrade ate the library, the pass stops there.
- **Bundling is a first-class constraint.** Attention is the scarce resource: state the time cost, design for one sitting.
- **Ends in a verdict, not a vibe.** Findings come back as prose; the agent converts them to issues.

## The enforcement half
`kernel:ship` gains a human-pass step and this framing: for anything a person will use, the completion states are *validated → merged → deployed → **accepted***, and CI can only prove the first three. Without a guide and a recorded verdict, the release reports as "awaiting your pass on <build>" — never "shipped".

Governance, corpus, and schema suites green.