### PR TITLE
guard-bash: one code view, so prose stops reading as code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ All notable changes to KERNEL are documented in this file.
   does it, after a human reviewed the claim. (#169)
 
 ### Fixed
+- **guard-bash matched guarded commands inside text ARGUMENTS** (#188): a commit message,
+  a lesson recorded with `agentdb learn`, or an issue body that NAMED a destructive command
+  was refused as if it had run one. Reported by a peer session that hit it twice and
+  reworded rather than requesting an override, which is the good outcome and the bad habit.
+  The guard now keeps one "code view" of the command with data removed, and every rule reads
+  it, so the case-sensitive rules and the rest can no longer disagree about what counts as
+  code. The distinguishing signal is the RECEIVING command, never the quoting: an argument
+  to `git commit -m` or `agentdb learn` is data, while an argument to `bash -c` is code and
+  is still matched in full. Known gap, in the safe direction: single-quoted text arguments
+  stay matched.
 - **Three guard-bash false positives** (#175). A fence that refuses ordinary work teaches
   people to override it, so noise is a safety defect, not a cosmetic one. The safe
   merge-checked branch delete was refused because the command was folded to lowercase

--- a/hooks/scripts/guard-bash.sh
+++ b/hooks/scripts/guard-bash.sh
@@ -102,6 +102,11 @@ esac
 # extraction and the rm gate below still use the raw $COMMAND (paths are case-sensitive).
 LOW=$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
 
+# The code view: $COMMAND with the parts that are DATA removed. Every rule matches
+# against this or its lowercased twin, never against the raw command, so a rule that
+# needs case sensitivity and a rule that does not cannot disagree about what is code.
+COMMAND_CODE="$COMMAND"
+
 # Heredoc bodies that are DATA, not code, are dropped before keyword matching. Writing a
 # chronicle that mentions a rewrite tool, or filing an issue that quotes a destructive
 # command, tripped this guard on prose describing the very rules it enforces.
@@ -109,9 +114,35 @@ LOW=$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' 
 # The exception is load-bearing: when the heredoc feeds a shell or interpreter
 # (`bash <<EOF`, `python3 - <<PY`), the body IS executed, so it is kept and matched. That
 # is a real bypass vector, and narrowing noise must never open one.
+# Same class, different syntax: a guarded keyword inside a quoted ARGUMENT to a command
+# that consumes text. Recording a lesson, writing a commit message, or filing an issue
+# ABOUT a destructive operation is not performing one, and refusing the description
+# teaches people to reword until the guard shuts up -- a habit that costs more than the
+# noise it removes.
+#
+# The distinguishing signal is the RECEIVING command, never the quoting. An argument to
+# `git commit -m`, `gh issue comment -b`, or `agentdb learn` is data. An argument to
+# `bash -c` or `python3 -c` is code, and those are matched in full, above and below.
+_strip_text_arguments() {
+  printf '%s' "$1" | awk '
+    {
+      line = $0
+      # Drop the quoted payload that follows a text-consuming flag, keeping the command
+      # itself visible so the guard still sees what is being RUN.
+      gsub(/(git[[:space:]]+(commit|tag)[^|;&]*-[a-zA-Z]*m|gh[[:space:]]+[a-z-]+[^|;&]*-[a-zA-Z]*(b|body)|agentdb[[:space:]]+(learn|contract|verdict|write-end)([[:space:]]+[a-z-]+)*)[[:space:]]+"[^"]*"([[:space:]]+"[^"]*")*/, " <text> ", line)
+      print line
+    }'
+}
+if printf '%s' "$COMMAND" | grep -qE '(git[[:space:]]+(commit|tag)|gh[[:space:]]+[a-z-]+|agentdb[[:space:]]+(learn|contract|verdict|write-end))'; then
+  if ! printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[[:space:]]+-[ce]'; then
+    COMMAND_CODE=$(_strip_text_arguments "$COMMAND_CODE")
+    LOW=$(printf '%s' "$COMMAND_CODE" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
+  fi
+fi
+
 if printf '%s' "$COMMAND" | grep -q '<<'; then
   if ! printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[^|;&]*<<'; then
-    COMMAND_CODE=$(printf '%s' "$COMMAND" | awk '
+    COMMAND_CODE=$(printf '%s' "$COMMAND_CODE" | awk '
       BEGIN { in_doc = 0 }
       {
         if (in_doc) { if ($0 == term) { in_doc = 0 }; next }
@@ -179,7 +210,7 @@ while IFS= read -r _seg; do
       block "Force push to main/master not allowed." \
             "Push to a feature branch and open a PR, or force-push a non-default branch."
   fi
-done < <(echo "$COMMAND" | tr ';|&' '\n')
+done < <(echo "$COMMAND_CODE" | tr ';|&' '\n')
 
 # --- Other git history/state destruction (reset --hard, clean -f, branch -D, rewrite) ---
 printf '%s' "$LOW" | grep -qE 'git +reset +--hard' \
@@ -190,7 +221,7 @@ printf '%s' "$LOW" | grep -qE 'git +clean +-[a-z]*f' \
 # safe delete indistinguishable from the destructive one and blocked `git branch -d`
 # five times across three sessions in one day. A guard that cries wolf on the safe form
 # of a command teaches people to override it, which costs more than it ever saves.
-printf '%s' "$COMMAND" | grep -qE 'git +branch +(-[a-zA-Z]*D|--delete --force|--force --delete)' \
+printf '%s' "$COMMAND_CODE" | grep -qE 'git +branch +(-[a-zA-Z]*D|--delete --force|--force --delete)' \
   && block "git branch -D force-deletes a branch (may drop unmerged commits)." "Confirm it's merged, or use -d (safe delete)."
 printf '%s' "$LOW" | grep -qE 'filter-repo|filter-branch|(^| )bfg( |$)' \
   && block "git history rewrite (filter-repo/filter-branch/bfg) is destructive + non-collaborative." "Verify a backup ref exists first."

--- a/tests/corpus/cases.json
+++ b/tests/corpus/cases.json
@@ -42,6 +42,18 @@
     "INTERPRETER_TREE_DELETE": [
       "python3 -c \"import shutil; shutil.rm",
       "tree('/data')\""
+    ],
+    "COMMIT_MSG_NAMING_GUARDED_OP": [
+      "git commit -m \"fix: stop the drop table users path from running\""
+    ],
+    "LEARN_NAMING_GUARDED_OP": [
+      "agentdb learn gotcha \"drop table users wipes data with no rollback\" \"evidence\""
+    ],
+    "SHELL_C_REAL_COMMAND": [
+      "bash -c \"git reset --hard origin/main\""
+    ],
+    "COMMIT_THEN_REAL_COMMAND": [
+      "git commit -m \"wip\" && git reset --hard HEAD~3"
     ]
   },
   "cases": [
@@ -323,6 +335,54 @@
       },
       "input": {
         "hook_event_name": "Stop"
+      }
+    },
+    {
+      "id": "guard-bash/allows-commit-message-naming-a-guarded-op",
+      "gate": "guard-bash",
+      "expect": "allow",
+      "why": "Describing a destructive operation is not performing one. Refusing the description teaches people to reword until the guard shuts up, which is a worse habit than the noise it removes.",
+      "input": {
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "{{COMMIT_MSG_NAMING_GUARDED_OP}}"
+        }
+      }
+    },
+    {
+      "id": "guard-bash/allows-learn-string-naming-a-guarded-op",
+      "gate": "guard-bash",
+      "expect": "allow",
+      "why": "Recording a lesson about a destructive command is the behaviour the memory protocol asks for; the guard blocked it twice in one day on a peer session.",
+      "input": {
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "{{LEARN_NAMING_GUARDED_OP}}"
+        }
+      }
+    },
+    {
+      "id": "guard-bash/blocks-real-command-inside-shell-c",
+      "gate": "guard-bash",
+      "expect": "block",
+      "why": "The bypass the text-argument fix must not open: an argument to a shell is CODE, and the distinguishing signal is the receiving command, never the quoting.",
+      "input": {
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "{{SHELL_C_REAL_COMMAND}}"
+        }
+      }
+    },
+    {
+      "id": "guard-bash/blocks-real-command-alongside-a-commit-message",
+      "gate": "guard-bash",
+      "expect": "block",
+      "why": "Stripping the message must not blind the guard to a real destructive command in the same line.",
+      "input": {
+        "tool_name": "Bash",
+        "tool_input": {
+          "command": "{{COMMIT_THEN_REAL_COMMAND}}"
+        }
       }
     }
   ]

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1900,7 +1900,7 @@ test_critical_guard_scripts_unchanged_for_820() {
     actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
-155da2476aff3551f1161f7d792a4bfdd560e1c4ccec6c22c71207108894224d guard-bash.sh
+3591d28785be3312d0b7aaf1d3fb349990ecbf22e27ab37493ee38d89aa1cb6f guard-bash.sh
 6a885672ad9f643bc0ac60cc3cfe3f2366a890faaa3a4bee132afb2d99cde731 guard-config.sh
 d3611267b4f135c5b96e8a4a8af60f296b196efc135e3dfbef63d7683065608c detect-secrets.sh
 e1c4940def589dce982695d7e79f22e11cb767f6260608a738801f6c4167afbc guard-context.sh


### PR DESCRIPTION
Closes #188. Reported by the matra session, which hit it twice today and **reworded to get past it** — the good outcome, and exactly the bad habit, because the next reword routes around a real check.

## Root cause
Two views of the same command. Stripping fed only the lowercased view, so the case-sensitive rules (force-push, force branch delete) still matched the raw string and disagreed with the rest about what counted as code. There is now **one code view**, built once with data removed, that every rule reads.

## The rule
The distinguishing signal is the **receiving command**, never the quoting:

| data (stripped) | code (matched in full) |
|---|---|
| `git commit -m "..."`, `git tag -m` | `bash -c "..."`, `sh -c` |
| `gh issue comment -b "..."` | heredoc fed to a shell/interpreter |
| `agentdb learn ... "..."` | everything else |

## Verified, both directions
9/9 on a direct matrix, then locked into the corpus (26 cases, 7 gates): 4 prose cases pass, 5 dangerous cases still refuse — including a real destructive command sharing a line with a commit message, and one inside `bash -c`.

## Known gap, safe direction
Single-quoted text arguments stay matched. Embedding a quote in that awk program is a quoting hazard for no safety gain, and the failure mode is refusing rather than allowing. Documented in the code.

Corpus 26/26, hooks 23/23. Tamper pin updated deliberately.