### PR TITLE
release: 9.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Fences, not leashes: enforced boundaries for Claude Code in auto mode",
-      "version": "9.1.2"
+      "version": "9.2.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.1.2",
+  "version": "9.2.0",
   "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.1.2",
+  "version": "9.2.0",
   "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: b72f6ff7d3e7a9e1f62840c1a1b9edfc0deb1ac3d65e92ebf701f188ec287ee4; adapter: codex -->
-<kernel version="9.1.2">
+<kernel version="9.2.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to KERNEL are documented in this file.
 
-## [Unreleased]
+## [9.2.0] - 2026-08-09
 
 ### Added
 - **Violation corpus** (`tests/corpus/`): a standing harness proving KERNEL's gates can

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: b72f6ff7d3e7a9e1f62840c1a1b9edfc0deb1ac3d65e92ebf701f188ec287ee4; adapter: claude -->
-<kernel version="9.1.2">
+<kernel version="9.2.0">
 
 
 <!-- ============================================ -->

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.1.2.
+Quick reference for KERNEL v9.2.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>


### PR DESCRIPTION
Cuts 9.2.0. Every issue in the signed three-session commission is closed (#169 #170 #171 #173 #174 #175 #179 #188), each as its own PR merged on explicitly read green conclusions.

**Goal, in its falsifiable form:** every kernel fence has proven it can fail.

- **#173** violation corpus: gate registry + divergence/coverage/liveness. Found **guard-bash failing OPEN when jq was missing** — one absent binary had been opening the destructive-command guard for months.
- **#174** retirement ledger + erosion check. Excluding tests as callers revealed 5 stranded functions hiding behind their own assertions.
- **#171** process rules, validated by both pilots.
- **#170** chronicle Stop-gate (a gate, not a trap) + scaffolding tripwire.
- **#169** state-change receipts; cadence posting retired with verdicts.
- **#179** human-pass skill + ship verdict gate.
- **#175/#188** four guard false positives fixed, each with corpus cases proving the dangerous twin still blocks.

446/446 local.