### PR TITLE
fix(codex): use a plugin-root variable Codex actually substitutes

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -6,18 +6,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/session-start.sh",
             "timeout": 30,
             "statusMessage": "Loading KERNEL context..."
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/autopush.sh install",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/autopush.sh install",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/knowledge-graph.sh install",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/knowledge-graph.sh install",
             "timeout": 15
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/guard-bash.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/guard-bash.sh",
             "timeout": 5
           }
         ]
@@ -39,22 +39,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/guard-config.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/guard-config.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/detect-secrets.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/detect-secrets.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/validate-structure.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/validate-structure.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
             "timeout": 5
           }
         ]
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/guard-context.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/guard-context.sh",
             "timeout": 5
           }
         ]
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/auto-approve-safe.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/auto-approve-safe.sh",
             "timeout": 5
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/scan-output.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/scan-output.sh",
             "timeout": 10
           }
         ]
@@ -98,12 +98,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/log-write.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/log-write.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/validate-json-schema.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/validate-json-schema.sh",
             "timeout": 5
           }
         ]
@@ -115,12 +115,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/route-request.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/route-request.sh",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/post-compact-restore.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/post-compact-restore.sh",
             "timeout": 5
           }
         ]
@@ -132,7 +132,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/chronicle-gate.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/chronicle-gate.sh",
             "timeout": 15
           }
         ]
@@ -144,7 +144,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/pre-compact-commit.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/pre-compact-commit.sh",
             "timeout": 30,
             "statusMessage": "Saving context snapshot..."
           }
@@ -157,7 +157,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CODEX_PLUGIN_ROOT}/hooks/scripts/session-end.sh",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/session-end.sh",
             "timeout": 210,
             "statusMessage": "Closing session..."
           }

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -77,8 +77,14 @@ def version() -> str:
 
 
 def plugin_root_var(host_key: str) -> str:
-    """Each host names the plugin root differently."""
-    return "${CLAUDE_PLUGIN_ROOT}" if host_key == "claude" else "${CODEX_PLUGIN_ROOT}"
+    """Each host names the plugin root differently.
+
+    Codex's hook command runner substitutes exactly four names: PLUGIN_ROOT,
+    CLAUDE_PLUGIN_ROOT, PLUGIN_DATA, CLAUDE_PLUGIN_DATA. CODEX_PLUGIN_ROOT was
+    never one of them. It expanded to the empty string, so every Codex hook ran
+    `/hooks/scripts/<name>` and exited 127 on every lifecycle event.
+    """
+    return "${CLAUDE_PLUGIN_ROOT}" if host_key == "claude" else "${PLUGIN_ROOT}"
 
 
 # --------------------------------------------------------------------------

--- a/tests/kernel9/test_adapters.py
+++ b/tests/kernel9/test_adapters.py
@@ -198,12 +198,23 @@ class CodexAdapter(unittest.TestCase):
         self.assertEqual(self.host["hooks_file"], "hooks.json")
         self.assertTrue(os.path.isfile(os.path.join(REPO, "hooks.json")))
 
-    def test_hook_bindings_use_the_codex_root_var(self):
+    def test_hook_bindings_use_a_root_var_codex_actually_substitutes(self):
+        """Codex substitutes PLUGIN_ROOT / CLAUDE_PLUGIN_ROOT and nothing else.
+
+        A name Codex does not know expands to the empty string, so the hook
+        runs `/hooks/scripts/<name>` and exits 127 on every single event. The
+        old assertion pinned the invented name and stayed green while every
+        Codex hook in the plugin was dead.
+        """
+        substituted = ("${PLUGIN_ROOT}", "${CLAUDE_PLUGIN_ROOT}")
         doc = load(self.host["hooks_file"])
         for event, groups in doc["hooks"].items():
             for group in groups:
                 for hook in group["hooks"]:
-                    self.assertIn("${CODEX_PLUGIN_ROOT}", hook["command"], event)
+                    self.assertTrue(
+                        hook["command"].startswith(substituted),
+                        f"{event}: {hook['command']} uses a root var Codex never sets",
+                    )
 
     def test_normal_requests_reach_the_adaptive_router(self):
         doc = load(self.host["hooks_file"])


### PR DESCRIPTION
## The defect

Every Codex hook in the plugin was dead, on every session, silently.

`hooks.json` bound each script as `${CODEX_PLUGIN_ROOT}/hooks/scripts/<name>`. Codex's hook command runner substitutes exactly four names:

```
PLUGIN_ROOT   CLAUDE_PLUGIN_ROOT   PLUGIN_DATA   CLAUDE_PLUGIN_DATA
```

`CODEX_PLUGIN_ROOT` was invented in this repo and is not one of them. It expanded to the empty string, so every hook ran the nonexistent path `/hooks/scripts/<name>` and exited **127**. SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop: all of them.

Reproduction:

```
$ env -u CODEX_PLUGIN_ROOT sh -c '${CODEX_PLUGIN_ROOT}/hooks/scripts/session-start.sh'
sh: /hooks/scripts/session-start.sh: No such file or directory
exit=127
```

## Why nothing caught it

`test_adapters.py` asserted the invented name as the expected value:

```python
self.assertIn("${CODEX_PLUGIN_ROOT}", hook["command"], event)
```

Green for the whole life of the defect, because it only asserted the generator agreed with itself. The test now asserts the command starts with a variable Codex is known to substitute.

## Evidence

Patched the installed 9.2.0 cache and ran a real headless Codex session.

Before: three SessionStart hooks, all exit 127.
After:

```
hook: SessionStart Completed
hook: SessionStart Completed
hook: SessionStart Completed
hook: UserPromptSubmit Completed  (x3)
hook: Stop Completed
```

Full suite: 446 passed, 0 failed. `generate-adapters.py --check` clean.