### PR TITLE
fix(adapters): resolve every host's bindings, not just Claude's

### DIFF
--- a/governance/hosts.json
+++ b/governance/hosts.json
@@ -6,7 +6,14 @@
     "",
     "supported_lifecycle_events is a claim about the HOST, not about Kernel.",
     "It must be backed by the evidence named in verified_by. Adding an event",
-    "here without evidence is how a false parity claim gets shipped."
+    "here without evidence is how a false parity claim gets shipped.",
+    "",
+    "plugin_root_var is the same kind of claim: the variable name the HOST",
+    "substitutes in a hook command. A name the host does not know expands to",
+    "the empty string, so every hook runs an absolute path off / and exits",
+    "127. This was invented as CODEX_PLUGIN_ROOT once and killed every Codex",
+    "hook until #191. It lives here, not in the generator, so it cannot be",
+    "chosen without the evidence rule above applying to it."
   ],
 
   "kernel_lifecycle_bindings": [
@@ -29,6 +36,7 @@
       "marketplace_manifest": ".claude-plugin/marketplace.json",
       "hooks_file": "hooks/hooks.json",
       "skills_declaration": "implicit",
+      "plugin_root_var": "CLAUDE_PLUGIN_ROOT",
       "supported_lifecycle_events": [
         "SessionStart",
         "SessionEnd",
@@ -54,6 +62,7 @@
       "marketplace_manifest": ".agents/plugins/marketplace.json",
       "hooks_file": "hooks.json",
       "skills_declaration": "explicit",
+      "plugin_root_var": "PLUGIN_ROOT",
       "supported_lifecycle_events": [
         "SessionStart",
         "SessionEnd",

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -76,15 +76,16 @@ def version() -> str:
     return load_json(CLAUDE_PLUGIN)["version"]
 
 
-def plugin_root_var(host_key: str) -> str:
-    """Each host names the plugin root differently.
+def plugin_root_var(host: dict) -> str:
+    """The variable name this host substitutes in a hook command.
 
-    Codex's hook command runner substitutes exactly four names: PLUGIN_ROOT,
-    CLAUDE_PLUGIN_ROOT, PLUGIN_DATA, CLAUDE_PLUGIN_DATA. CODEX_PLUGIN_ROOT was
-    never one of them. It expanded to the empty string, so every Codex hook ran
-    `/hooks/scripts/<name>` and exited 127 on every lifecycle event.
+    Declared in governance/hosts.json, not chosen here. A name the host does
+    not know expands to the empty string, so every hook runs an absolute path
+    off / and exits 127. CODEX_PLUGIN_ROOT was invented in this function and
+    killed every Codex hook until #191; keeping the value in the canonical
+    source puts it under that file's evidence rule.
     """
-    return "${CLAUDE_PLUGIN_ROOT}" if host_key == "claude" else "${PLUGIN_ROOT}"
+    return "${%s}" % host["plugin_root_var"]
 
 
 # --------------------------------------------------------------------------
@@ -95,7 +96,7 @@ def plugin_root_var(host_key: str) -> str:
 def build_hooks(host_key: str, host: dict) -> tuple[dict, list[str]]:
     """Return (hooks document, list of dropped bindings)."""
     supported = set(host["supported_lifecycle_events"])
-    root = plugin_root_var(host_key)
+    root = plugin_root_var(host)
 
     grouped: dict[str, list] = {}
     dropped: list[str] = []

--- a/tests/kernel9/test_adapters.py
+++ b/tests/kernel9/test_adapters.py
@@ -120,20 +120,6 @@ class ClaudeAdapter(unittest.TestCase):
         for key in ("interface", "skills", "apps", "mcpServers"):
             self.assertNotIn(key, m, f"Claude manifest carries Codex-only key {key!r}")
 
-    def test_hook_bindings_reference_real_scripts(self):
-        doc = load(self.host["hooks_file"])
-        for event, groups in doc["hooks"].items():
-            for group in groups:
-                for hook in group["hooks"]:
-                    cmd = hook["command"]
-                    self.assertIn("${CLAUDE_PLUGIN_ROOT}", cmd, f"{event}: wrong root var")
-                    rel = cmd.split("${CLAUDE_PLUGIN_ROOT}/")[1].split()[0]
-                    with self.subTest(event=event, script=rel):
-                        self.assertTrue(
-                            os.path.isfile(os.path.join(REPO, rel)),
-                            f"{event} binds missing script {rel}",
-                        )
-
     def test_normal_requests_reach_the_adaptive_router(self):
         doc = load(self.host["hooks_file"])
         commands = [
@@ -198,24 +184,6 @@ class CodexAdapter(unittest.TestCase):
         self.assertEqual(self.host["hooks_file"], "hooks.json")
         self.assertTrue(os.path.isfile(os.path.join(REPO, "hooks.json")))
 
-    def test_hook_bindings_use_a_root_var_codex_actually_substitutes(self):
-        """Codex substitutes PLUGIN_ROOT / CLAUDE_PLUGIN_ROOT and nothing else.
-
-        A name Codex does not know expands to the empty string, so the hook
-        runs `/hooks/scripts/<name>` and exits 127 on every single event. The
-        old assertion pinned the invented name and stayed green while every
-        Codex hook in the plugin was dead.
-        """
-        substituted = ("${PLUGIN_ROOT}", "${CLAUDE_PLUGIN_ROOT}")
-        doc = load(self.host["hooks_file"])
-        for event, groups in doc["hooks"].items():
-            for group in groups:
-                for hook in group["hooks"]:
-                    self.assertTrue(
-                        hook["command"].startswith(substituted),
-                        f"{event}: {hook['command']} uses a root var Codex never sets",
-                    )
-
     def test_normal_requests_reach_the_adaptive_router(self):
         doc = load(self.host["hooks_file"])
         commands = [
@@ -228,6 +196,67 @@ class CodexAdapter(unittest.TestCase):
             "Codex UserPromptSubmit does not reach the Kernel 9 router",
         )
 
+
+
+class EveryHostBindsRealScripts(unittest.TestCase):
+    """Both hosts, one check. Not one host's bindings and a promise about the other.
+
+    Two separate defects shipped through the gap this class closes.
+
+    The Claude adapter had a binding-resolves-on-disk test; the Codex adapter
+    never did. So when the generator emitted ${CODEX_PLUGIN_ROOT} -- a variable
+    Codex does not substitute -- every Codex command expanded to the empty
+    string, ran `/hooks/scripts/<name>`, and exited 127 on every lifecycle
+    event of every session. The Codex test that existed asserted the invented
+    name was present, which is the generator agreeing with itself, so it was
+    green for the defect's whole life (#191, #194).
+
+    Parameterizing over governance/hosts.json means a third host cannot opt out
+    of this by simply never having a test written for it.
+    """
+
+    # The names Codex's hook command runner actually substitutes, read out of
+    # the shipped binary's codex_hooks::engine::command_runner string block,
+    # plus Claude's own. Anything else expands to empty and exits 127.
+    SUBSTITUTED = {"CLAUDE_PLUGIN_ROOT", "PLUGIN_ROOT"}
+
+    def _bindings(self, host):
+        doc = load(host["hooks_file"])
+        for event, groups in doc["hooks"].items():
+            for group in groups:
+                for hook in group["hooks"]:
+                    yield event, hook["command"]
+
+    def test_every_binding_uses_the_root_var_the_host_declares(self):
+        for key, host in spec()["hosts"].items():
+            declared = "${%s}" % host["plugin_root_var"]
+            for event, cmd in self._bindings(host):
+                with self.subTest(host=key, event=event):
+                    self.assertTrue(
+                        cmd.startswith(declared + "/"),
+                        f"{key} {event}: {cmd} does not use declared {declared}",
+                    )
+
+    def test_declared_root_var_is_one_the_host_substitutes(self):
+        """The declaration itself has to be a real name, not a plausible one."""
+        for key, host in spec()["hosts"].items():
+            with self.subTest(host=key):
+                self.assertIn(
+                    host["plugin_root_var"], self.SUBSTITUTED,
+                    f"{key} declares {host['plugin_root_var']!r}, which no host "
+                    "substitutes; every hook would expand to / and exit 127",
+                )
+
+    def test_every_binding_resolves_to_a_script_on_disk(self):
+        for key, host in spec()["hosts"].items():
+            for event, cmd in self._bindings(host):
+                # Strip whatever ${...}/ prefix this host uses, then drop args.
+                rel = cmd.split("}/", 1)[1].split()[0]
+                with self.subTest(host=key, event=event, script=rel):
+                    self.assertTrue(
+                        os.path.isfile(os.path.join(REPO, rel)),
+                        f"{key} {event} binds missing script {rel}",
+                    )
 
 class TruthfulCapabilityReporting(unittest.TestCase):
     """Requirement 14. The heart of the honesty guarantee."""


### PR DESCRIPTION
Closes #194.

The Claude adapter had a test resolving each hook binding to a real script on disk. The Codex adapter never did.

That asymmetry is the second reason the `CODEX_PLUGIN_ROOT` defect shipped. The Codex test that existed asserted the invented name was *present* — the generator agreeing with itself — so it stayed green for the whole life of a bug that killed every Codex hook with exit 127.

## Changes

**The root variable moves into `governance/hosts.json`.** It was invented as a Python constant precisely because no rule governed constants in that function. In hosts.json the file's own stated rule applies: a claim about the HOST must be backed by named evidence.

**The generator reads the declared name** instead of choosing one.

**The binding tests are parameterized over every host**, so a third host cannot opt out of coverage by never having a test written for it. They assert:

- each binding uses the variable its host declares
- the declared variable is one a host actually substitutes
- every binding resolves to a file on disk

## Proof the test catches the real bug

Not assumed — run. Reintroducing `CODEX_PLUGIN_ROOT` in hosts.json and regenerating:

```
FAIL: test_declared_root_var_is_one_the_host_substitutes (host='codex')
Ran 29 tests
FAILED (failures=1)
```
