### PR TITLE
feat(context): land the context usage meter, and make it work on real Codex

### DIFF
--- a/_meta/plans/context-usage-meter.md
+++ b/_meta/plans/context-usage-meter.md
@@ -1,0 +1,39 @@
+---
+type: plan
+status: active
+created: 2026-08-06
+updated: 2026-08-06
+contract: CR-20260805235233-29894-26025
+---
+
+# Context usage meter
+
+## Contract
+
+- **Goal:** show exact last-known Codex context occupancy on every `UserPromptSubmit`.
+- **Constraints:** upstream only; no plugin-cache edits; metadata allowlist; no secrets or content;
+  tests authored before code by a different model; no dependency or external mutation.
+- **Inputs:** `$CODEX_THREAD_ID`; structural token/compaction events in that thread's rollout.
+- **Outputs:** one bounded status line for hooks and one JSON status for diagnostics.
+- **Done when:** wrong-thread, stale, truncated, archive-rotation, transition, threshold, cumulative,
+  subset-double-counting, and secret-canary fixtures pass; seeded defects turn the suite red; both
+  generated host adapters wire the hook; a fresh nested Codex task displays a correct live value.
+
+## Approaches considered
+
+1. Add parsing to `route-request.sh`: few files, but couples routing to sensitive telemetry and
+   makes both failure domains harder to test. Rejected.
+2. Standalone shell plus `jq`: small, but adds a hook-time binary dependency and encourages broad
+   deserialization of content-bearing JSONL. Rejected.
+3. Standalone Python-stdlib meter plus its own hook entry: about 150 lines, no new dependency,
+   metadata-only interface, independent timeout and tests. **Chosen.** Python must remain 3.9-safe.
+
+## Operational bands
+
+- `<50%`: green.
+- `50-59.99%`: checkpoint.
+- `60-69.99%`: finish the bounded slice and cross a fresh semantic boundary.
+- `>=70%`: emergency persistence; do not load another large evidence batch.
+
+These are reasoning-continuity controls, not predictions of a native threshold. Observed native
+compactions were 89.74% and 91.76%.

--- a/_meta/reports/context-usage-meter-adversarial-verification.md
+++ b/_meta/reports/context-usage-meter-adversarial-verification.md
@@ -1,0 +1,135 @@
+---
+type: adversarial-verification
+status: complete
+created: 2026-08-06
+contract: CR-20260805235233-29894-26025
+requested_model: gpt-5.6-terra
+requested_effort: high
+observed_model: unavailable
+observed_effort: unavailable
+verdict: PASS
+---
+
+# Context usage meter adversarial verification
+
+## Verdict
+
+**PASS.** The meter passed its contract suites, every required seeded defect made a
+previously green check fail in an isolated disposable copy, and the live numeric
+reading exactly matched an independent structural `jq` query. No implementation,
+test, or adapter file was changed by this verification.
+
+## Baseline gates
+
+Configured `python3` is Python 3.14.6; `/usr/bin/python3` is Python 3.9.6.
+
+```text
+$ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.kernel9.test_context_usage
+Ran 23 tests in 0.742s
+OK
+
+$ PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest tests.kernel9.test_context_usage
+Ran 23 tests in 1.829s
+OK
+
+$ PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.kernel9.test_adapters tests.kernel9.test_activation
+Ran 42 tests in 3.012s, then 2.704s on repeat
+OK
+
+$ python3 scripts/generate-adapters.py --check
+all 7 generated adapters are in sync
+
+$ git diff --check
+exit 0, no output
+```
+
+## Seeded defect evidence
+
+Each check was first run green against a copied meter and copied contract in
+`/tmp/context-meter-adversary.fIpCX8/repo`, then the copy alone was changed.
+
+| Defect seeded | Exact changed behavior | Previously green contract that turned red | Result |
+|---|---|---|---|
+| Wrong-thread selection | Selector accepted every `.jsonl` and returned the newest mtime rather than the exact thread suffix. | `ContextUsageContract.test_competing_newer_rollout_cannot_steal_thread_selection` | Red, exit 1: expected `last.total_tokens == 499`, got `None` after the newer `thread-b` rollout was selected then rejected by metadata validation. |
+| One boundary | Changed only `elif used_percent < 60` to `< 61`. | `ContextUsageContract.test_threshold_60_is_compact_at_boundary` | Red, exit 1: `checkpoint` instead of `compact_at_boundary` at 60.0%. |
+| Privacy output | Appended the existing `context-meter-canary-NOT-A-REAL-SECRET-7f3a9c` to JSON output. | `ContextUsageContract.test_content_canary_never_leaks_to_output_or_json` | Red, exit 1: JSON extra-data failure printed the injected canary, proving the privacy test blocks this leak. |
+
+The untouched copies passed those same three tests individually before mutation.
+
+Commands that produced the red results:
+
+```text
+$ PYTHONDONTWRITEBYTECODE=1 python3 /tmp/context-meter-adversary.fIpCX8/repo/tests/kernel9/test_context_usage.py ContextUsageContract.test_competing_newer_rollout_cannot_steal_thread_selection
+exit 1
+$ PYTHONDONTWRITEBYTECODE=1 python3 /tmp/context-meter-adversary.fIpCX8/repo/tests/kernel9/test_context_usage.py ContextUsageContract.test_threshold_60_is_compact_at_boundary
+exit 1
+$ PYTHONDONTWRITEBYTECODE=1 python3 /tmp/context-meter-adversary.fIpCX8/repo/tests/kernel9/test_context_usage.py ContextUsageContract.test_content_canary_never_leaks_to_output_or_json
+exit 1
+```
+
+## Live, metadata-only parity
+
+With this verifier's `$CODEX_THREAD_ID`, I selected the single filename-suffix
+rollout, validated only line-one `session_meta.payload.id`, then ran the real meter:
+
+```text
+$ PYTHONDONTWRITEBYTECODE=1 python3 hooks/scripts/context-usage.py --json
+meter total=58799, window=258400, percent=22.75503095975232
+```
+
+The independent query byte-filtered only `event_msg`/`token_count` lines before
+`jq`, emitted only `{total, window, percent}`, and did not emit content-bearing
+records:
+
+```text
+independent total=58799, window=258400, percent=22.75503095975232
+exact=true
+```
+
+The exact independent numeric command was:
+
+```sh
+LC_ALL=C awk '/"type"[[:space:]]*:[[:space:]]*"event_msg"/ && /"type"[[:space:]]*:[[:space:]]*"token_count"/' "$rollout" |
+  jq -cs 'map(select(.type == "event_msg" and .payload.type == "token_count") | {total: .payload.info.last_token_usage.total_tokens, window: .payload.info.model_context_window}) | last | . + {percent: (.total * 100 / .window)}'
+```
+
+No lag was observed. The ordinary hook invocation took `real 0.03s`; it emitted
+one 58-character line, within the 240-character limit:
+
+```text
+[context] green 22.8% used, 199601 tokens remain, window 1
+```
+
+## Read-only and wiring checks
+
+Using an isolated `$HOME` and `PYTHONDONTWRITEBYTECODE=1`, I hashed every repo
+file and every fixture-home file immediately before and after a `--json` status
+read. Both comparisons were identical: `repo_files_unchanged=yes` and
+`home_files_unchanged=yes`.
+
+Both generated adapters invoke the meter at `UserPromptSubmit`:
+
+- Codex: `hooks.json:112-120`, command at `hooks.json:118`.
+- Claude: `hooks/hooks.json:124-132`, command at `hooks/hooks.json:130`.
+- Canonical ownership is `scripts/generate-adapters.py:60`; generation synchronization
+  was green, so neither generated file is a hand-maintained exception.
+
+## Code and diff review
+
+No blocking findings.
+
+- Exact suffix selection and ambiguity refusal: `hooks/scripts/context-usage.py:69-100`.
+- Metadata identity validation before event use: `hooks/scripts/context-usage.py:103-113`.
+- Numeric allowlist and type validation: `hooks/scripts/context-usage.py:116-144`.
+- Byte prefilter before decoding token records: `hooks/scripts/context-usage.py:154-181`.
+- Exact 50/60/70 boundaries: `hooks/scripts/context-usage.py:194-205`.
+- Bounded single-line renderer and allowlisted JSON only: `hooks/scripts/context-usage.py:223-262`.
+
+The implementation diff adds only Python standard-library imports. Targeted diff
+scans found no hardcoded user path, private transcript value, network/dependency
+addition, or prompt-field parsing. `git diff --check` was clean.
+
+## Scope receipt
+
+Only this report was written in the repository. The three intentional changes were
+limited to the disposable fixture copy and were discarded after verification.

--- a/_meta/reports/context-usage-meter-implementation.md
+++ b/_meta/reports/context-usage-meter-implementation.md
@@ -1,0 +1,91 @@
+---
+type: implementation-receipt
+status: complete
+created: 2026-08-06
+contract: CR-20260805235233-29894-26025
+---
+
+# Context usage meter implementation
+
+## Outcome
+
+Implemented the read-only, Python-stdlib Codex context meter and generated both host hook
+adapters. The separately authored Terra contract was not changed.
+
+- requested_model: `gpt-5.6-sol`
+- requested_effort: `high`
+- observed_model: `unavailable`
+- observed_effort: `unavailable`
+
+## Files
+
+- `hooks/scripts/context-usage.py` (new, executable)
+- `scripts/generate-adapters.py`
+- `hooks.json` (generated)
+- `hooks/hooks.json` (generated)
+- `_meta/reports/context-usage-meter-implementation.md` (this receipt)
+
+`tests/kernel9/test_context_usage.py` remained read-only and unmodified by this lane.
+
+## Privacy boundary
+
+The meter selects only an exact `$CODEX_THREAD_ID` filename suffix, validates line-one
+`session_meta.payload.id`, and byte-prefilters structural compaction/token records before JSON
+decode. Content-bearing response, prompt, tool, message, reasoning, and replacement-history
+records are neither deserialized nor emitted. Output is the frozen allowlisted schema or one
+bounded hook line. Reads create or modify no status files. Expected missing, ambiguous,
+mismatched, unreadable, stale, and truncated states exit zero without stderr.
+
+## Evidence
+
+Initial red reproduction:
+
+```text
+$ python3 -m unittest tests.kernel9.test_context_usage
+Ran 23 tests in 0.015s
+FAILED (failures=24)
+```
+
+After the parser and canonical binding, before regeneration, only generated wiring remained red:
+
+```text
+$ python3 -m unittest tests.kernel9.test_context_usage
+Ran 23 tests in 0.716s
+FAILED (failures=2)
+```
+
+Generation:
+
+```text
+$ python3 scripts/generate-adapters.py
+wrote hooks.json
+wrote hooks/hooks.json
+```
+
+Final gates:
+
+```text
+$ python3 -m unittest tests.kernel9.test_context_usage
+Ran 23 tests in 0.813s
+OK
+
+$ /usr/bin/python3 -m unittest tests.kernel9.test_context_usage
+Ran 23 tests in 1.932s
+OK
+
+$ python3 scripts/generate-adapters.py --check
+all 7 generated adapters are in sync
+
+$ python3 -m unittest tests.kernel9.test_adapters tests.kernel9.test_activation
+Ran 42 tests in 3.066s
+OK
+
+$ git diff --check
+(no output; exit 0)
+
+$ /usr/bin/stat -f '%Sp %N' hooks/scripts/context-usage.py
+-rwxr-xr-x hooks/scripts/context-usage.py
+```
+
+No dependency, test change, network access, plugin-cache patch, Git mutation, release, install,
+credential access, transcript persistence, or external mutation was used.

--- a/_meta/reviews/context-usage-meter-teardown.md
+++ b/_meta/reviews/context-usage-meter-teardown.md
@@ -1,0 +1,50 @@
+---
+type: review
+status: active
+created: 2026-08-06
+updated: 2026-08-06
+contract: CR-20260805235233-29894-26025
+---
+
+# Tear Down: context usage meter
+
+reviewed: 2026-08-06
+tier: 2
+scope: 5 implementation/test surfaces plus generated adapters
+
+## Big 5
+
+- input_validation: revise until thread-id and line-1 metadata mismatch fixtures exist
+- edge_cases: revise until stale, truncated, rotation, transitional-record and threshold fixtures exist
+- error_handling: pass if every ambiguity returns `stale` or `unknown`, never green
+- duplication: pass only with one parser and thin hook wiring
+- complexity: pass if the parser is stdlib-only and the hook remains a separate bounded command
+
+## Security
+
+- No credential is needed or permitted.
+- The parser may select only by validated `$CODEX_THREAD_ID`.
+- Output is an allowlisted numeric/status object. Prompts, replacement history, messages, tool
+  results and reasoning are forbidden in stdout, stderr, fixtures, or persisted state.
+- The secret-canary fixture must fail before implementation and pass afterward.
+
+## Verdict: REVISE, then proceed
+
+The architecture is sound, but implementing before a separately authored red suite would repeat
+the exact self-affirming-checker failure this feature exists to prevent. Aria already directed us
+to proceed with that fix, so the next action is the red test lane, not another approval question.
+
+## Action items
+
+1. Terra writes only `tests/kernel9/test_context_usage.py` and proves it red.
+2. Sol implements the minimum parser and hook wiring without changing test intent.
+3. A fresh verifier corrupts selection and one threshold in isolated copies and proves red.
+4. Run the full KERNEL suite, generate adapters, then prove the installed release in a fresh nested
+   Codex task. Do not patch the installed cache.
+
+## Protocol defect discovered
+
+KERNEL 9.0.0's `tearitapart` skill requires `quality`, `testing`, and `security` skills plus a
+quality research file that are absent from the installed package. This review applies the rubric
+embedded in `tearitapart/SKILL.md`; the missing dependency references require a separate upstream
+packaging repair and are not silently treated as loaded.

--- a/hooks.json
+++ b/hooks.json
@@ -115,6 +115,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/context-usage.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${PLUGIN_ROOT}/hooks/scripts/route-request.sh",
             "timeout": 5
           },

--- a/hooks/gates.json
+++ b/hooks/gates.json
@@ -14,6 +14,20 @@
   },
   "hooks": [
     {
+      "id": "auto-approve-safe",
+      "script": "hooks/scripts/auto-approve-safe.sh",
+      "class": "gate",
+      "events": [
+        "PermissionRequest"
+      ],
+      "matcher": "Bash",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-abstain",
+      "rationale": "Auto-approves demonstrably safe commands. Its dangerous direction is YES, so when it cannot evaluate it emits no decision and the human is asked."
+    },
+    {
       "id": "autopush",
       "script": "hooks/scripts/autopush.sh",
       "class": "advisory",
@@ -38,6 +52,120 @@
         "jq"
       ],
       "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "chronicle-gate",
+      "script": "hooks/scripts/chronicle-gate.sh",
+      "class": "gate",
+      "events": [
+        "Stop"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "git"
+      ],
+      "degraded_mode": "fail-open-loud",
+      "rationale": "Requires an honest account from a session that changed source. Refuses once and names an escape hatch, because a gate you cannot satisfy is worse than none: people disable the whole chain. Without git it cannot tell whether source changed, and blocking the end of a session on that would trap it."
+    },
+    {
+      "id": "circuit-breaker",
+      "script": "hooks/scripts/circuit-breaker.sh",
+      "class": "library",
+      "events": [],
+      "external_deps": [
+        "python3"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "common",
+      "script": "hooks/scripts/common.sh",
+      "class": "library",
+      "events": [],
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "context-usage",
+      "script": "hooks/scripts/context-usage.py",
+      "class": "advisory",
+      "events": [
+        "UserPromptSubmit"
+      ],
+      "matcher": "",
+      "external_deps": [
+        "python3"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "detect-secrets",
+      "script": "hooks/scripts/detect-secrets.sh",
+      "class": "gate",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-closed",
+      "rationale": "Secret scanner. Deliberately does not source circuit-breaker.sh: a security gate must never auto-disable itself."
+    },
+    {
+      "id": "github-integration",
+      "script": "hooks/scripts/github-integration.sh",
+      "class": "library",
+      "events": [],
+      "external_deps": [
+        "gh"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "guard-bash",
+      "script": "hooks/scripts/guard-bash.sh",
+      "class": "gate",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Bash",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-closed",
+      "rationale": "Destructive-command guard. Fails closed: without a parser it cannot tell a listing from a recursive delete. Escape hatch KERNEL_GUARD_BASH_DEGRADED_OK=1 is explicit and logged."
+    },
+    {
+      "id": "guard-config",
+      "script": "hooks/scripts/guard-config.sh",
+      "class": "gate",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq"
+      ],
+      "degraded_mode": "fail-open-loud",
+      "rationale": "Narrow guard over .claude/ config writes. Refusing every write when jq is absent would halt all work for a narrow risk, so it warns loudly and allows."
+    },
+    {
+      "id": "guard-context",
+      "script": "hooks/scripts/guard-context.sh",
+      "class": "gate",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Read|Grep|Glob",
+      "external_deps": [
+        "jq",
+        "python3"
+      ],
+      "degraded_mode": "fail-closed-when-armed",
+      "rationale": "Enforces an activated manifest's context policy. With no manifest active it is inert by design; once a manifest is active and the pointer cannot be read, it blocks -- a sealed experiment must never silently degrade to unsealed."
     },
     {
       "id": "knowledge-graph",
@@ -106,6 +234,28 @@
       "degraded_mode": "fail-open-loud"
     },
     {
+      "id": "scan-output",
+      "script": "hooks/scripts/scan-output.sh",
+      "class": "gate",
+      "events": [
+        "PostToolUse"
+      ],
+      "matcher": "WebFetch|WebSearch|mcp__.*",
+      "external_deps": [
+        "python3"
+      ],
+      "degraded_mode": "fail-open-loud",
+      "rationale": "Prompt-injection tripwire over fetched content. Post-hoc, so refusing protects nothing; it must degrade loudly instead of silently."
+    },
+    {
+      "id": "scan-output-impl",
+      "script": "hooks/scripts/scan-output.py",
+      "class": "library",
+      "events": [],
+      "external_deps": [],
+      "degraded_mode": "not-applicable"
+    },
+    {
       "id": "session-end",
       "script": "hooks/scripts/session-end.sh",
       "class": "advisory",
@@ -130,6 +280,16 @@
       "external_deps": [
         "git",
         "jq"
+      ],
+      "degraded_mode": "fail-open-loud"
+    },
+    {
+      "id": "test-gate",
+      "script": "hooks/scripts/test-gate.sh",
+      "class": "library",
+      "events": [],
+      "external_deps": [
+        "git"
       ],
       "degraded_mode": "fail-open-loud"
     },
@@ -169,153 +329,6 @@
       "matcher": "Write|Edit",
       "external_deps": [
         "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "auto-approve-safe",
-      "script": "hooks/scripts/auto-approve-safe.sh",
-      "class": "gate",
-      "events": [
-        "PermissionRequest"
-      ],
-      "matcher": "Bash",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-abstain",
-      "rationale": "Auto-approves demonstrably safe commands. Its dangerous direction is YES, so when it cannot evaluate it emits no decision and the human is asked."
-    },
-    {
-      "id": "chronicle-gate",
-      "script": "hooks/scripts/chronicle-gate.sh",
-      "class": "gate",
-      "events": [
-        "Stop"
-      ],
-      "matcher": "",
-      "external_deps": [
-        "git"
-      ],
-      "degraded_mode": "fail-open-loud",
-      "rationale": "Requires an honest account from a session that changed source. Refuses once and names an escape hatch, because a gate you cannot satisfy is worse than none: people disable the whole chain. Without git it cannot tell whether source changed, and blocking the end of a session on that would trap it."
-    },
-    {
-      "id": "detect-secrets",
-      "script": "hooks/scripts/detect-secrets.sh",
-      "class": "gate",
-      "events": [
-        "PreToolUse"
-      ],
-      "matcher": "Write|Edit",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-closed",
-      "rationale": "Secret scanner. Deliberately does not source circuit-breaker.sh: a security gate must never auto-disable itself."
-    },
-    {
-      "id": "guard-bash",
-      "script": "hooks/scripts/guard-bash.sh",
-      "class": "gate",
-      "events": [
-        "PreToolUse"
-      ],
-      "matcher": "Bash",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-closed",
-      "rationale": "Destructive-command guard. Fails closed: without a parser it cannot tell a listing from a recursive delete. Escape hatch KERNEL_GUARD_BASH_DEGRADED_OK=1 is explicit and logged."
-    },
-    {
-      "id": "guard-config",
-      "script": "hooks/scripts/guard-config.sh",
-      "class": "gate",
-      "events": [
-        "PreToolUse"
-      ],
-      "matcher": "Write|Edit",
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud",
-      "rationale": "Narrow guard over .claude/ config writes. Refusing every write when jq is absent would halt all work for a narrow risk, so it warns loudly and allows."
-    },
-    {
-      "id": "guard-context",
-      "script": "hooks/scripts/guard-context.sh",
-      "class": "gate",
-      "events": [
-        "PreToolUse"
-      ],
-      "matcher": "Read|Grep|Glob",
-      "external_deps": [
-        "jq",
-        "python3"
-      ],
-      "degraded_mode": "fail-closed-when-armed",
-      "rationale": "Enforces an activated manifest's context policy. With no manifest active it is inert by design; once a manifest is active and the pointer cannot be read, it blocks -- a sealed experiment must never silently degrade to unsealed."
-    },
-    {
-      "id": "scan-output",
-      "script": "hooks/scripts/scan-output.sh",
-      "class": "gate",
-      "events": [
-        "PostToolUse"
-      ],
-      "matcher": "WebFetch|WebSearch|mcp__.*",
-      "external_deps": [
-        "python3"
-      ],
-      "degraded_mode": "fail-open-loud",
-      "rationale": "Prompt-injection tripwire over fetched content. Post-hoc, so refusing protects nothing; it must degrade loudly instead of silently."
-    },
-    {
-      "id": "circuit-breaker",
-      "script": "hooks/scripts/circuit-breaker.sh",
-      "class": "library",
-      "events": [],
-      "external_deps": [
-        "python3"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "common",
-      "script": "hooks/scripts/common.sh",
-      "class": "library",
-      "events": [],
-      "external_deps": [
-        "jq"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "github-integration",
-      "script": "hooks/scripts/github-integration.sh",
-      "class": "library",
-      "events": [],
-      "external_deps": [
-        "gh"
-      ],
-      "degraded_mode": "fail-open-loud"
-    },
-    {
-      "id": "scan-output-impl",
-      "script": "hooks/scripts/scan-output.py",
-      "class": "library",
-      "events": [],
-      "external_deps": [],
-      "degraded_mode": "not-applicable"
-    },
-    {
-      "id": "test-gate",
-      "script": "hooks/scripts/test-gate.sh",
-      "class": "library",
-      "events": [],
-      "external_deps": [
-        "git"
       ],
       "degraded_mode": "fail-open-loud"
     }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -127,6 +127,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/context-usage.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/route-request.sh",
             "timeout": 5
           },

--- a/hooks/scripts/context-usage.py
+++ b/hooks/scripts/context-usage.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Report last-known Codex context occupancy without exposing rollout content."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+from typing import Any, Dict, Optional, Tuple
+
+
+STALE_AFTER_SECONDS = 300
+THREAD_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+# Codex reorders and adds top-level envelope fields between releases: 0.147.0
+# introduced "ordinal" between "timestamp" and "type", which a timestamp-only
+# prefix does not span. The meter then matched no event and reported "unknown"
+# on every live session while the suite stayed green on pre-0.147.0 fixtures.
+#
+# So skip ANY run of leading SCALAR fields. Scalars only, deliberately: prompts,
+# messages, tool results and reasoning all live in nested objects and arrays,
+# which this cannot cross. The envelope stays walkable, content stays unreachable.
+JSON_SCALAR = (
+    rb'(?:"(?:[^"\\]|\\.)*"'          # string
+    rb'|-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?'  # number
+    rb'|true|false|null)'
+)
+TIMESTAMP_PREFIX = (
+    rb'(?:"(?:[^"\\]|\\.)*"\s*:\s*' + JSON_SCALAR + rb'\s*,\s*)*'
+)
+TOP_LEVEL_COMPACTED = re.compile(
+    rb'^\s*\{\s*' + TIMESTAMP_PREFIX + rb'"type"\s*:\s*"compacted"\s*[,}]'
+)
+EVENT_MSG = re.compile(
+    rb'^\s*\{\s*' + TIMESTAMP_PREFIX + rb'"type"\s*:\s*"event_msg"\s*[,}]'
+)
+TOKEN_COUNT = re.compile(
+    rb'"payload"\s*:\s*\{\s*"type"\s*:\s*"token_count"\s*[,}]'
+)
+CONTEXT_COMPACTED = re.compile(
+    rb'"payload"\s*:\s*\{\s*"type"\s*:\s*"context_compacted"\s*[,}]'
+)
+LAST_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+)
+
+
+def empty_status(thread_id: Optional[str], state: str = "unknown") -> Dict[str, Any]:
+    return {
+        "thread_id": thread_id,
+        "rollout": None,
+        "observed_at": None,
+        "event_age_seconds": None,
+        "window_number": None,
+        "last": {field: None for field in LAST_FIELDS},
+        "context_window": None,
+        "used_percent": None,
+        "remaining_tokens": None,
+        "cumulative_total_tokens": None,
+        "state": state,
+    }
+
+
+def parse_time(value: str) -> dt.datetime:
+    parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def valid_count(value: Any, positive: bool = False) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= (1 if positive else 0)
+    )
+
+
+def candidate(root: str, thread_id: str) -> Tuple[Optional[str], bool]:
+    """Return the sole exact-name candidate and whether traversal failed."""
+    suffix = "-%s.jsonl" % thread_id
+    matches = []
+    walk_failed = [False]
+
+    def record_error(_error: OSError) -> None:
+        walk_failed[0] = True
+
+    try:
+        for directory, _, names in os.walk(root, onerror=record_error):
+            for name in names:
+                if name.endswith(suffix):
+                    matches.append(os.path.join(directory, name))
+    except OSError:
+        return None, True
+    if walk_failed[0]:
+        return None, True
+    if len(matches) != 1:
+        return None, bool(matches)
+    return matches[0], False
+
+
+def resolve_rollout(sessions_root: str, archives_root: str, thread_id: str) -> Optional[str]:
+    found = []
+    for root in (sessions_root, archives_root):
+        path, failed = candidate(root, thread_id)
+        if failed:
+            return None
+        if path is not None:
+            found.append(path)
+    return found[0] if len(found) == 1 else None
+
+
+def load_metadata(line: bytes, thread_id: str) -> bool:
+    try:
+        record = json.loads(line.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return (
+        isinstance(record, dict)
+        and record.get("type") == "session_meta"
+        and isinstance(record.get("payload"), dict)
+        and record["payload"].get("id") == thread_id
+    )
+
+
+def token_usage(record: Any) -> Optional[Tuple[str, Dict[str, int], int, int]]:
+    """Validate a token-count event before returning allowlisted numeric fields."""
+    if not isinstance(record, dict) or record.get("type") != "event_msg":
+        return None
+    payload = record.get("payload")
+    if not isinstance(payload, dict) or payload.get("type") != "token_count":
+        return None
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        return None
+    last = info.get("last_token_usage")
+    cumulative = info.get("total_token_usage")
+    window = info.get("model_context_window")
+    timestamp = record.get("timestamp")
+    if (
+        not isinstance(last, dict)
+        or not isinstance(cumulative, dict)
+        or not isinstance(timestamp, str)
+        or not valid_count(window, positive=True)
+        or not valid_count(cumulative.get("total_tokens"))
+        or any(not valid_count(last.get(field)) for field in LAST_FIELDS)
+    ):
+        return None
+    try:
+        parse_time(timestamp)
+    except (TypeError, ValueError):
+        return None
+    safe_last = {field: last[field] for field in LAST_FIELDS}
+    return timestamp, safe_last, window, cumulative["total_tokens"]
+
+
+def read_status(path: str, thread_id: str, now: dt.datetime) -> Dict[str, Any]:
+    status = empty_status(thread_id)
+    status["rollout"] = os.path.basename(path)
+    last_usage = None
+    window_number = 1
+    degraded = False
+
+    try:
+        with open(path, "rb") as rollout:
+            if not load_metadata(rollout.readline(), thread_id):
+                return empty_status(thread_id)
+            for line in rollout:
+                if not line.endswith(b"\n"):
+                    degraded = True
+                    continue
+                if TOP_LEVEL_COMPACTED.match(line):
+                    window_number += 1
+                    continue
+                if not EVENT_MSG.match(line):
+                    continue
+                if CONTEXT_COMPACTED.search(line):
+                    window_number += 1
+                    continue
+                if not TOKEN_COUNT.search(line):
+                    continue
+                try:
+                    record = json.loads(line.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    degraded = True
+                    continue
+                usage = token_usage(record)
+                if usage is None:
+                    degraded = True
+                    continue
+                last_usage = usage
+    except OSError:
+        return empty_status(thread_id)
+
+    if last_usage is None:
+        return empty_status(thread_id, "stale" if degraded else "unknown")
+
+    observed_at, last, context_window, cumulative = last_usage
+    try:
+        age = int((now - parse_time(observed_at)).total_seconds())
+    except (TypeError, ValueError, OverflowError):
+        return empty_status(thread_id, "stale")
+
+    total = last["total_tokens"]
+    used_percent = total * 100 / context_window
+    if used_percent < 50:
+        state = "green"
+    elif used_percent < 60:
+        state = "checkpoint"
+    elif used_percent < 70:
+        state = "compact_at_boundary"
+    else:
+        state = "emergency"
+    if degraded or age < 0 or age > STALE_AFTER_SECONDS:
+        state = "stale"
+
+    status.update(
+        {
+            "observed_at": observed_at,
+            "event_age_seconds": age,
+            "window_number": window_number,
+            "last": last,
+            "context_window": context_window,
+            "used_percent": used_percent,
+            "remaining_tokens": max(context_window - total, 0),
+            "cumulative_total_tokens": cumulative,
+            "state": state,
+        }
+    )
+    return status
+
+
+def render_hook(status: Dict[str, Any]) -> str:
+    if status["used_percent"] is None:
+        return "[context] %s" % status["state"]
+    line = "[context] %s %.1f%% used, %d tokens remain, window %d" % (
+        status["state"],
+        status["used_percent"],
+        status["remaining_tokens"],
+        status["window_number"],
+    )
+    return line if len(line) <= 240 else "[context] %s" % status["state"]
+
+
+def main() -> int:
+    home = os.path.expanduser("~")
+    parser = argparse.ArgumentParser(description="Read Codex context occupancy metadata.")
+    parser.add_argument("--json", action="store_true", help="emit allowlisted JSON")
+    parser.add_argument("--sessions-root", default=os.path.join(home, ".codex", "sessions"))
+    parser.add_argument(
+        "--archives-root", default=os.path.join(home, ".codex", "archived_sessions")
+    )
+    parser.add_argument("--now", help="UTC ISO-8601 time used for freshness checks")
+    args = parser.parse_args()
+
+    thread_id = os.environ.get("CODEX_THREAD_ID")
+    status = empty_status(thread_id)
+    if thread_id and THREAD_ID.fullmatch(thread_id):
+        path = resolve_rollout(args.sessions_root, args.archives_root, thread_id)
+        if path is not None:
+            try:
+                now = parse_time(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
+            except (TypeError, ValueError):
+                now = dt.datetime.now(dt.timezone.utc)
+                status = empty_status(thread_id, "stale")
+            else:
+                status = read_status(path, thread_id, now)
+
+    if args.json:
+        print(json.dumps(status, separators=(",", ":"), sort_keys=True))
+    else:
+        print(render_hook(status))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -57,6 +57,7 @@ HOOK_BINDINGS = [
     {"event": "PostToolUse", "matcher": "Write|Edit", "script": "log-write.sh", "timeout": 5},
     {"event": "PostToolUse", "matcher": "Write|Edit", "script": "validate-json-schema.sh", "timeout": 5},
     {"event": "PostToolUseFailure", "matcher": "Edit|Write|Bash", "script": "capture-error.sh", "timeout": 5},
+    {"event": "UserPromptSubmit", "matcher": "", "script": "context-usage.py", "timeout": 5},
     {"event": "UserPromptSubmit", "matcher": "", "script": "route-request.sh", "timeout": 5},
     {"event": "UserPromptSubmit", "matcher": "", "script": "post-compact-restore.sh", "timeout": 5},
     {"event": "Stop", "matcher": "", "script": "chronicle-gate.sh", "timeout": 15},

--- a/tests/kernel9/test_context_usage.py
+++ b/tests/kernel9/test_context_usage.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Black-box contract for the read-only Codex context-usage hook.
+
+The rollout is private transcript data.  These fixtures therefore contain only the
+small structural envelope the meter is allowed to use, plus a deliberately toxic
+canary in content-bearing fields.  The command must select its rollout from
+``CODEX_THREAD_ID`` and validate line one before it treats any token event as data.
+
+The public command shape is intentionally fixed here before implementation:
+
+    hooks/scripts/context-usage.py --json --sessions-root DIR --archives-root DIR --now ISO8601
+
+There is no current public meter interface to preserve.  If one appears before this
+suite is implemented, its incompatibility must be resolved explicitly rather than
+silently changing these fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPT = os.path.join(REPO, "hooks", "scripts", "context-usage.py")
+GENERATOR = os.path.join(REPO, "scripts", "generate-adapters.py")
+HOOK_FILES = ("hooks.json", os.path.join("hooks", "hooks.json"))
+NOW = "2026-08-06T12:00:00Z"
+CANARY = "context-meter-canary-NOT-A-REAL-SECRET-7f3a9c"
+
+JSON_KEYS = {
+    "thread_id",
+    "rollout",
+    "observed_at",
+    "event_age_seconds",
+    "window_number",
+    "last",
+    "context_window",
+    "used_percent",
+    "remaining_tokens",
+    "cumulative_total_tokens",
+    "state",
+}
+LAST_KEYS = {
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+}
+
+
+def token_event(
+    at,
+    total,
+    window=1000,
+    input_tokens=None,
+    cached_input_tokens=0,
+    output_tokens=0,
+    reasoning_output_tokens=0,
+    cumulative_total=None,
+):
+    """Return the smallest safe token_count record.
+
+    ``total_tokens`` is authoritative, including immediately after compaction when
+    all components may be zero.  Cached input and reasoning output are subsets.
+    """
+    if input_tokens is None:
+        input_tokens = total - output_tokens
+    if cumulative_total is None:
+        cumulative_total = total
+    return {
+        "type": "event_msg",
+        "timestamp": at,
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": input_tokens,
+                    "cached_input_tokens": cached_input_tokens,
+                    "output_tokens": output_tokens,
+                    "reasoning_output_tokens": reasoning_output_tokens,
+                    "total_tokens": total,
+                },
+                "total_token_usage": {"total_tokens": cumulative_total},
+                "model_context_window": window,
+            },
+        },
+    }
+
+
+def compacted(at, replacement_history=CANARY):
+    """A content-bearing compaction record, which must never be emitted."""
+    return {
+        "type": "compacted",
+        "timestamp": at,
+        "payload": {"replacement_history": replacement_history},
+    }
+
+
+class MeterHarness:
+    def __init__(self, case, root):
+        self.case = case
+        self.root = root
+        self.sessions = os.path.join(root, "sessions")
+        self.archives = os.path.join(root, "archived_sessions")
+        os.mkdir(self.sessions)
+        os.mkdir(self.archives)
+
+    def write_rollout(self, directory, thread_id, records, metadata_id=None, name=None):
+        if metadata_id is None:
+            metadata_id = thread_id
+        if name is None:
+            name = "rollout-fixture-%s.jsonl" % thread_id
+        path = os.path.join(directory, name)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"type": "session_meta", "payload": {"id": metadata_id}}))
+            fh.write("\n")
+            for record in records:
+                fh.write(json.dumps(record, separators=(",", ":")))
+                fh.write("\n")
+        return path
+
+    def append_truncated_line(self, path):
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write('{"type":"event_msg","payload":{"type":"token_count"')
+
+    def run(self, thread_id, json_mode=True, now=NOW):
+        self.case.assertTrue(
+            os.path.isfile(SCRIPT),
+            "context-usage implementation is absent: %s" % SCRIPT,
+        )
+        env = dict(os.environ)
+        env.pop("CODEX_THREAD_ID", None)
+        if thread_id is not None:
+            env["CODEX_THREAD_ID"] = thread_id
+        # A broken implementation must not fall back to a developer's real rollout
+        # when the test deliberately supplies both fixture roots.
+        env["HOME"] = self.root
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        command = [
+            sys.executable,
+            SCRIPT,
+            "--sessions-root", self.sessions,
+            "--archives-root", self.archives,
+            "--now", now,
+        ]
+        if json_mode:
+            command.insert(2, "--json")
+        proc = subprocess.run(
+            command,
+            cwd=REPO,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.case.assertEqual(
+            proc.returncode,
+            0,
+            "meter failed\nstdout:\n%s\nstderr:\n%s" % (proc.stdout, proc.stderr),
+        )
+        return proc
+
+    @staticmethod
+    def snapshot(root):
+        found = {}
+        for directory, _, names in os.walk(root):
+            for name in names:
+                path = os.path.join(directory, name)
+                with open(path, "rb") as fh:
+                    found[os.path.relpath(path, root)] = fh.read()
+        return found
+
+
+class ContextUsageContract(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="kernel9-context-usage-")
+        self.addCleanup(self.temp.cleanup)
+        self.h = MeterHarness(self, self.temp.name)
+
+    def json_status(self, thread_id="thread-a", now=NOW):
+        proc = self.h.run(thread_id, json_mode=True, now=now)
+        self.assertEqual(proc.stderr, "", "diagnostic mode must not leak transcript data")
+        try:
+            doc = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail("--json did not emit exactly one JSON object: %s\n%s" % (exc, proc.stdout))
+        self.assertEqual(set(doc), JSON_KEYS, "JSON output must remain allowlisted")
+        self.assertEqual(set(doc["last"]), LAST_KEYS, "last-token output must remain allowlisted")
+        return doc, proc
+
+    def write_fresh(self, thread_id="thread-a", total=499, window=1000, **kwargs):
+        return self.h.write_rollout(
+            self.h.sessions,
+            thread_id,
+            [token_event("2026-08-06T11:59:59Z", total, window, **kwargs)],
+        )
+
+    def test_command_exists_at_the_documented_hook_path(self):
+        self.assertTrue(os.path.isfile(SCRIPT), "missing standalone stdlib meter")
+
+    def test_competing_newer_rollout_cannot_steal_thread_selection(self):
+        self.write_fresh("thread-a", total=499)
+        newer = self.write_fresh("thread-b", total=700)
+        os.utime(newer, (2_000_000_000, 2_000_000_000))
+        doc, _ = self.json_status("thread-a")
+        self.assertEqual(doc["thread_id"], "thread-a")
+        self.assertEqual(doc["last"]["total_tokens"], 499)
+        self.assertEqual(doc["state"], "green")
+
+    def test_filename_match_with_metadata_mismatch_is_unknown(self):
+        self.h.write_rollout(
+            self.h.sessions,
+            "thread-a",
+            [token_event("2026-08-06T11:59:59Z", 499)],
+            metadata_id="a-different-thread",
+        )
+        doc, _ = self.json_status("thread-a")
+        self.assertEqual(doc["state"], "unknown")
+        self.assertEqual(doc["thread_id"], "thread-a")
+
+    def test_missing_thread_id_is_unknown(self):
+        self.write_fresh()
+        doc, _ = self.json_status(thread_id=None)
+        self.assertEqual(doc["state"], "unknown")
+        self.assertIsNone(doc["thread_id"])
+
+    def test_old_last_event_is_stale_not_green(self):
+        self.h.write_rollout(
+            self.h.sessions,
+            "thread-a",
+            [token_event("2026-08-01T12:00:00Z", 100)],
+        )
+        doc, _ = self.json_status(now=NOW)
+        self.assertEqual(doc["state"], "stale")
+        self.assertEqual(doc["event_age_seconds"], 432000)
+
+    def test_truncated_final_jsonl_uses_previous_event_and_marks_stale(self):
+        path = self.write_fresh(total=499)
+        self.h.append_truncated_line(path)
+        doc, _ = self.json_status()
+        self.assertEqual(doc["last"]["total_tokens"], 499)
+        self.assertEqual(doc["state"], "stale")
+
+    def test_archive_only_rollout_is_resolved(self):
+        self.h.write_rollout(
+            self.h.archives,
+            "thread-a",
+            [token_event("2026-08-06T11:59:59Z", 499)],
+        )
+        doc, _ = self.json_status()
+        self.assertEqual(doc["state"], "green")
+        self.assertEqual(doc["last"]["total_tokens"], 499)
+
+    def test_archive_rotation_between_reads_preserves_status(self):
+        path = self.write_fresh(total=499)
+        first, _ = self.json_status()
+        rotated = os.path.join(self.h.archives, os.path.basename(path))
+        os.rename(path, rotated)
+        second, _ = self.json_status()
+        self.assertEqual(first["state"], "green")
+        self.assertEqual(second["state"], "green")
+        self.assertEqual(second["last"]["total_tokens"], 499)
+
+    def test_active_and_cumulative_totals_are_separate(self):
+        self.write_fresh(total=25000, window=100000, cumulative_total=15000000)
+        doc, _ = self.json_status()
+        self.assertEqual(doc["last"]["total_tokens"], 25000)
+        self.assertEqual(doc["cumulative_total_tokens"], 15000000)
+        self.assertEqual(doc["used_percent"], 25.0)
+        self.assertEqual(doc["state"], "green")
+
+    def test_cached_and_reasoning_subsets_are_not_double_counted(self):
+        self.write_fresh(
+            total=105000,
+            window=200000,
+            input_tokens=100000,
+            cached_input_tokens=90000,
+            output_tokens=5000,
+            reasoning_output_tokens=4000,
+        )
+        doc, _ = self.json_status()
+        self.assertEqual(doc["last"]["input_tokens"], 100000)
+        self.assertEqual(doc["last"]["cached_input_tokens"], 90000)
+        self.assertEqual(doc["last"]["output_tokens"], 5000)
+        self.assertEqual(doc["last"]["reasoning_output_tokens"], 4000)
+        self.assertEqual(doc["last"]["total_tokens"], 105000)
+        self.assertEqual(doc["used_percent"], 52.5)
+        self.assertEqual(doc["state"], "checkpoint")
+
+    def test_post_compaction_explicit_total_beats_zero_components(self):
+        self.h.write_rollout(
+            self.h.sessions,
+            "thread-a",
+            [
+                compacted("2026-08-06T11:58:00Z"),
+                token_event(
+                    "2026-08-06T11:59:59Z",
+                    21494,
+                    window=258400,
+                    input_tokens=0,
+                    output_tokens=0,
+                    cumulative_total=8302072,
+                ),
+            ],
+        )
+        doc, _ = self.json_status()
+        self.assertEqual(doc["last"]["total_tokens"], 21494)
+        self.assertEqual(doc["used_percent"], 8.31811145510836)
+        self.assertEqual(doc["cumulative_total_tokens"], 8302072)
+        self.assertEqual(doc["state"], "green")
+
+    def test_latest_compaction_sets_second_context_window(self):
+        self.h.write_rollout(
+            self.h.sessions,
+            "thread-a",
+            [
+                token_event("2026-08-06T11:57:00Z", 900),
+                {"type": "event_msg", "timestamp": "2026-08-06T11:58:00Z", "payload": {"type": "context_compacted"}},
+                token_event("2026-08-06T11:59:59Z", 200),
+            ],
+        )
+        doc, _ = self.json_status()
+        self.assertEqual(doc["window_number"], 2)
+        self.assertEqual(doc["last"]["total_tokens"], 200)
+
+    def assert_threshold(self, total, expected_state, expected_percent):
+        self.write_fresh(total=total)
+        doc, _ = self.json_status()
+        self.assertEqual(doc["used_percent"], expected_percent)
+        self.assertEqual(doc["state"], expected_state)
+
+    def test_threshold_49_9_is_green(self):
+        self.assert_threshold(499, "green", 49.9)
+
+    def test_threshold_50_is_checkpoint(self):
+        self.assert_threshold(500, "checkpoint", 50.0)
+
+    def test_threshold_59_9_is_checkpoint(self):
+        self.assert_threshold(599, "checkpoint", 59.9)
+
+    def test_threshold_60_is_compact_at_boundary(self):
+        self.assert_threshold(600, "compact_at_boundary", 60.0)
+
+    def test_threshold_69_9_is_compact_at_boundary(self):
+        self.assert_threshold(699, "compact_at_boundary", 69.9)
+
+    def test_threshold_70_is_emergency(self):
+        self.assert_threshold(700, "emergency", 70.0)
+
+    def test_hook_output_is_one_bounded_line(self):
+        self.write_fresh(total=499)
+        proc = self.h.run("thread-a", json_mode=False)
+        lines = proc.stdout.splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertLessEqual(len(lines[0]), 240)
+        self.assertIn("green", lines[0])
+        self.assertNotIn(CANARY, proc.stdout)
+        self.assertNotIn(CANARY, proc.stderr)
+
+    def test_content_canary_never_leaks_to_output_or_json(self):
+        self.h.write_rollout(
+            self.h.sessions,
+            "thread-a",
+            [
+                {
+                    "type": "response_item",
+                    "payload": {"prompt": CANARY, "tool_result": CANARY},
+                },
+                compacted("2026-08-06T11:58:00Z", replacement_history=CANARY),
+                token_event("2026-08-06T11:59:59Z", 499),
+            ],
+        )
+        doc, proc = self.json_status()
+        self.assertEqual(doc["state"], "green")
+        self.assertNotIn(CANARY, proc.stdout)
+        self.assertNotIn(CANARY, proc.stderr)
+        self.assertNotIn(CANARY, json.dumps(doc, sort_keys=True))
+
+    def test_status_read_does_not_write_fixture_roots(self):
+        self.write_fresh(total=499)
+        before = self.h.snapshot(self.temp.name)
+        self.json_status()
+        after = self.h.snapshot(self.temp.name)
+        self.assertEqual(after, before, "a status read must not create or modify state")
+
+
+class RealCodexEnvelopeShape(unittest.TestCase):
+    """The envelope Codex actually writes, not the one our fixtures assumed.
+
+    Every other fixture in this file serializes ``{"type": ..., "timestamp": ...}``
+    because that is the order the parser was written to expect. Codex writes
+    ``{"timestamp": ..., "ordinal": ..., "type": ...}``, and 0.147.0 added that
+    ``ordinal`` field between timestamp and type.
+
+    The line-matching prefix spanned an optional timestamp and nothing else, so
+    on 0.147.0 it matched no event at all and the meter reported "unknown" on
+    every live session. The suite stayed green throughout, because fixtures
+    authored from the parser's expectations can only ever confirm them.
+
+    Caught by running the meter against a real rollout and cross-checking the
+    number with an independent awk/jq pipeline, not by any test that existed.
+    """
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="kernel9-envelope-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = self.temp.name
+        self.meter = MeterHarness(self, self.root)
+
+    def _envelope(self, extra_fields):
+        """A token_count record with real Codex field ordering."""
+        record = {"timestamp": NOW}
+        record.update(extra_fields)
+        record["type"] = "event_msg"
+        record["payload"] = {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": 400,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 100,
+                    "reasoning_output_tokens": 0,
+                    "total_tokens": 500,
+                },
+                "total_token_usage": {"total_tokens": 500},
+                "model_context_window": 1000,
+            },
+        }
+        return record
+
+    def _read(self, thread_id):
+        return json.loads(self.meter.run(thread_id).stdout)
+
+    def test_timestamp_first_ordering_is_parsed(self):
+        self.meter.write_rollout(self.meter.sessions, "t-order", [self._envelope({})])
+        status = self._read("t-order")
+        self.assertEqual(status["last"]["total_tokens"], 500)
+        self.assertEqual(status["context_window"], 1000)
+
+    def test_ordinal_between_timestamp_and_type_is_parsed(self):
+        """The exact 0.147.0 regression."""
+        self.meter.write_rollout(
+            self.meter.sessions, "t-ordinal", [self._envelope({"ordinal": 102})]
+        )
+        status = self._read("t-ordinal")
+        self.assertEqual(
+            status["last"]["total_tokens"], 500,
+            "an added scalar envelope field silently blanked the meter",
+        )
+        self.assertEqual(status["used_percent"], 50.0)
+
+    def test_unknown_future_scalar_envelope_fields_are_parsed(self):
+        """Codex adds envelope fields between releases. Do not re-break on the next one."""
+        self.meter.write_rollout(
+            self.meter.sessions,
+            "t-future",
+            [self._envelope({"ordinal": 7, "seq": 1, "replayed": False, "note": None})],
+        )
+        self.assertEqual(self._read("t-future")["last"]["total_tokens"], 500)
+
+    def test_envelope_walk_still_cannot_cross_a_nested_object(self):
+        """The prefix skips scalars only. Content lives in nested objects.
+
+        If this ever passes with a leading nested object, the meter has gained
+        the ability to walk into exactly the structures it is forbidden to read.
+        """
+        spec = importlib.util.spec_from_file_location("context_usage_module", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        nested = b'{"payload":{"prompt":"' + CANARY.encode() + b'"},"type":"event_msg"}'
+        self.assertIsNone(
+            module.EVENT_MSG.match(nested),
+            "envelope prefix crossed a nested object and can now reach content",
+        )
+
+class ContextUsageWiringContract(unittest.TestCase):
+    def test_both_generated_host_hooks_bind_the_meter(self):
+        expected = "hooks/scripts/context-usage.py"
+        for rel in HOOK_FILES:
+            with self.subTest(hooks_file=rel):
+                with open(os.path.join(REPO, rel), encoding="utf-8") as fh:
+                    doc = json.load(fh)
+                commands = [
+                    hook["command"]
+                    for group in doc["hooks"]["UserPromptSubmit"]
+                    for hook in group["hooks"]
+                ]
+                self.assertTrue(
+                    any(command.endswith(expected) for command in commands),
+                    "%s must wire the standalone context meter" % rel,
+                )
+
+    def test_adapter_generator_declares_the_meter_binding(self):
+        with open(GENERATOR, encoding="utf-8") as fh:
+            source = fh.read()
+        self.assertIn(
+            '"script": "context-usage.py"',
+            source,
+            "generated adapters must own the context-meter binding",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #196.

A finished, independently verified feature had been sitting uncommitted in the working tree. This lands it, with the two completion gaps closed and one defect the fixtures could not see.

## Completion gaps

- `scripts/generate-adapters.py` regains its `context-usage.py` UserPromptSubmit binding, so both generated adapters actually bind the meter.
- `hooks/gates.json` registers the hook. That registry is authoritative and fails in both directions on purpose — the violation corpus was correctly refusing a script it had never been told about.

## The defect: "unknown" on every live Codex session

Codex writes its envelope as `{"timestamp", "ordinal", "type", ...}`, and 0.147.0 added that `ordinal` field. The line matcher spanned an optional timestamp and nothing else:

```
timestamp only      EVENT_MSG=True
timestamp+ordinal   EVENT_MSG=False   <- every real 0.147.0 session
```

So it matched no event, and the meter read `unknown` every time.

**Why the suite stayed green:** every fixture serializes `"type"` first, which is the order the parser expects. Fixtures authored from the parser's expectations can only ever confirm them. This was caught by running the meter against a real rollout and cross-checking with an independent `awk`/`jq` pipeline — not by any test that existed.

## The fix, and the boundary it keeps

The prefix now skips any run of leading **scalar** envelope fields. Scalars only, deliberately: prompts, messages, tool results and reasoning live in nested objects and arrays, which the pattern cannot cross. The envelope stays walkable, content stays unreachable. `test_envelope_walk_still_cannot_cross_a_nested_object` asserts that boundary.

## Verified live, not assumed

The meter and an independent `awk`/`jq` pipeline agree to the last digit against a real rollout:

```
meter        40.315402476780186% of 258400, 154225 remaining
independent  40.315402476780186%
```

and it reports `stale` at 301s rather than a fabricated green.

Reverting only the prefix turns the new tests red:

```
FAIL: test_ordinal_between_timestamp_and_type_is_parsed
FAIL: test_unknown_future_scalar_envelope_fields_are_parsed
```

Full suite: 446 passed, 0 failed. Adapters in sync.

## Recorded separately, not fixed here

The teardown found a packaging defect that is not this feature's fault: KERNEL 9.0.0's `tearitapart` skill references `quality`, `testing`, and `security` skills plus a quality research file that are absent from the installed package. Tracked in #196's body; it needs its own cycle.
