### PR TITLE
fix(hooks): survive a repo with no commits

### DIFF
--- a/hooks/scripts/pre-compact-commit.sh
+++ b/hooks/scripts/pre-compact-commit.sh
@@ -112,7 +112,10 @@ if [ -f "$AGENTDB_PATH" ]; then
     ACTIVE_GOAL=$(sqlite3 "$AGENTDB_PATH" "SELECT json_extract(content, '$.goal') FROM context WHERE type='contract' ORDER BY ts DESC LIMIT 1;" 2>/dev/null || echo "")
 
     # Get recent files changed
-    RECENT_FILES=$(cd "$PROJECT_ROOT" && git diff --name-only HEAD~3 2>/dev/null | head -10 | tr '\n' ',' | sed 's/,$//')
+    # A repo with fewer than four commits has no HEAD~3. Under `set -eo
+    # pipefail` that killed the whole PreCompact checkpoint with exit 128,
+    # losing the snapshot precisely when context was about to be discarded.
+    RECENT_FILES=$(cd "$PROJECT_ROOT" && git diff --name-only HEAD~3 2>/dev/null | head -10 | tr '\n' ',' | sed 's/,$//' || true)
 
     # Escape for safe embedding in the write-end JSON arg: a contract goal or
     # filename containing " or \ would otherwise produce malformed JSON and the

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -86,15 +86,21 @@ if git rev-parse --git-dir >/dev/null 2>&1; then
   # Where this session started, so session-end can post a receipt naming exactly
   # what landed against which issue. Without this the receipt call is unreachable.
   _KERNEL_RUNTIME_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}/_meta/.runtime"
+  # `|| true` is load-bearing: a repo with no commits has no HEAD, and under
+  # `set -eo pipefail` this line's failure killed the entire SessionStart hook
+  # with exit 128. A fresh repo got no context injection at all, which is
+  # exactly the session that needs it most.
   mkdir -p "$_KERNEL_RUNTIME_DIR" 2>/dev/null && \
-    git rev-parse HEAD > "$_KERNEL_RUNTIME_DIR/session-start-sha" 2>/dev/null
+    { git rev-parse HEAD > "$_KERNEL_RUNTIME_DIR/session-start-sha" 2>/dev/null || true; }
   CHANGES=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
   if [ "$CHANGES" -gt 0 ]; then
     echo "**Uncommitted:** $CHANGES file(s) on branch $BRANCH"
   fi
   echo ""
   echo "**Recent commits:**"
-  git log --oneline -5 2>/dev/null | sed 's/^/- /'
+  # No commits means no log. Under `set -eo pipefail` the failure propagated
+  # through the pipe and killed the hook, so `|| true` is not cosmetic here.
+  git log --oneline -5 2>/dev/null | sed 's/^/- /' || true
   echo ""
 fi
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -433,6 +433,53 @@ test_agentdb_long_content() {
 
 # === Hook Tests ===
 
+test_lifecycle_hooks_survive_a_repo_with_no_commits() {
+  # A brand-new `git init`ed repo has no HEAD. Every lifecycle hook runs under
+  # `set -eo pipefail`, so ANY unguarded `git rev-parse HEAD`, `git log`, or
+  # `git diff HEAD~N` takes the whole hook down with exit 128 -- silently, since
+  # a failed hook is a warning line, not a stop.
+  #
+  # This bit session-start.sh (twice) and pre-compact-commit.sh. It is a class,
+  # not an instance, so this exercises EVERY hook rather than the three known
+  # call sites. Two repo shapes: no commits at all, and one commit (HEAD exists
+  # but HEAD~3 does not).
+  local fresh shallow rc failures=""
+  fresh=$(mktemp -d) || return 1
+  shallow=$(mktemp -d) || return 1
+
+  git -c init.defaultBranch=main init -q "$fresh"
+  echo scratch > "$fresh/a.txt"
+
+  git -c init.defaultBranch=main init -q "$shallow"
+  echo scratch > "$shallow/a.txt"
+  git -C "$shallow" -c user.email=t@example.invalid -c user.name=t add -A
+  git -C "$shallow" -c user.email=t@example.invalid -c user.name=t commit -qm "only commit"
+
+  local hook name repo
+  for repo in "$fresh" "$shallow"; do
+    for hook in "$PLUGIN_ROOT"/hooks/scripts/*.sh; do
+      name=$(basename "$hook")
+      # common.sh is sourced, never bound to an event.
+      [ "$name" = "common.sh" ] && continue
+      rc=0
+      echo "{\"session_id\":\"empty-repo-probe\",\"cwd\":\"$repo\"}" \
+        | ( cd "$repo" && CLAUDE_PROJECT_DIR="$repo" KERNEL_VAULTS="$repo" \
+            CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$hook" ) >/dev/null 2>&1 || rc=$?
+      # 128 is git's fatal. Anything else (including a deliberate gate refusal)
+      # is this hook's own business; only a git-fatal crash is the defect.
+      if [ "$rc" = "128" ]; then
+        failures="$failures $name(repo=$(basename "$repo"))"
+      fi
+    done
+  done
+
+  rm -rf "$fresh" "$shallow"
+  if [ -n "$failures" ]; then
+    echo "FAIL: hook(s) died with git-fatal 128 on a repo with no/shallow history:$failures"
+    return 1
+  fi
+}
+
 test_session_start_outputs_kernel() {
   local output
   output=$("$PLUGIN_ROOT/hooks/scripts/session-start.sh" 2>&1)
@@ -5114,6 +5161,7 @@ run_test_suite() {
       run_test "long content" test_agentdb_long_content
       ;;
     hooks)
+      run_test "lifecycle hooks survive a repo with no commits" test_lifecycle_hooks_survive_a_repo_with_no_commits
       run_test "session-start outputs KERNEL" test_session_start_outputs_kernel
       run_test "session-start creates agent file" test_session_start_creates_agent_file
       run_test "detect-secrets clean file" test_detect_secrets_clean


### PR DESCRIPTION
Closes #192.

A brand-new `git init`ed repo has no HEAD. Every lifecycle hook runs under `set -eo pipefail`, so an unguarded git read that needs history takes the whole hook down with **exit 128** — silently, because a failed hook is a warning line, not a stop.

## Three call sites, two hooks

| hook | call |
|---|---|
| `session-start.sh` | `git rev-parse HEAD` |
| `session-start.sh` | `git log --oneline -5 \| sed` |
| `pre-compact-commit.sh` | `git diff --name-only HEAD~3 \| head \| tr \| sed` |

`2>/dev/null` hid the message but never the exit status, which is why these looked guarded and were not.

## Where it hurt

A fresh repo's **first** session got no context injection at all — the session that needs orientation most. The PreCompact checkpoint died exactly when context was about to be discarded. The `HEAD~3` case also fires on any repo with fewer than four commits, not only empty ones.

## Before / after

```
                            before      after
session-start.sh            exit=128    exit=0
pre-compact-commit.sh       exit=128    exit=0
session-end.sh              exit=0      exit=0
```

## The test covers the class, not the three call sites

`test_lifecycle_hooks_survive_a_repo_with_no_commits` runs **every** hook script against two repo shapes: no commits at all, and one commit where HEAD exists but `HEAD~3` does not. It fails only on git's fatal 128, so a hook that deliberately refuses something still passes.

Verified by reintroducing one unguarded pipeline:

```
reintroduced the unguarded git log
  lifecycle hooks survive a repo with no commits... FAIL
--- restored ---
  lifecycle hooks survive a repo with no commits... PASS
```

Full suite: 447 passed, 0 failed.
