### PR TITLE
fix(codex): stop declaring a SessionEnd timeout the host overrules

### DIFF
--- a/docs/kernel-9/HOST-CAPABILITIES.md
+++ b/docs/kernel-9/HOST-CAPABILITIES.md
@@ -7,13 +7,21 @@ What each host actually supports. Kernel does not claim parity it does not have.
 | Lifecycle event Kernel binds | Claude Code | Codex |
 |---|---|---|
 | SessionStart | yes | yes |
-| SessionEnd | yes | yes |
+| SessionEnd | yes | yes, capped at 3s |
 | PreToolUse | yes | yes |
 | PostToolUse | yes | yes |
 | PostToolUseFailure | yes | **no** |
 | UserPromptSubmit | yes | yes |
 | PreCompact | yes | yes |
 | PermissionRequest | yes | yes |
+
+## Host-enforced timeout ceilings
+
+### Codex
+
+- **SessionEnd** — capped at 3s. Kernel's binding wants 210s.
+
+codex-cli 0.147.0 hard-clamps SessionEnd hook timeouts and says so on every session start: `clamping SessionEnd hook timeout to 3s in <plugin>/hooks.json`. The clamp string is extracted from the shipped binary and is SessionEnd-specific; no other lifecycle event carries one. A declared timeout above this ceiling is not honoured, it is overruled.
 
 ## Unsupported features, and what degrades
 

--- a/governance/hosts.json
+++ b/governance/hosts.json
@@ -8,6 +8,10 @@
     "It must be backed by the evidence named in verified_by. Adding an event",
     "here without evidence is how a false parity claim gets shipped.",
     "",
+    "hook_timeout_ceilings_seconds is the same kind of claim again: a limit the",
+    "HOST enforces regardless of what Kernel asks for. Binding a timeout above a",
+    "ceiling does not buy time, it buys a truncated hook and a startup warning.",
+    "",
     "plugin_root_var is the same kind of claim: the variable name the HOST",
     "substitutes in a hook command. A name the host does not know expands to",
     "the empty string, so every hook runs an absolute path off / and exits",
@@ -74,6 +78,10 @@
         "Stop",
         "SubagentStop"
       ],
+      "hook_timeout_ceilings_seconds": {
+        "SessionEnd": 3
+      },
+      "hook_timeout_ceiling_evidence": "codex-cli 0.147.0 hard-clamps SessionEnd hook timeouts and says so on every session start: `clamping SessionEnd hook timeout to 3s in <plugin>/hooks.json`. The clamp string is extracted from the shipped binary and is SessionEnd-specific; no other lifecycle event carries one. A declared timeout above this ceiling is not honoured, it is overruled.",
       "unsupported_lifecycle_events": {
         "PostToolUseFailure": "Not implemented by Codex 0.146.0. Exact symbol search over the shipped binary returns zero occurrences, while every lifecycle event Kernel binds on this host returns 17 or more. Kernel's capture-error.sh is therefore not bound on this host, and error capture degrades to what PostToolUse can observe."
       },

--- a/hooks.json
+++ b/hooks.json
@@ -163,7 +163,7 @@
           {
             "type": "command",
             "command": "${PLUGIN_ROOT}/hooks/scripts/session-end.sh",
-            "timeout": 210,
+            "timeout": 3,
             "statusMessage": "Closing session..."
           }
         ]

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -94,13 +94,14 @@ def plugin_root_var(host: dict) -> str:
 # --------------------------------------------------------------------------
 
 
-def build_hooks(host_key: str, host: dict) -> tuple[dict, list[str]]:
-    """Return (hooks document, list of dropped bindings)."""
+def build_hooks(host_key: str, host: dict) -> tuple[dict, list[str], list[tuple]]:
+    """Return (hooks document, dropped bindings, bindings capped by a host ceiling)."""
     supported = set(host["supported_lifecycle_events"])
     root = plugin_root_var(host)
 
     grouped: dict[str, list] = {}
     dropped: list[str] = []
+    capped: list[tuple] = []
 
     for binding in HOOK_BINDINGS:
         event = binding["event"]
@@ -108,10 +109,20 @@ def build_hooks(host_key: str, host: dict) -> tuple[dict, list[str]]:
             dropped.append(f"{event}:{binding['script']}")
             continue
 
+        # Never declare a timeout the host will overrule. Codex hard-clamps
+        # SessionEnd to 3s and warns on every session start; asking for 210
+        # bought a truncated hook and a warning, not time. Emitting the real
+        # ceiling makes the manifest say what will actually happen.
+        ceiling = host.get("hook_timeout_ceilings_seconds", {}).get(event)
+        timeout = binding["timeout"]
+        if ceiling is not None and timeout > ceiling:
+            capped.append((event, binding["script"], timeout, ceiling))
+            timeout = ceiling
+
         entry = {
             "type": "command",
             "command": f"{root}/hooks/scripts/{binding['script']}",
-            "timeout": binding["timeout"],
+            "timeout": timeout,
         }
         if "statusMessage" in binding:
             entry["statusMessage"] = binding["statusMessage"]
@@ -125,7 +136,7 @@ def build_hooks(host_key: str, host: dict) -> tuple[dict, list[str]]:
         else:
             bucket.append({"matcher": binding["matcher"], "hooks": [entry]})
 
-    return {"hooks": grouped}, dropped
+    return {"hooks": grouped}, dropped, capped
 
 
 def build_plugin_manifest(host_key: str, host: dict, spec: dict) -> dict:
@@ -204,10 +215,34 @@ def build_capability_report(spec: dict) -> str:
     for event in wanted:
         row = [event]
         for host in spec["hosts"].values():
-            row.append("yes" if event in host["supported_lifecycle_events"] else "**no**")
+            if event not in host["supported_lifecycle_events"]:
+                row.append("**no**")
+                continue
+            # "Supported" and "supported with a ceiling that truncates our
+            # binding" are different claims. A flat yes hid the second one.
+            ceiling = host.get("hook_timeout_ceilings_seconds", {}).get(event)
+            row.append("yes" if ceiling is None else f"yes, capped at {ceiling}s")
         lines.append("| " + " | ".join(row) + " |")
 
-    lines += ["", "## Unsupported features, and what degrades", ""]
+    lines += ["", "## Host-enforced timeout ceilings", ""]
+    any_ceiling = False
+    for host in spec["hosts"].values():
+        ceilings = host.get("hook_timeout_ceilings_seconds", {})
+        if not ceilings:
+            continue
+        any_ceiling = True
+        lines += [f"### {host['display_name']}", ""]
+        for event, limit in sorted(ceilings.items()):
+            wanted_timeout = max(
+                (b["timeout"] for b in HOOK_BINDINGS if b["event"] == event), default=None
+            )
+            asked = f" Kernel's binding wants {wanted_timeout}s." if wanted_timeout else ""
+            lines.append(f"- **{event}** — capped at {limit}s.{asked}")
+        lines += ["", host.get("hook_timeout_ceiling_evidence", ""), ""]
+    if not any_ceiling:
+        lines += ["No host-enforced ceilings recorded.", ""]
+
+    lines += ["## Unsupported features, and what degrades", ""]
     any_gap = False
     for key, host in spec["hosts"].items():
         gaps = host.get("unsupported_lifecycle_events", {})
@@ -253,7 +288,7 @@ def targets(spec: dict) -> dict[str, str]:
     out: dict[str, str] = {}
 
     for host_key, host in spec["hosts"].items():
-        hooks_doc, _dropped = build_hooks(host_key, host)
+        hooks_doc, _dropped, _capped = build_hooks(host_key, host)
         out[host["hooks_file"]] = json.dumps(hooks_doc, indent=2) + "\n"
         out[host["plugin_manifest"]] = (
             json.dumps(build_plugin_manifest(host_key, host, spec), indent=2) + "\n"

--- a/tests/kernel9/test_adapters.py
+++ b/tests/kernel9/test_adapters.py
@@ -258,6 +258,63 @@ class EveryHostBindsRealScripts(unittest.TestCase):
                         f"{key} {event} binds missing script {rel}",
                     )
 
+class HostEnforcedTimeoutCeilings(unittest.TestCase):
+    """A timeout the host overrules is a claim, not a budget.
+
+    Codex hard-clamps SessionEnd hooks to 3s and says so on every session start:
+    `clamping SessionEnd hook timeout to 3s`. Kernel bound session-end.sh at 210
+    because it runs the project's test suite there. The declared budget was 70x
+    the real one, the gate was killed every time, and both hosts.json and the
+    capability report said a flat "yes" for SessionEnd on Codex.
+
+    hosts.json's own header calls that shape of claim the thing it exists to
+    prevent, so the ceiling now lives there with named evidence, the generator
+    emits the real number, and the report says "yes, capped at 3s".
+    """
+
+    def test_no_binding_declares_a_timeout_above_its_host_ceiling(self):
+        for key, host in spec()["hosts"].items():
+            ceilings = host.get("hook_timeout_ceilings_seconds", {})
+            if not ceilings:
+                continue
+            doc = load(host["hooks_file"])
+            for event, groups in doc["hooks"].items():
+                limit = ceilings.get(event)
+                if limit is None:
+                    continue
+                for group in groups:
+                    for hook in group["hooks"]:
+                        with self.subTest(host=key, event=event):
+                            self.assertLessEqual(
+                                hook["timeout"], limit,
+                                f"{key} {event} declares {hook['timeout']}s over a "
+                                f"{limit}s ceiling; the host silently overrules it",
+                            )
+
+    def test_every_declared_ceiling_carries_evidence(self):
+        """Same rule the file already applies to supported_lifecycle_events."""
+        for key, host in spec()["hosts"].items():
+            if not host.get("hook_timeout_ceilings_seconds"):
+                continue
+            with self.subTest(host=key):
+                evidence = host.get("hook_timeout_ceiling_evidence", "")
+                self.assertGreater(
+                    len(evidence), 60,
+                    f"{key} declares a timeout ceiling with no substantive evidence",
+                )
+
+    def test_capability_report_does_not_call_a_capped_event_a_flat_yes(self):
+        doc = open(os.path.join(REPO, CAPABILITY_DOC)).read() if os.path.isabs(CAPABILITY_DOC) \
+            else open(CAPABILITY_DOC).read()
+        for key, host in spec()["hosts"].items():
+            for event, limit in host.get("hook_timeout_ceilings_seconds", {}).items():
+                with self.subTest(host=key, event=event):
+                    self.assertIn(
+                        f"capped at {limit}s", doc,
+                        f"{event} is capped at {limit}s on {key} but the report "
+                        "does not say so",
+                    )
+
 class TruthfulCapabilityReporting(unittest.TestCase):
     """Requirement 14. The heart of the honesty guarantee."""
 


### PR DESCRIPTION
Closes #193.

Codex hard-clamps SessionEnd hooks to 3s and says so on every session start:

```
clamping SessionEnd hook timeout to 3s in <plugin>/hooks.json
```

Kernel bound `session-end.sh` at **210**, because that hook runs the project's test suite. The declared budget was 70x the real one, so the gate was killed every time and Codex users have had no red-suite detection at all.

## The truthfulness failure

`governance/hosts.json`'s own header calls this shape of claim the thing the file exists to prevent. Codex listed `SessionEnd` as supported with no qualification, and the report rendered a flat `yes`.

"Supported" and "supported with a ceiling that truncates our binding" are different claims.

## Fix

The ceiling becomes a declared host fact with named evidence, alongside `supported_lifecycle_events` and `plugin_root_var`. The generator emits the real number instead of a wish — which also clears the startup warning for the file Codex actually binds.

```
| SessionEnd | yes | yes, capped at 3s |
```

plus a section naming the limit, what Kernel asked for, and the evidence.

## Enforcement

Three tests: no binding may declare a timeout above its host's ceiling, every declared ceiling must carry substantive evidence, and the report must not call a capped event a flat yes.

Verified by disabling the cap:

```
FAIL: test_no_binding_declares_a_timeout_above_its_host_ceiling (host='codex', event='SessionEnd')
```

**Claude is deliberately untouched.** It has no such ceiling and genuinely needs the 210s; capping it to match Codex would break the host that works.

Full suite: 447 passed, 0 failed.

## Named, not buried

The functional gap this exposes — Codex cannot run the session-end test gate in 3s, so red-suite detection is Claude-only — is now stated rather than implied, and gets its own cycle.
