### PR TITLE
release: 9.3.0 - structured questions are the default reply shape

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Fences, not leashes: enforced boundaries for Claude Code in auto mode",
-      "version": "9.2.1"
+      "version": "9.3.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.2.1",
+  "version": "9.3.0",
   "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: b72f6ff7d3e7a9e1f62840c1a1b9edfc0deb1ac3d65e92ebf701f188ec287ee4; adapter: codex -->
+     source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: codex -->
 <kernel version="9.2.1">
 
 
@@ -98,6 +98,41 @@ when scope or hypothesis changes, and whenever a new failure appears.
   tier the work → define success before coding → execute (inline by default; delegate heavy file-disjoint work → surgeon → verify) → learn (agentdb learn).
   Never implement the first idea: generate 2-3 approaches, choose simplest. Details live in the skills, not here.
 </flow>
+
+<interaction>
+Structured questions are the DEFAULT response shape, not an escalation. Every turn that is not
+finished ends with the numbered QUESTION block below. Never bury "should I...?" in prose and stop: a question the
+reader has to excavate from a wall of text is a question that gets answered wrong or not at all.
+
+  <rule>Ask unless one of three holds: the work is fully done, the answer is trivially unambiguous
+  (exactly one real option), or the interface makes it impossible.</rule>
+  <rule>Impossible means non-interactive: you are a subagent, or the session is headless
+  (`claude -p`, `codex exec`, codex-lane.sh, cron, CI). The tool's absence from your tool list IS
+  the signal. Never stall a headless run waiting on an answer that cannot arrive; state the
+  assumption in the deliverable instead.</rule>
+  <rule>Subagents never ask the user. They escalate through their contract's ESCALATE IF line and
+  stop. The orchestrator answers from its own context whatever it can, and forwards only the
+  genuinely user-only questions, batched into ONE round. Five lanes each raising a dialog rebuilds
+  the wall of text this rule exists to kill.</rule>
+  <rule>One round, at most 4 questions, ordered by leverage: the answer that invalidates the most
+  downstream work goes first. Every option carries its consequence; the recommended one is listed
+  first and labelled. Never ask what the repo, the diff, or an agentdb recall already answers.</rule>
+  <rule>Guessing is the top defect source. If you catch yourself writing "I'll assume", ask.</rule>
+
+  <codex_fallback>
+  Codex exposes no structured-question tool. Its final message ends with this block and nothing
+  after it, one block per open decision, max 4:
+
+    QUESTION: &lt;the decision, one line&gt;
+      1. &lt;option&gt; - &lt;consequence&gt;  [recommended]
+      2. &lt;option&gt; - &lt;consequence&gt;
+      3. something else - tell me what you want instead
+
+  No question in prose outside this shape.
+  </codex_fallback>
+
+  Full protocol: _meta/reference/interaction-protocol.md
+</interaction>
 
 <contract>
 CONTRACT: {id} | GOAL: {observable} | CONSTRAINTS: {files} | FAILURE: {conditions} | TIER: {2|3} | BRANCH: {name}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: codex -->
-<kernel version="9.2.1">
+<kernel version="9.3.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.3.0] - 2026-08-10
+
+Structured questions become the default reply shape instead of an escalation. The agent
+will visibly ask more, and ask in a form you can answer at a glance rather than excavate
+from a recap.
+
+### Added
+- **`<interaction>` governance block: every unfinished turn ends with a structured
+  question.** Two failures share one fix. The first is guessing: an agent with a real fork
+  in front of it picks one silently and builds forward on the wrong branch, which is a
+  defect committed before a line is written. The second is presentation: agents that do ask
+  bury the question in paragraph seven next to three other half-questions, the reader
+  answers the one they noticed, and the rest get guessed anyway. A question that must be
+  excavated is functionally an unasked question. Three exemptions only, and no others: the
+  work is fully done, exactly one real option exists, or the interface makes asking
+  impossible.
+- **Non-interactive detection reads the tool list, not the environment.** Absence of the
+  question tool IS the signal. Headless runs (`claude -p`, `codex exec`, codex-lane, cron,
+  CI) never stall waiting for an answer that cannot arrive; they state the assumption
+  explicitly in the deliverable and proceed, because an assumption written down is
+  recoverable and one acted on silently is not.
+- **Subagents never ask the user.** They escalate through their contract's existing
+  `ESCALATE IF` line and stop. The orchestrator then triages: answer from its own context,
+  the repo, the diff, or an `agentdb recall` whatever it can, merge duplicate escalations,
+  and forward only the genuinely user-only remainder batched into one round of at most four
+  questions ordered by leverage. Without this, five parallel lanes each raise a dialog and
+  rebuild exactly the wall of text the rule exists to remove.
+- **`ASK_MECHANISM` adapter token, so neither client is told to call a tool it does not
+  have.** Codex has no AskUserQuestion equivalent: its model-facing surface is `shell`,
+  `apply_patch`, `update_plan`, `web_search`, plus MCP, and none of them render a picker.
+  The token resolves to the tool for Claude and to a fixed numbered `QUESTION:` block,
+  pinned to the end of the final message, for Codex. A local MCP chooser was considered and
+  deferred: it dies in every headless lane and needs the prose fallback anyway, so the
+  fallback ships first.
+- **The rule lands in the ambient source block**, since `session-start.sh` is the only
+  context-delivery mechanism plugin users actually load. A governance rule that reaches only
+  `CLAUDE.md` reaches contributors and nobody else.
+- Full protocol at `_meta/reference/interaction-protocol.md`. New test asserts all three
+  delivery surfaces carry the rule and that each adapter resolved its own mechanism;
+  verified by breaking the ambient line and the Codex resolution on purpose and confirming
+  the test caught both, rather than trusting a green run.
+
 ## [9.2.1] - 2026-08-09
 
 Every Codex hook in KERNEL was dead, and the test suite said it was fine. This release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: claude -->
-<kernel version="9.2.1">
+<kernel version="9.3.0">
 
 
 <!-- ============================================ -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
-     source-sha256: b72f6ff7d3e7a9e1f62840c1a1b9edfc0deb1ac3d65e92ebf701f188ec287ee4; adapter: claude -->
+     source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: claude -->
 <kernel version="9.2.1">
 
 
@@ -98,6 +98,41 @@ when scope or hypothesis changes, and whenever a new failure appears.
   tier the work → define success before coding → execute (inline by default; delegate heavy file-disjoint work → surgeon → verify) → learn (agentdb learn).
   Never implement the first idea: generate 2-3 approaches, choose simplest. Details live in the skills, not here.
 </flow>
+
+<interaction>
+Structured questions are the DEFAULT response shape, not an escalation. Every turn that is not
+finished ends with an AskUserQuestion call. Never bury "should I...?" in prose and stop: a question the
+reader has to excavate from a wall of text is a question that gets answered wrong or not at all.
+
+  <rule>Ask unless one of three holds: the work is fully done, the answer is trivially unambiguous
+  (exactly one real option), or the interface makes it impossible.</rule>
+  <rule>Impossible means non-interactive: you are a subagent, or the session is headless
+  (`claude -p`, `codex exec`, codex-lane.sh, cron, CI). The tool's absence from your tool list IS
+  the signal. Never stall a headless run waiting on an answer that cannot arrive; state the
+  assumption in the deliverable instead.</rule>
+  <rule>Subagents never ask the user. They escalate through their contract's ESCALATE IF line and
+  stop. The orchestrator answers from its own context whatever it can, and forwards only the
+  genuinely user-only questions, batched into ONE round. Five lanes each raising a dialog rebuilds
+  the wall of text this rule exists to kill.</rule>
+  <rule>One round, at most 4 questions, ordered by leverage: the answer that invalidates the most
+  downstream work goes first. Every option carries its consequence; the recommended one is listed
+  first and labelled. Never ask what the repo, the diff, or an agentdb recall already answers.</rule>
+  <rule>Guessing is the top defect source. If you catch yourself writing "I'll assume", ask.</rule>
+
+  <codex_fallback>
+  Codex exposes no structured-question tool. Its final message ends with this block and nothing
+  after it, one block per open decision, max 4:
+
+    QUESTION: &lt;the decision, one line&gt;
+      1. &lt;option&gt; - &lt;consequence&gt;  [recommended]
+      2. &lt;option&gt; - &lt;consequence&gt;
+      3. something else - tell me what you want instead
+
+  No question in prose outside this shape.
+  </codex_fallback>
+
+  Full protocol: _meta/reference/interaction-protocol.md
+</interaction>
 
 <contract>
 CONTRACT: {id} | GOAL: {observable} | CONSTRAINTS: {files} | FAILURE: {conditions} | TIER: {2|3} | BRANCH: {name}

--- a/_meta/reference/interaction-protocol.md
+++ b/_meta/reference/interaction-protocol.md
@@ -1,0 +1,129 @@
+---
+type: reference
+status: active
+created: 2026-08-10
+updated: 2026-08-10
+---
+
+# Interaction protocol: structured questions as the default reply
+
+Governance summary lives in the `<interaction>` block of `CLAUDE.md` / `AGENTS.md` (generated from
+`governance/kernel.md.tmpl`). This file is the full version: why, the exact shapes, and the
+failure modes it was written against.
+
+## The failure it fixes
+
+Guessing is the top defect source. Not bad code, not missing tests: an agent that had a real fork
+in front of it, picked one silently, and built forward on the wrong branch. Every "I'll assume the
+user meant X" is a defect committed before a line was written.
+
+The second failure is presentation. Agents that *do* ask usually bury the question in the seventh
+paragraph of a recap, next to three other half-questions and a status dump. The reader skims,
+answers the one they noticed, and the other two get guessed anyway. A question that has to be
+excavated is functionally an unasked question.
+
+So: questions get a dedicated, structured, scannable surface, and they get it by default.
+
+## The rule
+
+Every turn that is not finished ends with a structured question. Three exemptions, and only three:
+
+1. **Fully done.** The work is complete and verified. Nothing is pending.
+2. **Trivially unambiguous.** There is exactly one real option. Not "one obviously better option",
+   one *real* one. If you can articulate a second choice a reasonable person would make, ask.
+3. **Non-interactive.** Nobody can answer. See below.
+
+Exemption 2 is the one that erodes. It is not a licence to keep guessing under a nicer name. The
+test is adversarial: could a fresh reviewer name an alternative you did not surface? Then it was
+not trivially unambiguous.
+
+## Non-interactive detection
+
+Do not try to detect headless mode by inspecting environment variables. The reliable signal is
+already in front of you:
+
+- **Claude**: `AskUserQuestion` absent from your tool list means no interactive channel. Subagents
+  spawned via the Agent tool are non-interactive by policy even when a tool appears available.
+- **Codex**: `codex exec`, `_meta/services/codex-lanes/codex-lane.sh submit`, cron, and CI are all
+  non-interactive. Interactive Codex is the TUI a human is watching.
+
+In a non-interactive run, never stall waiting for an answer that cannot arrive. State the
+assumption explicitly in the deliverable, mark it as an assumption, and proceed. An assumption
+written down is recoverable; an assumption acted on silently is not.
+
+## Subagents never ask
+
+A subagent that raises its own question either blocks forever (non-interactive) or, worse,
+succeeds: five parallel lanes each pop a dialog and the user is back to the wall of text.
+
+The channel already exists. Every write-capable spawn contract carries:
+
+```text
+ACCEPTANCE: externally checkable done condition
+ESCALATE IF: evidence that should stop or re-scope the lane
+OWNED PATHS: exact writable boundary
+```
+
+`ESCALATE IF` is the subagent's question channel. The subagent stops and reports; it does not ask.
+
+The orchestrator then does triage, in this order:
+
+1. **Answer it yourself.** Most escalated questions are answerable from the orchestrator's context,
+   the repo, the diff, or an `agentdb recall`. Answer those and resume the lane. Do not forward a
+   question you could have resolved: forwarding solvable questions is its own form of noise.
+2. **Merge duplicates.** Three lanes hitting the same ambiguity is one question, not three.
+3. **Batch the remainder into ONE round**, ordered by leverage.
+
+## Question shape
+
+One round. At most 4 questions. Ordered by leverage: the answer that invalidates the most
+downstream work goes first, so a single reply can redirect everything after it.
+
+Per question:
+
+- A `header` of at most 12 characters. It is a chip, not a sentence.
+- 2-4 options, each mutually exclusive unless `multiSelect` is set.
+- Every option states its **consequence**, not just its name. "Ship to plugin users (needs a
+  release + tests)" beats "kernel-claude".
+- The recommended option goes **first** and is labelled `(Recommended)`. Having an opinion is part
+  of the job; withholding it to seem neutral just pushes the work back onto the reader.
+- Use `preview` when the options are concrete artifacts to compare visually (layouts, snippets,
+  diagrams), not for preference questions where labels suffice.
+
+Never ask what the repo already answers. Read the file first. A question whose answer was one
+`grep` away spends the user's attention on your laziness.
+
+## Codex fallback
+
+Codex has no structured-question tool. Its model-facing surface is `shell`, `apply_patch`,
+`update_plan`, `web_search`, plus MCP; none of them render a picker. So the protocol degrades to a
+strict text shape, placed at the very end of the final message with nothing after it:
+
+```text
+QUESTION: <the decision, one line>
+  1. <option> - <consequence>  [recommended]
+  2. <option> - <consequence>
+  3. something else - tell me what you want instead
+```
+
+One block per open decision, at most 4. No question in prose outside this shape. The fixed
+position and fixed shape are what make it scannable; a "mostly like this" variant is not the
+protocol.
+
+A local MCP server exposing a real chooser (for example `osascript choose from list`) was
+considered and deliberately deferred: it dies in every headless lane, needs a timeout fallback
+anyway, and the fallback is the prose block. Build the floor first.
+
+## Prose is still allowed
+
+This protocol governs *questions* and turn endings, not the whole reply. Findings, evidence, paths,
+and outcomes still get stated, and substantive deliverables are still files, not chat. What is
+banned is the open decision dissolved into narration.
+
+Rule of thumb: everything above the question block is the smallest context needed to answer it.
+
+## Related
+
+- Spawn contracts and escalation: `Vaults/_meta/reference/coordination/multi-agent-coordination.md`
+- Model and effort routing per lane: `Vaults/_meta/reference/coordination/model-routing.md`
+- Output quality and artifact-first rules: `_meta/reference/output-quality.md`

--- a/governance/adapters.json
+++ b/governance/adapters.json
@@ -4,6 +4,10 @@
     "codex": "AGENTS.md"
   },
   "tokens": {
+    "ASK_MECHANISM": {
+      "claude": "an AskUserQuestion call",
+      "codex": "the numbered QUESTION block below"
+    },
     "CLIENT_NAME": {
       "claude": "Claude Code",
       "codex": "Codex"

--- a/governance/kernel.md.tmpl
+++ b/governance/kernel.md.tmpl
@@ -17,6 +17,8 @@ Default is inline. Spawn a subagent only to protect context, to buy real wall-cl
 Route model and effort by task shape and measured evidence, never prestige. Preserve the exact request; never silently substitute. Receipts keep `requested_model` and `requested_effort` separate from `observed_model` and `observed_effort`, and use `unavailable` when the runtime does not expose a value.
 Protected receipts require distinct `builder_identity` and `verifier_identity`; the builder never grades its own protected work.
 Claude invokes skills as /kernel:name; Codex invokes them as $kernel:name. Use the matching form; /kernel:help or $kernel:help lists them.
+Structured questions are the default reply shape, not an escalation. End every unfinished turn with one; Claude uses the AskUserQuestion tool, Codex has no such tool and ends with a numbered QUESTION block instead. Skip only when the work is fully done, exactly one real option exists, or the session is non-interactive. The tool's absence from your tool list IS the non-interactive signal: never stall a headless run on an answer that cannot arrive.
+Subagents never ask the user. They escalate through their contract's ESCALATE IF line and stop; the orchestrator answers what its own context can answer and batches the rest into ONE round. Guessing is the top defect source: an unstated assumption you acted on is a defect you shipped.
 KERNEL_AMBIENT_SOURCE_END -->
 
 <!-- ============================================ -->
@@ -114,6 +116,41 @@ when scope or hypothesis changes, and whenever a new failure appears.
   tier the work → define success before coding → execute (inline by default; delegate heavy file-disjoint work → surgeon → verify) → learn (agentdb learn).
   Never implement the first idea: generate 2-3 approaches, choose simplest. Details live in the skills, not here.
 </flow>
+
+<interaction>
+Structured questions are the DEFAULT response shape, not an escalation. Every turn that is not
+finished ends with {{ASK_MECHANISM}}. Never bury "should I...?" in prose and stop: a question the
+reader has to excavate from a wall of text is a question that gets answered wrong or not at all.
+
+  <rule>Ask unless one of three holds: the work is fully done, the answer is trivially unambiguous
+  (exactly one real option), or the interface makes it impossible.</rule>
+  <rule>Impossible means non-interactive: you are a subagent, or the session is headless
+  (`claude -p`, `codex exec`, codex-lane.sh, cron, CI). The tool's absence from your tool list IS
+  the signal. Never stall a headless run waiting on an answer that cannot arrive; state the
+  assumption in the deliverable instead.</rule>
+  <rule>Subagents never ask the user. They escalate through their contract's ESCALATE IF line and
+  stop. The orchestrator answers from its own context whatever it can, and forwards only the
+  genuinely user-only questions, batched into ONE round. Five lanes each raising a dialog rebuilds
+  the wall of text this rule exists to kill.</rule>
+  <rule>One round, at most 4 questions, ordered by leverage: the answer that invalidates the most
+  downstream work goes first. Every option carries its consequence; the recommended one is listed
+  first and labelled. Never ask what the repo, the diff, or an agentdb recall already answers.</rule>
+  <rule>Guessing is the top defect source. If you catch yourself writing "I'll assume", ask.</rule>
+
+  <codex_fallback>
+  Codex exposes no structured-question tool. Its final message ends with this block and nothing
+  after it, one block per open decision, max 4:
+
+    QUESTION: &lt;the decision, one line&gt;
+      1. &lt;option&gt; - &lt;consequence&gt;  [recommended]
+      2. &lt;option&gt; - &lt;consequence&gt;
+      3. something else - tell me what you want instead
+
+  No question in prose outside this shape.
+  </codex_fallback>
+
+  Full protocol: _meta/reference/interaction-protocol.md
+</interaction>
 
 <contract>
 CONTRACT: {id} | GOAL: {observable} | CONSTRAINTS: {files} | FAILURE: {conditions} | TIER: {2|3} | BRANCH: {name}

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -149,6 +149,8 @@ Default is inline. Spawn a subagent only to protect context, to buy real wall-cl
 Route model and effort by task shape and measured evidence, never prestige. Preserve the exact request; never silently substitute. Receipts keep `requested_model` and `requested_effort` separate from `observed_model` and `observed_effort`, and use `unavailable` when the runtime does not expose a value.
 Protected receipts require distinct `builder_identity` and `verifier_identity`; the builder never grades its own protected work.
 Claude invokes skills as /kernel:name; Codex invokes them as $kernel:name. Use the matching form; /kernel:help or $kernel:help lists them.
+Structured questions are the default reply shape, not an escalation. End every unfinished turn with one; Claude uses the AskUserQuestion tool, Codex has no such tool and ends with a numbered QUESTION block instead. Skip only when the work is fully done, exactly one real option exists, or the session is non-interactive. The tool's absence from your tool list IS the non-interactive signal: never stall a headless run on an answer that cannot arrive.
+Subagents never ask the user. They escalate through their contract's ESCALATE IF line and stop; the orchestrator answers what its own context can answer and batches the rest into ONE round. Guessing is the top defect source: an unstated assumption you acted on is a defect you shipped.
 KERNEL_CONTEXT
 # END GENERATED KERNEL AMBIENT
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.2.1.
+Quick reference for KERNEL v9.3.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2041,6 +2041,38 @@ test_claude_md_token_budget() {
   }
 }
 
+test_interaction_protocol_reaches_every_surface() {
+  # The <interaction> rule is worthless if it only lands in files plugin users never load.
+  # session-start.sh is the ONLY ambient delivery mechanism; assert all three surfaces carry it,
+  # each adapter resolved its own ASK_MECHANISM, and the reference doc it points at exists.
+  local failed=0
+
+  grep -qF "<interaction>" "$PLUGIN_ROOT/CLAUDE.md" || {
+    echo "FAIL: CLAUDE.md missing <interaction> block"; failed=1; }
+  grep -qF "<interaction>" "$PLUGIN_ROOT/AGENTS.md" || {
+    echo "FAIL: AGENTS.md missing <interaction> block"; failed=1; }
+
+  grep -qF "an AskUserQuestion call" "$PLUGIN_ROOT/CLAUDE.md" || {
+    echo "FAIL: CLAUDE.md should resolve ASK_MECHANISM to the AskUserQuestion tool"; failed=1; }
+  if grep -qF "AskUserQuestion call" "$PLUGIN_ROOT/AGENTS.md"; then
+    echo "FAIL: AGENTS.md must not tell Codex to call AskUserQuestion (no such tool)"; failed=1
+  fi
+  grep -qF "numbered QUESTION block" "$PLUGIN_ROOT/AGENTS.md" || {
+    echo "FAIL: AGENTS.md should resolve ASK_MECHANISM to the prose QUESTION block"; failed=1; }
+
+  # Ambient block is what plugin users actually see.
+  grep -qF "Structured questions are the default reply shape" \
+    "$PLUGIN_ROOT/hooks/scripts/session-start.sh" || {
+    echo "FAIL: session-start.sh ambient block missing the structured-question rule"; failed=1; }
+  grep -qF "Subagents never ask the user" \
+    "$PLUGIN_ROOT/hooks/scripts/session-start.sh" || {
+    echo "FAIL: session-start.sh ambient block missing the subagent escalation rule"; failed=1; }
+
+  assert_file_exists "$PLUGIN_ROOT/_meta/reference/interaction-protocol.md" || failed=1
+
+  return $failed
+}
+
 test_commands_token_budget() {
   # Skills should be focused. Guided generators (landing-page) and autonomous
   # engines (forge) legitimately run long; cap reflects real sizes.
@@ -5230,6 +5262,7 @@ run_test_suite() {
       ;;
     tokens)
       run_test "CLAUDE.md token budget" test_claude_md_token_budget
+      run_test "interaction protocol reaches every surface" test_interaction_protocol_reaches_every_surface
       run_test "commands token budget" test_commands_token_budget
       run_test "agents token budget" test_agents_token_budget
       run_test "critical content at edges" test_critical_content_at_edges


### PR DESCRIPTION
## What

Makes structured questions the default reply shape instead of an escalation. Every turn that is not finished ends with one.

Two failures share a fix. **Guessing**: an agent with a real fork in front of it picks one silently and builds forward on the wrong branch, which is a defect committed before a line is written. **Presentation**: agents that do ask bury the question in paragraph seven next to three other half-questions, the reader answers the one they noticed, and the rest get guessed anyway. A question that has to be excavated is functionally an unasked question.

Three exemptions and no others: the work is fully done, exactly one real option exists, or the interface makes it impossible.

## Codex has no equivalent tool

Codex's model-facing surface is `shell`, `apply_patch`, `update_plan`, `web_search`, plus MCP. None of them render a picker. The new `ASK_MECHANISM` adapter token resolves to the tool for Claude and to a fixed numbered `QUESTION:` block for Codex, so neither adapter instructs its client to call something that does not exist.

A local MCP chooser (`osascript choose from list`) was considered and deferred: it dies in every headless lane and needs the prose fallback anyway, so the fallback ships first.

## Design points worth reviewing

- **Non-interactive detection reads the tool list, not the environment.** Absence of the question tool IS the signal. Headless runs never stall on an answer that cannot arrive; they state the assumption in the deliverable and proceed.
- **Subagents never ask.** They escalate through their contract's existing `ESCALATE IF` line. The orchestrator answers from its own context what it can, merges duplicates, and forwards only the user-only remainder as one round. Without this, five parallel lanes each raise a dialog and rebuild the wall of text the rule removes.
- **The rule is in the ambient source block.** `session-start.sh` is the only delivery mechanism plugin users load; a rule reaching only `CLAUDE.md` reaches contributors and nobody else.

## Verification

- 448/448 local tests pass.
- New test asserts all three delivery surfaces carry the rule and that each adapter resolved its own mechanism. Verified by breaking the ambient line and the Codex resolution on purpose and confirming it caught both, rather than trusting a green run.
- `.codex-plugin/plugin.json` was missed on the version sweep and caught by `test_versions_agree_across_manifests`.
- `CLAUDE.md` at 374/400 lines.

Full protocol: `_meta/reference/interaction-protocol.md`