### PR TITLE
A termination protocol for the review loop: distance-gated blocking, acceptance profiles, and finality

### DIFF
--- a/agents/adversary.md
+++ b/agents/adversary.md
@@ -30,8 +30,16 @@ Reference: skills/quality/reference/quality-research.md
   does not buy independence, it buys a reviewer with amnesia who relitigates settled questions for
   free. Reopening a settled entry takes new evidence of a named kind (a new failing input, a
   changed dependency, a missed requirement, a disproven assumption), never a rephrasing.
-- **The declared objective**: what this project is for, with its date and success condition. A
-  demo and a payments system do not get the same bar.
+- **The acceptance profile** (`schemas/kernel.acceptance-profile.v1.schema.json`): the structured
+  context this artifact is judged against. Its `blocks_at` map decides the blocking threshold per
+  dimension, so the same finding blocks in one context and quarantines in another. Read the
+  dimensions, not the `stage` label: the label is descriptive and adjudication ignores it, because
+  a demo handling real people's data still requires production-grade privacy.
+- **Any acceptance record for this commit** (`schemas/kernel.acceptance.v1.schema.json`). If one
+  exists, the commit is FROZEN. Raising a settled concern again is not a finding. Reopening takes
+  one of: `new_failing_input`, `changed_dependency`, `missed_requirement`, `disproven_assumption`,
+  `profile_changed`, `owner_promotion`. Disagreeing with a previous reviewer is not on that list
+  and never will be.
 </startup_reads>
 
 <protocol>
@@ -128,10 +136,13 @@ run still returns PASS.
      ecosystem, the 2026-08-03 genre pivot, was distance-3.)
 3. **Names an observable failure.** "Predict what breaks and how we would see it." No observable,
    no block. Scored WITH distance, never instead of it, since a far-fetched observable is cheap.
-4. **On-objective.** Off-objective never blocks however real it is. Production-hardening findings
-   on a demo are quarantine. Read the project's declared objective before assigning severity;
-   with none declared, a reviewer defaults to production rigor every time because that is the
-   safest-looking answer and it costs the reviewer nothing.
+4. **Violates the acceptance profile.** Tag every finding with its `dimension` and, where you can,
+   its `failure_mode`. A finding on a dimension the profile tolerates is quarantine however real,
+   proven and distance-0 it is; a failure mode already listed in `acceptable_failure_modes` is
+   quarantine because someone decided in writing before you ran. With no profile supplied the old
+   fallback applies (only `blocker` severity blocks), and a reviewer given no context defaults to
+   production rigor every time, because that is the safest-looking answer and it costs you
+   nothing.
 
 Coordination-phase and reachability failures are distance-0 by construction and keep their
 existing absolute FAIL.
@@ -215,6 +226,9 @@ agentdb write-end '{"agent":"adversary","result":"pass|fail","phases_completed":
 - [ ] Every FAIL clears the fail_bar (pasted output + distance threshold + observable + on-objective)
 - [ ] CANNOT FALSIFY printed on PASS
 - [ ] Quarantined findings filed as issues with distance labels
+- [ ] Every finding carries a dimension
+- [ ] Acceptance profile read; stage label NOT treated as the decision
+- [ ] Acceptance record checked; a frozen commit reopened only on a recognised event
 - [ ] Findings adjudicated by scripts/adjudicate.py (not by you)
 - [ ] Verdict written to AgentDB
 </checklist>

--- a/agents/adversary.md
+++ b/agents/adversary.md
@@ -151,6 +151,24 @@ An interrupted verification blocks the claim it was going to prove. Report it as
 and escalate to the signer rather than letting it read as an absence.
 </cannot_falsify>
 
+<adjudicate>
+You do not decide the verdict. You propose findings; `scripts/adjudicate.py` decides. This is not
+ceremony: a critic asked whether its own criticism is complete has no way to answer and will always
+say no, which is why the loop never closed before.
+
+Write your findings as a `kernel.verdict/v1` document (schema:
+`schemas/kernel.verdict.v1.schema.json`), then run:
+
+```bash
+python3 scripts/adjudicate.py findings.json --text --strict
+# exit 0 = PASS · 1 = FAIL · 2 = INVALID (usually an empty cannot_falsify)
+```
+
+Report what it returns. Do not overrule it, and do not restate its verdict in your own words.
+A PreToolUse gate (`hooks/scripts/verdict-gate.sh`) refuses any verdict whose stated outcome
+disagrees with adjudication of its own findings, so disagreeing is not available to you anyway.
+</adjudicate>
+
 agentdb verdict pass|fail '{"tested":[...],"evidence":"<actual_output>","big5":"pass|fail","cannot_falsify":[...],"quarantined":[...]}'
 
 Surface to GitHub: if github-oss/production profile and issue exists, post verdict as issue
@@ -197,6 +215,7 @@ agentdb write-end '{"agent":"adversary","result":"pass|fail","phases_completed":
 - [ ] Every FAIL clears the fail_bar (pasted output + distance threshold + observable + on-objective)
 - [ ] CANNOT FALSIFY printed on PASS
 - [ ] Quarantined findings filed as issues with distance labels
+- [ ] Findings adjudicated by scripts/adjudicate.py (not by you)
 - [ ] Verdict written to AgentDB
 </checklist>
 

--- a/agents/adversary.md
+++ b/agents/adversary.md
@@ -25,6 +25,13 @@ Reference: skills/quality/reference/quality-research.md
 - Recent failures from AgentDB
 - Surgeon's checkpoint (what they claim)
 - Contract (success criteria)
+- **The acceptance record**: claims, declared invariants, and tradeoffs already consciously
+  accepted. Blind to the builder's REASONING, never blind to the acceptance record. Withholding it
+  does not buy independence, it buys a reviewer with amnesia who relitigates settled questions for
+  free. Reopening a settled entry takes new evidence of a named kind (a new failing input, a
+  changed dependency, a missed requirement, a disproven assumption), never a rephrasing.
+- **The declared objective**: what this project is for, with its date and success condition. A
+  demo and a payments system do not get the same bar.
 </startup_reads>
 
 <protocol>
@@ -98,8 +105,58 @@ Partial = FAIL.
 </protocol>
 
 <verdict>
-agentdb verdict pass|fail '{"tested":[...],"evidence":"<actual_output>","big5":"pass|fail"}'
-Surface to GitHub: if github-oss/production profile and issue exists, post verdict as issue comment with PASS/FAIL badge.
+The verdict stays binary. What changed (#204) is what earns a FAIL, because ten phases each able
+to FAIL independently is flat severity, and flat severity selects for weak instruments: when
+every finding blocks, the cheapest way to keep shipping is an instrument that finds little.
+
+<fail_bar>
+FAIL requires a finding that meets ALL FOUR. Anything short of all four is QUARANTINE, and the
+run still returns PASS.
+
+1. **Pasted output.** Not a described procedure, not a read of the code. The command and its
+   actual output. Criticism is not evidence.
+2. **Clears its distance proof threshold.** Distance sets how much proof is needed, never whether
+   a finding may block. A distance-3 finding with overwhelming evidence blocks; a distance-0
+   finding with none does not.
+   - distance 0, the changed code fails: pasted output.
+   - distance 1, violates a declared invariant: pasted output naming the invariant.
+   - distance 2, pre-existing defect this change exposed: reproduction plus a user-visible
+     consequence.
+   - distance 3+, needs assumptions outside the change: blocks only on an executed demonstration,
+     a cited prior failure, or an outcome someone actually experienced. Taste never clears this
+     bar. A playtest record does. (Do NOT auto-close distance 3: the highest-value review in this
+     ecosystem, the 2026-08-03 genre pivot, was distance-3.)
+3. **Names an observable failure.** "Predict what breaks and how we would see it." No observable,
+   no block. Scored WITH distance, never instead of it, since a far-fetched observable is cheap.
+4. **On-objective.** Off-objective never blocks however real it is. Production-hardening findings
+   on a demo are quarantine. Read the project's declared objective before assigning severity;
+   with none declared, a reviewer defaults to production rigor every time because that is the
+   safest-looking answer and it costs the reviewer nothing.
+
+Coordination-phase and reachability failures are distance-0 by construction and keep their
+existing absolute FAIL.
+</fail_bar>
+
+<cannot_falsify>
+MANDATORY on every PASS. Silence about coverage reads as coverage. A gate that passes must print
+what it structurally could not check:
+
+  ADVERSARY: PASS
+  CANNOT FALSIFY:
+    - <what no instrument above could see: no real device, conformance only, no live data...>
+    - <every claim whose instrument did not finish. An unfinished instrument is RED, never
+       neutral: "we could not reproduce it" and "it is not a problem" are different sentences.>
+
+An interrupted verification blocks the claim it was going to prove. Report it as `unverifiable`
+and escalate to the signer rather than letting it read as an absence.
+</cannot_falsify>
+
+agentdb verdict pass|fail '{"tested":[...],"evidence":"<actual_output>","big5":"pass|fail","cannot_falsify":[...],"quarantined":[...]}'
+
+Surface to GitHub: if github-oss/production profile and issue exists, post verdict as issue
+comment with PASS/FAIL badge, the CANNOT FALSIFY block, and the quarantined list. File each
+quarantined finding as an issue with its `distance:N` label and the `quarantine` milestone. The
+issue tracker IS the ledger; do not keep a parallel document.
 </verdict>
 
 <ask_user>
@@ -113,7 +170,13 @@ Surface to GitHub: if github-oss/production profile and issue exists, post verdi
 - trust_claims: Run actual commands. Paste output.
 - trust_surgeon_summary: The summary describes intent. The file describes reality. Read the
   file. Modelmind surgeon claimed drag-and-drop was implemented; the file had only types.
-- soft_pass: PASS or FAIL. No exceptions.
+- soft_pass: PASS or FAIL. No exceptions. (Narrowing the FAIL bar is not a soft pass: the
+  verdict stays binary, the threshold moved.)
+- flat_severity: ten phases each able to veto is how a review process drifts toward instruments
+  that cannot fail. Route through the fail_bar.
+- silent_coverage: a PASS with no CANNOT FALSIFY block is not a PASS.
+- ask_if_complete: never ask discovery whether criticism is complete. It cannot answer and will
+  always say no. Completeness is acceptance's call.
 - fix_bugs: Surgeon's job. Document and FAIL.
 </anti_patterns>
 
@@ -131,6 +194,9 @@ agentdb write-end '{"agent":"adversary","result":"pass|fail","phases_completed":
 - [ ] Edge cases tested (3+ categories)
 - [ ] Regression suite passed
 - [ ] Evidence is actual output
+- [ ] Every FAIL clears the fail_bar (pasted output + distance threshold + observable + on-objective)
+- [ ] CANNOT FALSIFY printed on PASS
+- [ ] Quarantined findings filed as issues with distance labels
 - [ ] Verdict written to AgentDB
 </checklist>
 

--- a/hooks.json
+++ b/hooks.json
@@ -56,6 +56,11 @@
             "type": "command",
             "command": "${PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/scripts/verdict-gate.sh",
+            "timeout": 10
           }
         ]
       },

--- a/hooks/gates.json
+++ b/hooks/gates.json
@@ -320,6 +320,21 @@
       "degraded_mode": "fail-open-loud"
     },
     {
+      "id": "verdict-gate",
+      "script": "hooks/scripts/verdict-gate.sh",
+      "class": "gate",
+      "events": [
+        "PreToolUse"
+      ],
+      "matcher": "Write|Edit",
+      "external_deps": [
+        "jq",
+        "python3"
+      ],
+      "degraded_mode": "fail-closed",
+      "rationale": "Refuses a review verdict that nobody can rely on: an empty cannot_falsify, or a stated outcome that disagrees with adjudication of its own findings. Inert on writes that are not verdict documents; where it applies, a missing dependency REFUSES rather than waving the verdict through. Review has no natural stopping condition, so acceptance has to be a mechanism rather than the last reviewer's opinion (#204)."
+    },
+    {
       "id": "warn-hardcoded",
       "script": "hooks/scripts/warn-hardcoded.sh",
       "class": "advisory",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -56,6 +56,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/warn-hardcoded.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/verdict-gate.sh",
+            "timeout": 10
           }
         ]
       },

--- a/hooks/scripts/verdict-gate.sh
+++ b/hooks/scripts/verdict-gate.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# PreToolUse hook: refuse to record a review verdict that cannot be relied on.
+# Events: PreToolUse (matcher: Write|Edit)
+#
+# Applicable only to verdict documents: inert unless the payload declares
+# "kernel.verdict/v1". Where it applies it is fail-closed, because its dangerous
+# direction is YES -- accepting a verdict nobody can trust is the whole defect
+# class this exists to kill (#204). Arming is detected without jq or python3 so
+# that a missing dependency refuses the write instead of waving it through.
+#
+# What it refuses:
+#   - a verdict with an empty or missing cannot_falsify. Silence about coverage
+#     reads as coverage. Two flagship gates in this ecosystem printed PASS for
+#     weeks because ripgrep was not installed and nothing said so.
+#   - a verdict whose stated outcome disagrees with adjudication, i.e. an agent
+#     writing PASS over findings that clear the block bar, or FAIL over findings
+#     that do not. The critic proposes; scripts/adjudicate.py decides.
+#
+# What it deliberately does NOT do: judge whether the findings are correct. That
+# is not a hook's job and pretending otherwise would make it a gate that cannot
+# fail honestly.
+
+INPUT=$(cat)
+
+# Arming is detected on the RAW payload with no external dependency. Doing this with jq first
+# was a fail-dark bug the violation corpus caught on its first run: with jq missing the extraction
+# returned empty, the marker never matched, and a verdict write sailed through the gate meant to
+# check it. A fence that fails dark is a leash you think you are holding.
+case "$INPUT" in
+  *kernel.verdict/v1*) ;;
+  *) exit 0 ;;
+esac
+
+# Applicable from here on: every failure below is a refusal, never a shrug.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCKED: verdict gate cannot run (jq not found). A verdict recorded without its gate is not a verdict." >&2
+  exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "BLOCKED: verdict gate cannot run (python3 not found). Install python3 or do not record a verdict." >&2
+  exit 2
+fi
+
+CONTENT=$(printf '%s' "$INPUT" | jq -r '
+  [.tool_input.content, .tool_input.new_string,
+   (if (.tool_input.patch | type) == "string" then
+      [.tool_input.patch | split("\n")[] | select(startswith("+"))] | join("\n")
+    else empty end)]
+  | map(select(type == "string"))
+  | join("\n")
+' 2>/dev/null)
+
+# The marker was in the payload but not in the written content (a tool_use echo, a log line).
+[ -z "$CONTENT" ] && exit 0
+case "$CONTENT" in
+  *kernel.verdict/v1*) ;;
+  *) exit 0 ;;
+esac
+
+ADJ="$(dirname "$0")/../../scripts/adjudicate.py"
+if [ ! -f "$ADJ" ]; then
+  echo "BLOCKED: verdict gate cannot find scripts/adjudicate.py. Refusing rather than waving a verdict through." >&2
+  exit 2
+fi
+
+# The written document may be the findings input or an already-adjudicated verdict;
+# adjudicate.py is idempotent over both because it reads .findings and .cannot_falsify.
+RESULT=$(printf '%s' "$CONTENT" | python3 "$ADJ" - 2>/dev/null)
+if [ -z "$RESULT" ]; then
+  echo "BLOCKED: verdict document declares kernel.verdict/v1 but could not be adjudicated (malformed JSON?)." >&2
+  exit 2
+fi
+
+ADJUDICATED=$(printf '%s' "$RESULT" | jq -r '.verdict')
+ERRORS=$(printf '%s' "$RESULT" | jq -r '.errors[]?' 2>/dev/null)
+
+if [ "$ADJUDICATED" = "INVALID" ]; then
+  echo "BLOCKED: this verdict is INVALID, which is not a soft pass -- nobody may rely on the run." >&2
+  printf '%s\n' "$ERRORS" >&2
+  echo "Fix: declare cannot_falsify. Name what no instrument in this run could structurally see, and every claim whose instrument did not finish. An unfinished instrument is red, never neutral." >&2
+  exit 2
+fi
+
+# If the author stated an outcome, it must match what adjudication produced.
+CLAIMED=$(printf '%s' "$CONTENT" | jq -r '.verdict // empty' 2>/dev/null)
+if [ -n "$CLAIMED" ] && [ "$CLAIMED" != "$ADJUDICATED" ]; then
+  echo "BLOCKED: verdict says $CLAIMED, adjudication of its own findings says $ADJUDICATED." >&2
+  echo "The critic proposes findings; scripts/adjudicate.py decides the verdict. Never ask the critic whether criticism is complete." >&2
+  printf '%s' "$RESULT" | jq -r '.blocking[]? | "  BLOCK d\(.distance) \(.summary)"' >&2
+  exit 2
+fi
+
+exit 0

--- a/hooks/scripts/verdict-gate.sh
+++ b/hooks/scripts/verdict-gate.sh
@@ -15,6 +15,10 @@
 #   - a verdict whose stated outcome disagrees with adjudication, i.e. an agent
 #     writing PASS over findings that clear the block bar, or FAIL over findings
 #     that do not. The critic proposes; scripts/adjudicate.py decides.
+#   - a FAIL written over a commit already frozen by a recorded acceptance with
+#     no recognised reopen event. That is a fresh reviewer relitigating settled
+#     work, which is the tax itself, and it is refused here rather than argued
+#     about downstream.
 #
 # What it deliberately does NOT do: judge whether the findings are correct. That
 # is not a hook's job and pretending otherwise would make it a gate that cannot
@@ -86,6 +90,11 @@ CLAIMED=$(printf '%s' "$CONTENT" | jq -r '.verdict // empty' 2>/dev/null)
 if [ -n "$CLAIMED" ] && [ "$CLAIMED" != "$ADJUDICATED" ]; then
   echo "BLOCKED: verdict says $CLAIMED, adjudication of its own findings says $ADJUDICATED." >&2
   echo "The critic proposes findings; scripts/adjudicate.py decides the verdict. Never ask the critic whether criticism is complete." >&2
+  if [ "$(printf '%s' "$RESULT" | jq -r '.frozen')" = "true" ]; then
+    echo "This commit was already accepted. Reopening takes new evidence, not a new opinion: one of" >&2
+    echo "  new_failing_input · changed_dependency · missed_requirement · disproven_assumption · profile_changed · owner_promotion" >&2
+    printf '%s' "$RESULT" | jq -r '.finality[]? | "  \(.)"' >&2
+  fi
   printf '%s' "$RESULT" | jq -r '.blocking[]? | "  BLOCK d\(.distance) \(.summary)"' >&2
   exit 2
 fi

--- a/schemas/kernel.acceptance-profile.v1.schema.json
+++ b/schemas/kernel.acceptance-profile.v1.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "kernel.acceptance-profile.v1",
+  "title": "KERNEL acceptance profile",
+  "description": "The context review judges against, stated as structured dimensions rather than prose. Severity is a function of the finding AND this profile, so the same finding is blocking in one context and quarantined in another. A reviewer handed no profile defaults to production rigor every time, because that is the safest-looking answer and it costs the reviewer nothing. Refs ariaxhan/kernel-claude#204.",
+  "type": "object",
+  "required": ["schema", "id", "blocks_at"],
+  "additionalProperties": true,
+  "properties": {
+    "schema": { "const": "kernel.acceptance-profile/v1", "x-kernel-enforced-by": "hook" },
+    "id": {
+      "type": "string",
+      "description": "Stable name for this profile, e.g. 'quantum-demo-2026-08-13'. Recorded in the acceptance so a later profile change is detectable.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "stage": {
+      "enum": ["demo", "prototype", "mvp", "beta", "production"],
+      "description": "DESCRIPTIVE ONLY, never authoritative. It exists so humans can read the profile at a glance and MUST NOT be consulted by adjudication: a demo handling real people's health data still requires production-grade privacy, and a production internal tool may tolerate ugly performance. The dimensions below decide; this label does not.",
+      "x-kernel-enforced-by": "agent"
+    },
+    "users": {
+      "type": "object",
+      "description": "Who is exposed. Real people raise the bar regardless of stage.",
+      "properties": {
+        "who": { "type": "string", "x-kernel-enforced-by": "agent" },
+        "count": { "type": ["integer", "string"], "x-kernel-enforced-by": "agent" },
+        "real_people": { "type": "boolean", "x-kernel-enforced-by": "agent" }
+      },
+      "x-kernel-enforced-by": "agent"
+    },
+    "data_sensitivity": {
+      "enum": ["none", "internal", "personal", "regulated"],
+      "description": "none: synthetic or public. internal: ours only. personal: identifiable people. regulated: health, financial, biometric, or minors.",
+      "x-kernel-enforced-by": "agent"
+    },
+    "lifetime": {
+      "enum": ["throwaway", "days", "weeks", "months", "years"],
+      "description": "How long this must keep working. A maintainability finding means something different at 'throwaway' than at 'years'.",
+      "x-kernel-enforced-by": "agent"
+    },
+    "availability": {
+      "enum": ["none", "best_effort", "business_hours", "always"],
+      "x-kernel-enforced-by": "agent"
+    },
+    "blast_radius": {
+      "enum": ["self", "team", "customers", "public", "irreversible"],
+      "description": "Who is hurt when it goes wrong, and whether it can be undone. 'irreversible' is the one that disqualifies ship-and-watch as an alternative to another review pass.",
+      "x-kernel-enforced-by": "agent"
+    },
+    "scale_target": { "type": "string", "x-kernel-enforced-by": "agent" },
+    "acceptable_failure_modes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Failure modes CONSCIOUSLY accepted for this artifact, e.g. 'crashes on malformed CSV', 'loses unsaved state on refresh'. A finding whose failure_mode matches one of these is quarantined however severe, because someone already decided. Writing it here IS the decision; it is not a place to shrug things off after the fact.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "required_evidence": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Evidence this profile demands before acceptance, e.g. 'walk the demo script 3x', 'contract tests green', 'a real device'. Missing required evidence is reported on the verdict; it never silently passes.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "blocks_at": {
+      "type": "object",
+      "description": "THE AUTHORITATIVE PART. Per dimension, the minimum finding severity that blocks. 'never' means findings on that dimension are quarantined however severe. This is what lets a demo profile set performance:never while still setting privacy:minor, so privacy blocks a demo and a slow render does not. An omitted dimension defaults to 'blocker', the strictest real setting, because silence in a profile must never quietly widen what ships.",
+      "additionalProperties": { "enum": ["nit", "minor", "major", "blocker", "never"] },
+      "properties": {
+        "correctness": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "security": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "privacy": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "data_loss": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "availability": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "performance": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "accessibility": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" },
+        "maintainability": { "enum": ["nit", "minor", "major", "blocker", "never"], "x-kernel-enforced-by": "compiler" }
+      },
+      "x-kernel-enforced-by": "compiler"
+    },
+    "owner": {
+      "type": "string",
+      "description": "Who may promote a quarantined finding to blocking, and who signs an acceptance. Never 'the last agent to speak'.",
+      "x-kernel-enforced-by": "agent"
+    }
+  }
+}

--- a/schemas/kernel.acceptance.v1.schema.json
+++ b/schemas/kernel.acceptance.v1.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "kernel.acceptance.v1",
+  "title": "KERNEL acceptance record",
+  "description": "Res judicata for one exact commit. Records that commit X was accepted under profile Y, with the blind spots declared, the non-blockers known at the time, and the tradeoffs consciously taken. Once recorded, that commit is frozen from ordinary re-review: a fresh reviewer with a new opinion cannot reopen it, only genuinely new evidence can. Without this, every fresh context is a reviewer with amnesia and no cost for relitigating settled questions, which is the single biggest generator of the review tax once severity is fixed. Refs ariaxhan/kernel-claude#204.",
+  "type": "object",
+  "required": ["schema", "commit", "profile_id", "profile_hash", "cannot_falsify", "accepted_at"],
+  "additionalProperties": true,
+  "properties": {
+    "schema": { "const": "kernel.acceptance/v1", "x-kernel-enforced-by": "hook" },
+    "commit": {
+      "type": "string",
+      "description": "The exact commit sha accepted. Acceptance is never inherited by a descendant: a later commit is a different artifact and every fix invalidates part of the evidence collected for the one before it.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "profile_id": { "type": "string", "x-kernel-enforced-by": "compiler" },
+    "profile_hash": {
+      "type": "string",
+      "description": "Hash of the acceptance profile this was judged against. If the profile later changes, the hash stops matching and the acceptance is void, because it was an answer to a question nobody is asking any more.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "accepted_at": { "type": "string", "x-kernel-enforced-by": "agent" },
+    "signer": {
+      "type": "string",
+      "description": "Who said yes. A named authority, never the last agent to speak.",
+      "x-kernel-enforced-by": "agent"
+    },
+    "cannot_falsify": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" },
+      "description": "Carried from the verdict. What nothing in that run could see. A frozen acceptance whose blind spots were never written down is worse than no acceptance, because it looks settled.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "known_non_blockers": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "The quarantined findings known at acceptance time. A later reviewer raising one of these is repeating a settled question, not making a discovery, and adjudication says so by name.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "accepted_tradeoffs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tradeoff", "reason"],
+        "properties": {
+          "tradeoff": { "type": "string", "x-kernel-enforced-by": "agent" },
+          "reason": { "type": "string", "x-kernel-enforced-by": "agent" }
+        },
+        "x-kernel-enforced-by": "agent"
+      },
+      "description": "Decisions taken deliberately, with the reason. Reopening one requires new evidence, not a new opinion.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "reopened": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["event", "detail"],
+        "properties": {
+          "event": {
+            "enum": [
+              "new_failing_input",
+              "changed_dependency",
+              "missed_requirement",
+              "disproven_assumption",
+              "profile_changed",
+              "owner_promotion"
+            ],
+            "x-kernel-enforced-by": "compiler"
+          },
+          "detail": { "type": "string", "x-kernel-enforced-by": "agent" },
+          "at": { "type": "string", "x-kernel-enforced-by": "agent" }
+        },
+        "x-kernel-enforced-by": "compiler"
+      },
+      "description": "The audit trail of legitimate reopens. An empty list on an old acceptance is the normal, healthy state.",
+      "x-kernel-enforced-by": "compiler"
+    }
+  }
+}

--- a/schemas/kernel.verdict.v1.schema.json
+++ b/schemas/kernel.verdict.v1.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "kernel.verdict.v1",
+  "title": "KERNEL review verdict",
+  "description": "A typed review outcome. Findings are proposed by a critic and adjudicated by scripts/adjudicate.py, which the critic does not get to be. Untyped findings cannot be adjudicated, which is why open-ended review never terminates: with everything a free-text string, no policy can be computed over it and the last reviewer to speak wins by default. Refs ariaxhan/kernel-claude#204.",
+  "type": "object",
+  "required": [
+    "schema",
+    "verdict",
+    "cannot_falsify"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schema": {
+      "const": "kernel.verdict/v1",
+      "x-kernel-enforced-by": "hook"
+    },
+    "verdict": {
+      "enum": [
+        "PASS",
+        "FAIL",
+        "INVALID"
+      ],
+      "description": "PASS when no finding clears the block bar. FAIL when at least one does. INVALID when the verdict itself is malformed, most often an empty cannot_falsify. INVALID is not a soft pass: it means nobody may rely on this run.",
+      "x-kernel-enforced-by": "hook"
+    },
+    "objective": {
+      "type": "object",
+      "description": "What the project is for. Severity is a function of the finding AND this. A reviewer given no objective defaults to production rigor every time, because that is the safest-looking answer and it costs the reviewer nothing.",
+      "properties": {
+        "statement": {
+          "type": "string",
+          "x-kernel-enforced-by": "agent"
+        },
+        "tier": {
+          "enum": [
+            "demo",
+            "real",
+            "critical"
+          ],
+          "description": "demo: survive one scripted walkthrough on a date; off-script findings are quarantine by definition. real: people depend on it, mistakes recoverable. critical: money, health, privacy, irreversible; here the review tax is worth paying.",
+          "x-kernel-enforced-by": "agent"
+        },
+        "date": {
+          "type": "string",
+          "x-kernel-enforced-by": "agent"
+        }
+      },
+      "x-kernel-enforced-by": "agent"
+    },
+    "cannot_falsify": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      },
+      "description": "MANDATORY and non-empty on every verdict, PASS or FAIL. What no instrument in this run could structurally see, plus every claim whose instrument did not finish. Silence about coverage reads as coverage. Two flagship gates in this ecosystem printed PASS for weeks because ripgrep was not installed; the exit code was swallowed and nothing said so.",
+      "x-kernel-enforced-by": "hook"
+    },
+    "blocking": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/finding"
+      },
+      "x-kernel-enforced-by": "compiler"
+    },
+    "quarantined": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/finding"
+      },
+      "x-kernel-enforced-by": "compiler"
+    },
+    "escalate": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/finding"
+      },
+      "description": "Findings that could be neither reproduced nor refuted. They do not block by default and they do not vanish either: the signer waives in writing or blocks. This exists because an interrupted verification otherwise reads as a neutral absence.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "x-kernel-enforced-by": "compiler"
+    },
+    "counts": {
+      "type": "object",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "validation_rate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "x-kernel-enforced-by": "compiler"
+    }
+  },
+  "definitions": {
+    "finding": {
+      "type": "object",
+      "required": [
+        "summary",
+        "severity",
+        "distance",
+        "validated"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "summary": {
+          "type": "string",
+          "x-kernel-enforced-by": "agent"
+        },
+        "severity": {
+          "enum": [
+            "blocker",
+            "major",
+            "minor",
+            "nit"
+          ],
+          "description": "Only blocker may block. Ten phases each able to veto independently is flat severity, and flat severity selects for weak instruments: when every finding blocks, the cheapest way to keep shipping is an instrument that finds little.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "distance": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Assumptions outside this change that must be challenged for the finding to matter. 0 the changed code fails; 1 violates a declared invariant; 2 pre-existing defect this change exposed; 3+ needs outside assumptions. Distance sets a PROOF THRESHOLD, never a veto ceiling: the highest-value review on record was distance-3, and a hard cutoff would have auto-closed it.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "validated": {
+          "enum": [
+            "proven",
+            "refuted",
+            "pending",
+            "unverifiable"
+          ],
+          "description": "Criticism is not evidence. Only proven may block. unverifiable routes to escalate, never to silence.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "on_objective": {
+          "type": "boolean",
+          "description": "Does this affect what the project is actually for? Off-objective never blocks however real, proven and distance-0 it is.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "observable": {
+          "type": "string",
+          "description": "The stopping wager: predict a specific failure and how we would see it. No observable, no block. Scored WITH distance, never instead of it, since a far-fetched observable is cheap to invent.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "repro": {
+          "type": "string",
+          "description": "Pasted output from an executed command. Not a described procedure, not a reading of the code.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "consequence": {
+          "type": "string",
+          "description": "Required at distance 2: the user-visible cost of the pre-existing defect this change exposed.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "evidence_kind": {
+          "enum": [
+            "executed_demonstration",
+            "cited_prior_failure",
+            "observed_outcome"
+          ],
+          "description": "Required at distance 3+. Taste never clears this bar; a playtest record does.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "instrument": {
+          "type": "string",
+          "description": "The exact command that tests this.",
+          "x-kernel-enforced-by": "agent"
+        },
+        "invalidated_by": {
+          "type": "string",
+          "description": "The diff that voids this evidence. Claims expire on a diff, not a timer.",
+          "x-kernel-enforced-by": "agent"
+        },
+        "issue": {
+          "type": "string",
+          "description": "Issue number once filed. Quarantined findings live in the issue tracker with a distance label, not in a parallel document.",
+          "x-kernel-enforced-by": "agent"
+        },
+        "routed": {
+          "enum": [
+            "blocking",
+            "quarantine",
+            "escalate"
+          ],
+          "x-kernel-enforced-by": "compiler"
+        },
+        "not_blocking_because": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-kernel-enforced-by": "compiler"
+        }
+      }
+    }
+  }
+}

--- a/schemas/kernel.verdict.v1.schema.json
+++ b/schemas/kernel.verdict.v1.schema.json
@@ -96,6 +96,90 @@
         "null"
       ],
       "x-kernel-enforced-by": "compiler"
+    },
+    "profile": {
+      "$ref": "kernel.acceptance-profile.v1",
+      "description": "The acceptance profile this run judged against. Its blocks_at map decides the blocking threshold per dimension, replacing the blocker-only fallback used when no profile exists. Absent means the evidence bar alone decides, which is the pre-profile behaviour.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "commit": {
+      "type": "string",
+      "description": "The exact commit under review. Required for finality: acceptance is never inherited by a descendant commit.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "acceptance": {
+      "$ref": "kernel.acceptance.v1",
+      "description": "A prior acceptance covering this commit. Present means the commit is frozen from ordinary re-review and findings cannot produce a FAIL without a recognised reopen event.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "reopen": {
+      "type": "object",
+      "required": [
+        "event",
+        "detail"
+      ],
+      "properties": {
+        "event": {
+          "enum": [
+            "new_failing_input",
+            "changed_dependency",
+            "missed_requirement",
+            "disproven_assumption",
+            "profile_changed",
+            "owner_promotion"
+          ],
+          "description": "The only events that reopen a frozen acceptance. A fresh reviewer, a rephrased concern, or a different architectural preference is deliberately absent: those are what an amnesiac critic generates for free.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "detail": {
+          "type": "string",
+          "description": "What is actually new. An event with no detail is refused and the commit stays frozen.",
+          "x-kernel-enforced-by": "compiler"
+        }
+      },
+      "description": "A claim that this run is entitled to reopen a frozen acceptance.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Evidence actually gathered this run, matched against the profile's required_evidence. Anything required and missing is reported on the verdict rather than silently passing.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "frozen": {
+      "type": "boolean",
+      "description": "Set by adjudication, never by the author.",
+      "x-kernel-enforced-by": "compiler"
+    },
+    "finality": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "x-kernel-enforced-by": "compiler"
+    },
+    "missing_required_evidence": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "x-kernel-enforced-by": "compiler"
+    },
+    "profile_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "x-kernel-enforced-by": "compiler"
+    },
+    "profile_hash": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "x-kernel-enforced-by": "compiler"
     }
   },
   "definitions": {
@@ -196,6 +280,16 @@
           "items": {
             "type": "string"
           },
+          "x-kernel-enforced-by": "compiler"
+        },
+        "dimension": {
+          "type": "string",
+          "description": "Which acceptance dimension this finding lives on (correctness, security, privacy, data_loss, availability, performance, accessibility, maintainability, ...). The profile's blocks_at map is keyed by this. Defaults to 'correctness' when absent, and an unlisted dimension defaults to the strictest setting rather than the most permissive.",
+          "x-kernel-enforced-by": "compiler"
+        },
+        "failure_mode": {
+          "type": "string",
+          "description": "The concrete way this fails. If it matches one of the profile's acceptable_failure_modes it is quarantined however severe, because someone already decided in writing.",
           "x-kernel-enforced-by": "compiler"
         }
       }

--- a/scripts/adjudicate.py
+++ b/scripts/adjudicate.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""KERNEL verdict adjudicator: the critic proposes, this decides.
+
+    python3 scripts/adjudicate.py findings.json          # -> verdict JSON on stdout
+    python3 scripts/adjudicate.py findings.json --strict  # exit 1 if the verdict is FAIL
+
+Why this is code and not a prompt
+--------------------------------
+Review has no natural stopping condition. An agent asked to find problems answers "can I find
+anything else?", never "is this shippable?", so the loop never closes. The fix is not a better
+reviewer, it is an acceptance function that the reviewer does not get to be.
+
+Three defect classes this exists to kill, each bought with a real incident:
+
+1. Flat severity. Ten review phases each able to veto independently means every finding blocks,
+   and when every finding blocks the cheapest way to keep shipping is an instrument that finds
+   little. Flat severity selects for weak instruments.
+2. A distance cutoff that suppresses the best reviews. The highest-value review in this ecosystem
+   (2026-08-03, "buried it under a genre with no market") was distance-3. A hard "distance >= 2
+   cannot block" rule auto-closes it. So distance sets a PROOF THRESHOLD, never a veto ceiling.
+3. Silent coverage. A gate that passes without declaring what it could not check reads as
+   coverage. An unfinished instrument is red, never neutral: "we could not reproduce it" and
+   "it is not a problem" are different sentences.
+
+Refs: ariaxhan/kernel-claude#204.
+"""
+
+import argparse
+import json
+import sys
+
+SCHEMA = "kernel.verdict/v1"
+
+# distance -> what that finding must carry before it may block.
+# Distance never decides WHETHER a finding may block, only how much proof it needs.
+PROOF = {
+    0: ("repro",),                        # the changed code fails: pasted output
+    1: ("repro",),                        # violates a declared invariant: pasted output
+    2: ("repro", "consequence"),          # pre-existing, exposed here: needs a user-visible cost
+    3: ("repro", "evidence_kind"),        # outside assumptions: needs hard evidence, not taste
+}
+
+# What counts as hard evidence at distance 3+. Taste never clears this bar; a playtest record does.
+STRONG_EVIDENCE = {"executed_demonstration", "cited_prior_failure", "observed_outcome"}
+
+BLOCKING_SEVERITY = {"blocker"}
+
+
+def _norm_distance(value):
+    """Distance 4+ is treated as 3: the proof bar does not keep rising, it saturates."""
+    try:
+        d = int(value)
+    except (TypeError, ValueError):
+        return None
+    return 3 if d > 3 else (d if d >= 0 else None)
+
+
+def evaluate(finding):
+    """Return (blocks: bool, reasons: list[str]). Reasons explain a REFUSAL to block."""
+    reasons = []
+
+    if finding.get("severity") not in BLOCKING_SEVERITY:
+        reasons.append(f"severity {finding.get('severity')!r} is not blocking")
+
+    if finding.get("on_objective") is not True:
+        reasons.append("off-objective: real, but not what this project is for")
+
+    validated = finding.get("validated")
+    if validated != "proven":
+        reasons.append(f"validated={validated!r}; criticism is not evidence")
+
+    if not str(finding.get("observable") or "").strip():
+        reasons.append("no observable failure named (the stopping wager)")
+
+    distance = _norm_distance(finding.get("distance"))
+    if distance is None:
+        reasons.append("distance missing or malformed")
+    else:
+        for field in PROOF[distance]:
+            value = finding.get(field)
+            if field == "evidence_kind":
+                if value not in STRONG_EVIDENCE:
+                    reasons.append(
+                        f"distance {finding.get('distance')} needs evidence_kind in "
+                        f"{sorted(STRONG_EVIDENCE)}, got {value!r}"
+                    )
+            elif not str(value or "").strip():
+                reasons.append(f"distance {finding.get('distance')} requires {field}")
+
+    return (not reasons), reasons
+
+
+def adjudicate(doc):
+    findings = doc.get("findings") or []
+    cannot_falsify = [c for c in (doc.get("cannot_falsify") or []) if str(c).strip()]
+
+    blocking, quarantined, escalate = [], [], []
+    for finding in findings:
+        entry = dict(finding)
+        if finding.get("validated") == "unverifiable":
+            # Neither reproduced nor refuted. It does not block by default and it does not vanish
+            # into a backlog either; the signer waives in writing or blocks. Silence is not an
+            # option, because that is how an interrupted check becomes a pass.
+            entry["routed"] = "escalate"
+            escalate.append(entry)
+            continue
+        blocks, reasons = evaluate(finding)
+        if blocks:
+            entry["routed"] = "blocking"
+            blocking.append(entry)
+        else:
+            entry["routed"] = "quarantine"
+            entry["not_blocking_because"] = reasons
+            quarantined.append(entry)
+
+    errors = []
+    if not cannot_falsify:
+        # Enforced on every verdict, not only on PASS: a FAIL with unknown coverage is still a
+        # claim about the world. Silence about coverage reads as coverage.
+        errors.append(
+            "cannot_falsify is empty. State what no instrument here could see, "
+            "or the verdict is not a verdict."
+        )
+
+    verdict = "FAIL" if blocking else "PASS"
+    if errors:
+        verdict = "INVALID"
+
+    return {
+        "schema": SCHEMA,
+        "verdict": verdict,
+        "objective": doc.get("objective"),
+        "blocking": blocking,
+        "quarantined": quarantined,
+        "escalate": escalate,
+        "cannot_falsify": cannot_falsify,
+        "errors": errors,
+        "counts": {
+            "proposed": len(findings),
+            "blocking": len(blocking),
+            "quarantined": len(quarantined),
+            "escalate": len(escalate),
+        },
+        # Yield weighted by consequence, not count: a pass returning one blocker is worth more
+        # than one returning nine nits, and a raw count would have stopped the genre review.
+        "validation_rate": round(
+            sum(1 for f in findings if f.get("validated") == "proven") / len(findings), 3
+        ) if findings else None,
+    }
+
+
+def render(result):
+    lines = [f"ADVERSARY: {result['verdict']}"]
+    for f in result["blocking"]:
+        lines.append(f"  BLOCK  d{f.get('distance')} {f.get('summary','(no summary)')}")
+    for f in result["escalate"]:
+        lines.append(f"  ESCALATE (unverifiable) {f.get('summary','(no summary)')}")
+    for f in result["quarantined"]:
+        lines.append(f"  quarantine  {f.get('summary','(no summary)')}")
+        for r in f.get("not_blocking_because", []):
+            lines.append(f"      - {r}")
+    lines.append("CANNOT FALSIFY:")
+    for c in result["cannot_falsify"] or ["  (NONE DECLARED - this verdict is INVALID)"]:
+        lines.append(f"  - {c}")
+    for e in result["errors"]:
+        lines.append(f"ERROR: {e}")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("findings", help="path to a findings JSON document, or - for stdin")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 on FAIL, 2 on INVALID (for use as a gate)")
+    ap.add_argument("--text", action="store_true", help="human-readable output instead of JSON")
+    args = ap.parse_args(argv)
+
+    raw = sys.stdin.read() if args.findings == "-" else open(args.findings).read()
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: findings document is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    result = adjudicate(doc)
+    print(render(result) if args.text else json.dumps(result, indent=2))
+
+    if args.strict:
+        if result["verdict"] == "INVALID":
+            return 2
+        if result["verdict"] == "FAIL":
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/adjudicate.py
+++ b/scripts/adjudicate.py
@@ -22,14 +22,46 @@ Three defect classes this exists to kill, each bought with a real incident:
    coverage. An unfinished instrument is red, never neutral: "we could not reproduce it" and
    "it is not a problem" are different sentences.
 
+Two later additions, same shape:
+
+4. Context-blind severity. A finding's weight depends on what the artifact IS. An acceptance
+   profile (kernel.acceptance-profile/v1) states that context in structured dimensions, and a
+   finding must clear the evidence bar AND violate the profile to block. The stage label is
+   deliberately NOT consulted: a demo handling real people's data still requires production-grade
+   privacy.
+5. No finality. Every fresh context was a reviewer with amnesia, free to relitigate settled
+   questions. An acceptance record (kernel.acceptance/v1) freezes one exact commit under one exact
+   profile; reopening takes a recognised event, not a new opinion.
+
 Refs: ariaxhan/kernel-claude#204.
 """
 
 import argparse
+import hashlib
 import json
 import sys
 
 SCHEMA = "kernel.verdict/v1"
+
+# Severity ladder. A profile names the minimum severity that blocks per dimension, so the same
+# finding is blocking in one context and quarantined in another without anyone editing the finding.
+SEVERITY_ORDER = ["nit", "minor", "major", "blocker"]
+
+# An omitted dimension defaults to the strictest real setting. Silence in a profile must never
+# quietly widen what ships, which is the failure mode of every "we'll decide later" severity.
+DEFAULT_BLOCKS_AT = "blocker"
+
+# The only events that may reopen a frozen acceptance. A fresh reviewer, a rephrased concern, or a
+# different architectural preference is deliberately not on this list: those are exactly what an
+# amnesiac critic produces for free, and letting them reopen settled work is the tax.
+REOPEN_EVENTS = {
+    "new_failing_input",
+    "changed_dependency",
+    "missed_requirement",
+    "disproven_assumption",
+    "profile_changed",
+    "owner_promotion",
+}
 
 # distance -> what that finding must carry before it may block.
 # Distance never decides WHETHER a finding may block, only how much proof it needs.
@@ -46,6 +78,48 @@ STRONG_EVIDENCE = {"executed_demonstration", "cited_prior_failure", "observed_ou
 BLOCKING_SEVERITY = {"blocker"}
 
 
+def profile_hash(profile):
+    """Stable hash of the judged-against context. A changed profile voids an old acceptance."""
+    if not profile:
+        return None
+    material = {k: v for k, v in profile.items() if k not in ("schema", "owner")}
+    return hashlib.sha256(
+        json.dumps(material, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:16]
+
+
+def violates_profile(finding, profile):
+    """Return (violates: bool, reason: str|None).
+
+    Without a profile this returns True unconditionally, preserving the pre-profile behaviour:
+    the bar alone decides. That is deliberate back-compat, not a default-open, because the
+    evidence/distance/observable bar still has to be cleared either way.
+    """
+    if not profile:
+        return True, None
+
+    dimension = finding.get("dimension") or "correctness"
+    mode = finding.get("failure_mode")
+    accepted = profile.get("acceptable_failure_modes") or []
+    if mode and mode in accepted:
+        # Someone already decided this one, in writing, before the review ran.
+        return False, f"failure mode {mode!r} is an accepted failure mode of this profile"
+
+    blocks_at = (profile.get("blocks_at") or {}).get(dimension, DEFAULT_BLOCKS_AT)
+    if blocks_at == "never":
+        return False, f"profile tolerates any {dimension} finding (blocks_at: never)"
+
+    severity = finding.get("severity")
+    if severity not in SEVERITY_ORDER or blocks_at not in SEVERITY_ORDER:
+        return False, f"profile requires {dimension} >= {blocks_at}, got severity {severity!r}"
+
+    if SEVERITY_ORDER.index(severity) < SEVERITY_ORDER.index(blocks_at):
+        return False, (
+            f"profile blocks {dimension} only at {blocks_at} or above; this is {severity}"
+        )
+    return True, None
+
+
 def _norm_distance(value):
     """Distance 4+ is treated as 3: the proof bar does not keep rising, it saturates."""
     try:
@@ -55,11 +129,21 @@ def _norm_distance(value):
     return 3 if d > 3 else (d if d >= 0 else None)
 
 
-def evaluate(finding):
-    """Return (blocks: bool, reasons: list[str]). Reasons explain a REFUSAL to block."""
+def evaluate(finding, profile=None):
+    """Return (blocks: bool, reasons: list[str]). Reasons explain a REFUSAL to block.
+
+    Two independent gates, both required. The evidence bar asks "is this finding real enough to
+    act on"; the profile asks "does it matter for THIS artifact". A proven distance-0 blocker that
+    the profile tolerates is still not a blocker, and a finding the profile cares about deeply is
+    still not a blocker without evidence.
+    """
     reasons = []
 
-    if finding.get("severity") not in BLOCKING_SEVERITY:
+    if not profile and finding.get("severity") not in BLOCKING_SEVERITY:
+        # With no profile, "only blocker blocks" is the fallback threshold. That constant was
+        # always a stand-in for a profile nobody had written: once one exists, the owner declares
+        # the blocking threshold per dimension and violates_profile() applies it. Still a
+        # threshold, still one level, just a declared one instead of a hardcoded one.
         reasons.append(f"severity {finding.get('severity')!r} is not blocking")
 
     if finding.get("on_objective") is not True:
@@ -87,12 +171,70 @@ def evaluate(finding):
             elif not str(value or "").strip():
                 reasons.append(f"distance {finding.get('distance')} requires {field}")
 
+    ok, why = violates_profile(finding, profile)
+    if not ok:
+        reasons.append(why)
+
     return (not reasons), reasons
+
+
+def check_finality(doc):
+    """Is this commit frozen by a prior acceptance, and if so may this run reopen it?
+
+    Returns (frozen: bool, notes: list[str]). Frozen means ordinary re-review is refused: the
+    findings still get adjudicated and reported, but they cannot produce a FAIL, because a fresh
+    reviewer with no new evidence is not a new fact about the world.
+    """
+    acceptance = doc.get("acceptance")
+    if not acceptance:
+        return False, []
+
+    notes = []
+    commit = doc.get("commit")
+    if commit and acceptance.get("commit") and commit != acceptance["commit"]:
+        # Acceptance is never inherited. A later commit is a different artifact.
+        return False, [
+            f"acceptance covers {acceptance['commit'][:12]}, this is {commit[:12]}: not frozen"
+        ]
+
+    current = profile_hash(doc.get("profile"))
+    recorded = acceptance.get("profile_hash")
+    if current and recorded and current != recorded:
+        # The profile it was judged against no longer exists, so the answer no longer applies.
+        return False, [
+            f"acceptance profile changed ({recorded} -> {current}): prior acceptance is void, "
+            "re-review is required rather than merely permitted"
+        ]
+
+    event = (doc.get("reopen") or {}).get("event")
+    if event:
+        if event in REOPEN_EVENTS:
+            detail = (doc.get("reopen") or {}).get("detail") or ""
+            if not str(detail).strip():
+                return True, [f"reopen event {event!r} carries no detail: refused, still frozen"]
+            return False, [f"reopened on {event}: {detail}"]
+        return True, [
+            f"{event!r} is not a reopen event. Recognised: {sorted(REOPEN_EVENTS)}. "
+            "A new reviewer, a rephrased concern, or a different architectural preference is not "
+            "new evidence."
+        ]
+
+    return True, [
+        f"commit {acceptance.get('commit', '?')[:12]} was accepted under profile "
+        f"{acceptance.get('profile_id', '?')!r} at {acceptance.get('accepted_at', '?')}. "
+        "Frozen from ordinary re-review; reopening requires new evidence, not a new opinion."
+    ]
 
 
 def adjudicate(doc):
     findings = doc.get("findings") or []
+    profile = doc.get("profile")
     cannot_falsify = [c for c in (doc.get("cannot_falsify") or []) if str(c).strip()]
+    frozen, finality_notes = check_finality(doc)
+    settled = {
+        str(f.get("summary", "")).strip().lower()
+        for f in ((doc.get("acceptance") or {}).get("known_non_blockers") or [])
+    }
 
     blocking, quarantined, escalate = [], [], []
     for finding in findings:
@@ -104,7 +246,13 @@ def adjudicate(doc):
             entry["routed"] = "escalate"
             escalate.append(entry)
             continue
-        blocks, reasons = evaluate(finding)
+        blocks, reasons = evaluate(finding, profile)
+        if blocks and str(finding.get("summary", "")).strip().lower() in settled:
+            blocks = False
+            reasons = ["already a known non-blocker in the acceptance record for this commit"]
+        if blocks and frozen:
+            blocks = False
+            reasons = ["commit is frozen by a recorded acceptance; no recognised reopen event"]
         if blocks:
             entry["routed"] = "blocking"
             blocking.append(entry)
@@ -122,6 +270,14 @@ def adjudicate(doc):
             "or the verdict is not a verdict."
         )
 
+    missing_evidence = []
+    if profile:
+        supplied = {str(e).strip().lower() for e in (doc.get("evidence") or [])}
+        missing_evidence = [
+            e for e in (profile.get("required_evidence") or [])
+            if str(e).strip().lower() not in supplied
+        ]
+
     verdict = "FAIL" if blocking else "PASS"
     if errors:
         verdict = "INVALID"
@@ -130,6 +286,11 @@ def adjudicate(doc):
         "schema": SCHEMA,
         "verdict": verdict,
         "objective": doc.get("objective"),
+        "profile_id": (profile or {}).get("id"),
+        "profile_hash": profile_hash(profile),
+        "frozen": frozen,
+        "finality": finality_notes,
+        "missing_required_evidence": missing_evidence,
         "blocking": blocking,
         "quarantined": quarantined,
         "escalate": escalate,
@@ -151,6 +312,14 @@ def adjudicate(doc):
 
 def render(result):
     lines = [f"ADVERSARY: {result['verdict']}"]
+    if result.get("profile_id"):
+        lines.append(f"  profile: {result['profile_id']} ({result.get('profile_hash')})")
+    if result.get("frozen"):
+        lines.append("  FROZEN: this commit was already accepted. Ordinary re-review refused.")
+    for note in result.get("finality") or []:
+        lines.append(f"    {note}")
+    for missing in result.get("missing_required_evidence") or []:
+        lines.append(f"  MISSING REQUIRED EVIDENCE: {missing}")
     for f in result["blocking"]:
         lines.append(f"  BLOCK  d{f.get('distance')} {f.get('summary','(no summary)')}")
     for f in result["escalate"]:

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -51,6 +51,7 @@ HOOK_BINDINGS = [
     {"event": "PreToolUse", "matcher": "Write|Edit", "script": "detect-secrets.sh", "timeout": 5},
     {"event": "PreToolUse", "matcher": "Write|Edit", "script": "validate-structure.sh", "timeout": 5},
     {"event": "PreToolUse", "matcher": "Write|Edit", "script": "warn-hardcoded.sh", "timeout": 5},
+    {"event": "PreToolUse", "matcher": "Write|Edit", "script": "verdict-gate.sh", "timeout": 10},
     {"event": "PreToolUse", "matcher": "Read|Grep|Glob", "script": "guard-context.sh", "timeout": 5},
     {"event": "PermissionRequest", "matcher": "Bash", "script": "auto-approve-safe.sh", "timeout": 5},
     {"event": "PostToolUse", "matcher": "WebFetch|WebSearch|mcp__.*", "script": "scan-output.sh", "timeout": 10},

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -156,14 +156,19 @@ A finding blocks only with ALL of:
    executed demonstration or a cited prior failure. Never auto-close d3; taste never clears it,
    a real outcome does.
 3. a named observable failure: predict what breaks and how we would see it
-4. on-objective: a production-hardening finding on a demo is not a blocker however real it is
+4. violates the acceptance profile: tag the finding's `dimension`, and let the profile's
+   `blocks_at` map decide the threshold for that dimension. A production-hardening finding on a
+   demo is not a blocker however real it is, and a privacy finding on a demo IS one when the
+   profile says so. The `stage` label never decides; the dimensions do.
 
 Everything else is filed with its `distance:N` label under the `quarantine` milestone. Recurrence
 is signal, silence is a verdict.
 </block_bar>
 
 Read the acceptance record before reviewing: claims, declared invariants, and tradeoffs already
-accepted. Reopening a settled entry takes new evidence of a named kind, never a new opinion.
+accepted. If the commit carries one, it is FROZEN and adjudication will refuse a FAIL. Reopening
+takes `new_failing_input`, `changed_dependency`, `missed_requirement`, `disproven_assumption`,
+`profile_changed`, or `owner_promotion`. A new reviewer is not a reopen event.
 Never ask a reviewer whether criticism is complete; it cannot answer and will always say no.
 </verdict_rules>
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -135,9 +135,36 @@ Summary: APPROVE | REQUEST CHANGES | COMMENT
 </ask_user>
 
 <verdict_rules>
-- **APPROVE**: No critical or high issues
-- **REQUEST CHANGES**: Any critical or high issue
-- **COMMENT**: Only medium/low issues
+Review is finite because its purpose is AUTHORIZATION, not exhaustion. Approve once the change
+improves the health of the codebase, not once nothing else can be found. Nothing else can ever
+be found. (#204)
+
+- **APPROVE**: no finding clears the block bar. **Open non-blocking comments do NOT prevent
+  APPROVE** — say the issue number out loud and approve. Forcing another round to re-check a nit
+  costs more than the nit.
+- **REQUEST CHANGES**: at least one finding clears the block bar below.
+- **COMMENT**: findings worth saying, none blocking, and the author asked for a read rather than
+  a decision.
+
+<block_bar>
+A finding blocks only with ALL of:
+1. pasted output, not a described procedure
+2. a distance proof threshold cleared — distance sets how much evidence is needed, never whether
+   a finding may block:
+   d0 changed code fails · d1 violates a declared invariant · d2 pre-existing defect this change
+   exposed, needs a user-visible consequence · d3+ needs outside assumptions, blocks only on an
+   executed demonstration or a cited prior failure. Never auto-close d3; taste never clears it,
+   a real outcome does.
+3. a named observable failure: predict what breaks and how we would see it
+4. on-objective: a production-hardening finding on a demo is not a blocker however real it is
+
+Everything else is filed with its `distance:N` label under the `quarantine` milestone. Recurrence
+is signal, silence is a verdict.
+</block_bar>
+
+Read the acceptance record before reviewing: claims, declared invariants, and tradeoffs already
+accepted. Reopening a settled entry takes new evidence of a named kind, never a new opinion.
+Never ask a reviewer whether criticism is complete; it cannot answer and will always say no.
 </verdict_rules>
 
 <on_complete>

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -168,9 +168,17 @@ Never ask a reviewer whether criticism is complete; it cannot answer and will al
 </verdict_rules>
 
 <on_complete>
+Emit findings as a `kernel.verdict/v1` document and let the acceptance function decide. The
+reviewer never grades its own completeness.
+
 ```bash
-agentdb write-end '{"command":"review","verdict":"X","critical":N,"high":N,"big5_violations":N}'
+python3 scripts/adjudicate.py findings.json --text --strict   # 0 PASS · 1 FAIL · 2 INVALID
+agentdb write-end '{"command":"review","verdict":"X","critical":N,"high":N,"big5_violations":N,"quarantined":N}'
 ```
+
+`cannot_falsify` is mandatory and non-empty. State what this review structurally could not see
+(no real device, conformance only, no live data, a suite that did not finish). Silence about
+coverage reads as coverage.
 </on_complete>
 
 </skill>

--- a/tests/corpus/cases.json
+++ b/tests/corpus/cases.json
@@ -384,6 +384,58 @@
           "command": "{{COMMIT_THEN_REAL_COMMAND}}"
         }
       }
+    },
+    {
+      "id": "verdict-gate/blocks-verdict-with-no-declared-blind-spots",
+      "gate": "verdict-gate",
+      "expect": "block",
+      "why": "A PASS that declares nothing it could not check is the fail-dark class wearing a verdict. Two flagship gates in this ecosystem printed PASS for weeks because ripgrep was missing; silence about coverage reads as coverage.",
+      "input": {
+        "tool_name": "Write",
+        "tool_input": {
+          "file_path": "/tmp/verdict.json",
+          "content": "{\"schema\": \"kernel.verdict/v1\", \"verdict\": \"PASS\", \"cannot_falsify\": [], \"findings\": [{\"summary\": \"all checks green\", \"severity\": \"nit\", \"distance\": 0, \"validated\": \"proven\", \"on_objective\": true}]}"
+        }
+      }
+    },
+    {
+      "id": "verdict-gate/blocks-pass-over-its-own-blocking-finding",
+      "gate": "verdict-gate",
+      "expect": "block",
+      "why": "The critic proposes findings; adjudication decides the verdict. An agent writing PASS over a proven distance-0 blocker with pasted output is the reviewer grading its own homework.",
+      "input": {
+        "tool_name": "Write",
+        "tool_input": {
+          "file_path": "/tmp/verdict.json",
+          "content": "{\"schema\": \"kernel.verdict/v1\", \"verdict\": \"PASS\", \"cannot_falsify\": [\"conformance only\"], \"findings\": [{\"summary\": \"auth accepts an expired token\", \"severity\": \"blocker\", \"distance\": 0, \"validated\": \"proven\", \"on_objective\": true, \"observable\": \"expired JWT returns 200\", \"repro\": \"$ curl -H 'Authorization: Bearer <expired>' /me\\n200 OK\"}]}"
+        }
+      }
+    },
+    {
+      "id": "verdict-gate/allows-honest-pass-with-quarantined-nit",
+      "gate": "verdict-gate",
+      "expect": "allow",
+      "why": "APPROVE must stay reachable with open non-blocking comments, or the gate recreates the tax it exists to end. A nit quarantines and the verdict is still PASS.",
+      "input": {
+        "tool_name": "Write",
+        "tool_input": {
+          "file_path": "/tmp/verdict.json",
+          "content": "{\"schema\": \"kernel.verdict/v1\", \"verdict\": \"PASS\", \"cannot_falsify\": [\"no real device: software keyboard and focus zoom are outside every instrument here\"], \"findings\": [{\"summary\": \"naming could be clearer\", \"severity\": \"nit\", \"distance\": 1, \"validated\": \"pending\", \"on_objective\": true}]}"
+        }
+      }
+    },
+    {
+      "id": "verdict-gate/allows-unrelated-write",
+      "gate": "verdict-gate",
+      "expect": "allow",
+      "why": "Armed by payload only. A file that does not declare kernel.verdict/v1 is none of this gate's business.",
+      "input": {
+        "tool_name": "Write",
+        "tool_input": {
+          "file_path": "/tmp/notes.md",
+          "content": "# just some notes\n"
+        }
+      }
     }
   ]
 }

--- a/tests/corpus/cases.json
+++ b/tests/corpus/cases.json
@@ -436,6 +436,32 @@
           "content": "# just some notes\n"
         }
       }
+    },
+    {
+      "id": "verdict-gate/blocks-reopening-a-frozen-acceptance",
+      "gate": "verdict-gate",
+      "expect": "block",
+      "why": "A fresh reviewer with an architectural preference relitigating an already-accepted commit is the review tax in its purest form. Reopening takes new evidence, not a new opinion, and the refusal happens here rather than in an argument downstream.",
+      "input": {
+        "tool_name": "Write",
+        "tool_input": {
+          "file_path": "/tmp/verdict.json",
+          "content": "{\"schema\": \"kernel.verdict/v1\", \"verdict\": \"FAIL\", \"commit\": \"abc123def456\", \"profile\": {\"schema\": \"kernel.acceptance-profile/v1\", \"id\": \"matra-production\", \"stage\": \"production\", \"blocks_at\": {\"correctness\": \"major\", \"privacy\": \"nit\", \"performance\": \"major\"}}, \"cannot_falsify\": [\"conformance only\"], \"acceptance\": {\"schema\": \"kernel.acceptance/v1\", \"commit\": \"abc123def456\", \"profile_id\": \"matra-production\", \"profile_hash\": \"0b785547474ccfd2\", \"accepted_at\": \"2026-08-11T00:00:00Z\", \"signer\": \"aria\", \"cannot_falsify\": [\"conformance only\"]}, \"findings\": [{\"summary\": \"I would have structured the module differently\", \"severity\": \"blocker\", \"distance\": 1, \"validated\": \"proven\", \"on_objective\": true, \"dimension\": \"correctness\", \"observable\": \"harder to extend later\", \"repro\": \"$ read the file\\nit is long\"}]}"
+        }
+      }
+    },
+    {
+      "id": "verdict-gate/allows-pass-when-the-profile-tolerates-the-dimension",
+      "gate": "verdict-gate",
+      "expect": "allow",
+      "why": "A demo profile setting performance:never must let a proven, distance-0, major performance finding quarantine rather than block. Same finding, different context, different correct answer.",
+      "input": {
+        "tool_name": "Write",
+        "tool_input": {
+          "file_path": "/tmp/verdict.json",
+          "content": "{\"schema\": \"kernel.verdict/v1\", \"verdict\": \"PASS\", \"profile\": {\"schema\": \"kernel.acceptance-profile/v1\", \"id\": \"quantum-demo\", \"stage\": \"demo\", \"blocks_at\": {\"correctness\": \"blocker\", \"privacy\": \"minor\", \"performance\": \"never\"}}, \"cannot_falsify\": [\"no real device\"], \"findings\": [{\"summary\": \"first paint takes 4.2s\", \"severity\": \"major\", \"distance\": 0, \"validated\": \"proven\", \"on_objective\": true, \"dimension\": \"performance\", \"observable\": \"LCP 4.2s\", \"repro\": \"$ lighthouse\\nLCP 4200ms\"}]}"
+        }
+      }
     }
   ]
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -132,6 +132,12 @@ test_generated_governance() {
   python3 "$PLUGIN_ROOT/tests/test_governance.py"
 }
 
+# The acceptance function (#204). Review has no natural stopping condition, so the verdict is
+# decided by scripts/adjudicate.py rather than by the critic that produced the findings.
+test_verdict_adjudication() {
+  python3 "$PLUGIN_ROOT/tests/test_adjudicate.py"
+}
+
 test_agentdb_init_idempotent() {
   agentdb init >/dev/null
   local output
@@ -5070,6 +5076,7 @@ run_test_suite() {
   case "$suite" in
     governance)
       run_test "generated governance adapters and operator" test_generated_governance
+      run_test "verdict adjudication: the acceptance function" test_verdict_adjudication
       ;;
     knowledge_graph)
       run_test "knowledge-graph SKILL.md exists + explains orientation cost" test_knowledge_graph_skill_exists

--- a/tests/test_adjudicate.py
+++ b/tests/test_adjudicate.py
@@ -31,8 +31,11 @@ def finding(**kw):
     return base
 
 
-def doc(*findings, cannot_falsify=("conformance only",)):
-    return {"cannot_falsify": list(cannot_falsify), "findings": list(findings)}
+def doc(*findings, cannot_falsify=("conformance only",), evidence=None):
+    d = {"cannot_falsify": list(cannot_falsify), "findings": list(findings)}
+    if evidence is not None:
+        d["evidence"] = list(evidence)
+    return d
 
 
 class BlockBar(unittest.TestCase):
@@ -128,6 +131,213 @@ class Termination(unittest.TestCase):
         r = adjudicate.adjudicate(doc(*[finding(severity="nit", summary=f"n{i}") for i in range(9)]))
         self.assertEqual(r["verdict"], "PASS")
         self.assertEqual(r["counts"]["quarantined"], 9)
+
+
+# ---------------------------------------------------------------------------
+# Extension: acceptance context and finality.
+# The same finding must be blocking in one context and quarantined in another, and an accepted
+# commit must survive a fresh reviewer who simply feels differently about it.
+# ---------------------------------------------------------------------------
+
+DEMO = {
+    "schema": "kernel.acceptance-profile/v1",
+    "id": "quantum-demo-2026-08-13",
+    "stage": "demo",
+    "users": {"who": "two people in a room", "count": 2, "real_people": False},
+    "data_sensitivity": "none",
+    "lifetime": "days",
+    "blast_radius": "self",
+    "blocks_at": {
+        "correctness": "blocker",
+        "privacy": "minor",      # still strict, even on a demo
+        "security": "minor",     # still strict, even on a demo
+        "performance": "never",
+        "availability": "never",
+        "maintainability": "never",
+    },
+    "owner": "aria",
+}
+
+PROD = {
+    "schema": "kernel.acceptance-profile/v1",
+    "id": "matra-production",
+    "stage": "production",
+    "users": {"who": "pregnant people", "count": "thousands", "real_people": True},
+    "data_sensitivity": "regulated",
+    "lifetime": "years",
+    "blast_radius": "customers",
+    "blocks_at": {
+        "correctness": "major",
+        "privacy": "nit",
+        "security": "nit",
+        "performance": "major",
+        "availability": "major",
+        "maintainability": "never",
+    },
+    "owner": "aria",
+}
+
+
+def profiled(profile, *findings, **kw):
+    d = doc(*findings, **kw)
+    d["profile"] = profile
+    return d
+
+
+class ContextDecidesSeverity(unittest.TestCase):
+    def test_same_finding_blocks_in_production_and_quarantines_on_a_demo(self):
+        """The whole point of a profile: one finding, two contexts, two correct answers."""
+        slow = finding(summary="first paint takes 4.2s on 3G", severity="major",
+                       dimension="performance", observable="LCP 4.2s",
+                       repro="$ lighthouse\nLCP 4200ms")
+        self.assertEqual(adjudicate.adjudicate(profiled(PROD, slow))["verdict"], "FAIL")
+        r = adjudicate.adjudicate(profiled(DEMO, slow))
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertIn("blocks_at: never", " ".join(r["quarantined"][0]["not_blocking_because"]))
+
+    def test_privacy_still_blocks_a_demo_because_the_profile_says_so(self):
+        """The stage label is not authoritative. A demo can require production-grade privacy."""
+        leak = finding(summary="patient email written to the analytics log", severity="minor",
+                       dimension="privacy", observable="email appears in the log line",
+                       repro="$ grep @ analytics.log\nuser=jess@example.com")
+        self.assertEqual(adjudicate.adjudicate(profiled(DEMO, leak))["verdict"], "FAIL",
+                         "a demo profile that sets privacy:minor must still block on privacy")
+
+    def test_stage_label_alone_never_decides(self):
+        """A demo-stage profile with strict dimensions behaves strictly; only blocks_at decides."""
+        strict_demo = dict(DEMO, blocks_at=dict(DEMO["blocks_at"], performance="major"))
+        slow = finding(summary="4.2s first paint", severity="major", dimension="performance",
+                       observable="LCP 4.2s", repro="$ lighthouse\n4200ms")
+        self.assertEqual(adjudicate.adjudicate(profiled(strict_demo, slow))["verdict"], "FAIL")
+
+    def test_an_omitted_dimension_defaults_strict_not_permissive(self):
+        """Silence in a profile must never quietly widen what ships."""
+        bare = {"schema": "kernel.acceptance-profile/v1", "id": "bare", "blocks_at": {}}
+        f = finding(summary="crash on empty input", dimension="correctness")
+        self.assertEqual(adjudicate.adjudicate(profiled(bare, f))["verdict"], "FAIL")
+
+    def test_an_accepted_failure_mode_quarantines_however_severe(self):
+        p = dict(DEMO, acceptable_failure_modes=["loses unsaved state on refresh"])
+        f = finding(summary="refresh drops the draft", dimension="correctness",
+                    failure_mode="loses unsaved state on refresh")
+        r = adjudicate.adjudicate(profiled(p, f))
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertIn("accepted failure mode", " ".join(r["quarantined"][0]["not_blocking_because"]))
+
+    def test_missing_required_evidence_is_reported_not_swallowed(self):
+        p = dict(DEMO, required_evidence=["walk the demo script 3x", "contract tests green"])
+        r = adjudicate.adjudicate(profiled(p, evidence=["contract tests green"]))
+        self.assertEqual(r["missing_required_evidence"], ["walk the demo script 3x"])
+
+    def test_no_profile_preserves_the_original_behaviour(self):
+        """Back-compat: the evidence bar alone still decides when no context is supplied."""
+        self.assertEqual(adjudicate.adjudicate(doc(finding()))["verdict"], "FAIL")
+
+
+def accepted(profile, commit="abc123def456", **kw):
+    rec = {
+        "schema": "kernel.acceptance/v1",
+        "commit": commit,
+        "profile_id": profile["id"],
+        "profile_hash": adjudicate.profile_hash(profile),
+        "accepted_at": "2026-08-11T00:00:00Z",
+        "signer": "aria",
+        "cannot_falsify": ["no real device"],
+        "known_non_blockers": [],
+    }
+    rec.update(kw)
+    return rec
+
+
+class Finality(unittest.TestCase):
+    def _frozen_doc(self, **kw):
+        d = profiled(PROD, finding(summary="auth accepts an expired token"))
+        d["commit"] = "abc123def456"
+        d["acceptance"] = accepted(PROD)
+        d.update(kw)
+        return d
+
+    def test_an_accepted_commit_is_not_reopened_by_a_fresh_reviewer(self):
+        """The core of res judicata: a new opinion is not a new fact."""
+        r = adjudicate.adjudicate(self._frozen_doc())
+        self.assertTrue(r["frozen"])
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertEqual(r["counts"]["blocking"], 0)
+        self.assertIn("frozen", " ".join(r["quarantined"][0]["not_blocking_because"]))
+
+    def test_a_recognised_reopen_event_does_reopen_it(self):
+        r = adjudicate.adjudicate(self._frozen_doc(
+            reopen={"event": "new_failing_input", "detail": "token with nbf in the future"}))
+        self.assertFalse(r["frozen"])
+        self.assertEqual(r["verdict"], "FAIL")
+
+    def test_an_unrecognised_reopen_event_is_refused(self):
+        """'A different reviewer looked at it' is exactly what an amnesiac critic produces free."""
+        r = adjudicate.adjudicate(self._frozen_doc(
+            reopen={"event": "fresh_reviewer_disagrees", "detail": "I would do it differently"}))
+        self.assertTrue(r["frozen"])
+        self.assertEqual(r["verdict"], "PASS")
+
+    def test_a_reopen_event_with_no_detail_is_refused(self):
+        r = adjudicate.adjudicate(self._frozen_doc(
+            reopen={"event": "new_failing_input", "detail": "   "}))
+        self.assertTrue(r["frozen"])
+
+    def test_changing_the_acceptance_profile_invalidates_the_old_acceptance(self):
+        """The acceptance answered a question nobody is asking any more."""
+        d = self._frozen_doc()
+        d["profile"] = dict(PROD, data_sensitivity="regulated", blast_radius="irreversible")
+        r = adjudicate.adjudicate(d)
+        self.assertFalse(r["frozen"], "a changed profile must void the prior acceptance")
+        self.assertIn("profile changed", " ".join(r["finality"]))
+        self.assertEqual(r["verdict"], "FAIL")
+
+    def test_acceptance_is_not_inherited_by_a_later_commit(self):
+        """Every fix invalidates part of the evidence collected for the commit before it."""
+        d = self._frozen_doc()
+        d["commit"] = "999999999999"
+        r = adjudicate.adjudicate(d)
+        self.assertFalse(r["frozen"])
+        self.assertEqual(r["verdict"], "FAIL")
+
+    def test_a_known_non_blocker_is_named_rather_than_rediscovered(self):
+        d = profiled(PROD, finding(summary="naming is inconsistent"))
+        d["commit"] = "abc123def456"
+        d["acceptance"] = accepted(PROD, known_non_blockers=[{"summary": "naming is inconsistent"}])
+        d["reopen"] = {"event": "new_failing_input", "detail": "unrelated"}
+        r = adjudicate.adjudicate(d)
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertIn("known non-blocker", " ".join(r["quarantined"][0]["not_blocking_because"]))
+
+    def test_profile_hash_ignores_owner_so_a_signer_change_is_not_a_reopen(self):
+        self.assertEqual(adjudicate.profile_hash(PROD),
+                         adjudicate.profile_hash(dict(PROD, owner="someone else")))
+
+
+class PrinciplesHold(unittest.TestCase):
+    """The extension must not erode what was already there."""
+
+    def test_profile_cannot_rescue_a_finding_with_no_evidence(self):
+        """Context decides whether it matters; it never decides whether it is real."""
+        f = finding(summary="I think auth is broken", validated="pending", dimension="security")
+        self.assertEqual(adjudicate.adjudicate(profiled(PROD, f))["verdict"], "PASS")
+
+    def test_cannot_falsify_is_still_mandatory_under_a_profile(self):
+        r = adjudicate.adjudicate(profiled(PROD, finding(), cannot_falsify=()))
+        self.assertEqual(r["verdict"], "INVALID")
+
+    def test_a_frozen_commit_still_requires_declared_blind_spots(self):
+        d = profiled(PROD, finding(), cannot_falsify=())
+        d["commit"] = "abc123def456"
+        d["acceptance"] = accepted(PROD)
+        self.assertEqual(adjudicate.adjudicate(d)["verdict"], "INVALID")
+
+    def test_distance_still_changes_burden_not_scope(self):
+        """A distance-3 finding with real evidence blocks, under a profile that cares."""
+        f = finding(summary="the genre is wrong", distance=3, evidence_kind="observed_outcome",
+                    dimension="correctness", observable="5/5 playtesters quit at 4 min")
+        self.assertEqual(adjudicate.adjudicate(profiled(PROD, f))["verdict"], "FAIL")
+
 
 
 class Cli(unittest.TestCase):

--- a/tests/test_adjudicate.py
+++ b/tests/test_adjudicate.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Tests for scripts/adjudicate.py, the acceptance function.
+
+These are written fails-before: each one names a defect that was live in the review loop before
+this script existed, and would go red if the corresponding rule were removed. Refs #204.
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import adjudicate  # noqa: E402
+
+
+def finding(**kw):
+    base = {
+        "summary": "s",
+        "severity": "blocker",
+        "distance": 0,
+        "validated": "proven",
+        "on_objective": True,
+        "observable": "the request 500s",
+        "repro": "$ curl /x\n500",
+    }
+    base.update(kw)
+    return base
+
+
+def doc(*findings, cannot_falsify=("conformance only",)):
+    return {"cannot_falsify": list(cannot_falsify), "findings": list(findings)}
+
+
+class BlockBar(unittest.TestCase):
+    def test_a_complete_blocker_blocks(self):
+        r = adjudicate.adjudicate(doc(finding()))
+        self.assertEqual(r["verdict"], "FAIL")
+        self.assertEqual(r["counts"]["blocking"], 1)
+
+    def test_criticism_is_not_evidence(self):
+        """Reviewer says 'possible race condition' and the coder fixes it. The defect."""
+        r = adjudicate.adjudicate(doc(finding(validated="pending")))
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertIn("criticism is not evidence", " ".join(
+            r["quarantined"][0]["not_blocking_because"]))
+
+    def test_no_observable_no_block(self):
+        """The stopping wager: a blocker must predict what breaks and how we would see it."""
+        r = adjudicate.adjudicate(doc(finding(observable="")))
+        self.assertEqual(r["verdict"], "PASS")
+
+    def test_nits_never_block(self):
+        """Flat severity is the pressure that selects for weak instruments."""
+        for sev in ("major", "minor", "nit"):
+            self.assertEqual(adjudicate.adjudicate(doc(finding(severity=sev)))["verdict"], "PASS")
+
+    def test_off_objective_never_blocks_however_real(self):
+        """Production hardening on a demo: real, proven, distance-0, and still not a blocker."""
+        r = adjudicate.adjudicate(doc(finding(on_objective=False)))
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertIn("off-objective", " ".join(r["quarantined"][0]["not_blocking_because"]))
+
+
+class DistanceIsAProofThreshold(unittest.TestCase):
+    """The 2026-08-03 genre pivot was distance-3 and is the highest-value review on record.
+    A hard 'distance >= 2 cannot block' cutoff auto-closes it. These tests pin the fix."""
+
+    def test_distance_three_with_real_evidence_blocks(self):
+        r = adjudicate.adjudicate(doc(finding(
+            distance=3, evidence_kind="observed_outcome",
+            summary="the genre is wrong", observable="5/5 playtesters quit at 4 min")))
+        self.assertEqual(r["verdict"], "FAIL", "a distance-3 finding with real evidence must block")
+
+    def test_distance_three_on_taste_does_not_block(self):
+        r = adjudicate.adjudicate(doc(finding(distance=3, summary="prefer a strategy pattern")))
+        self.assertEqual(r["verdict"], "PASS")
+
+    def test_distance_two_needs_a_user_visible_consequence(self):
+        self.assertEqual(adjudicate.adjudicate(doc(finding(distance=2)))["verdict"], "PASS")
+        self.assertEqual(adjudicate.adjudicate(doc(finding(
+            distance=2, consequence="users lose custom rooms on restore")))["verdict"], "FAIL")
+
+    def test_distance_saturates_rather_than_rising_forever(self):
+        r = adjudicate.adjudicate(doc(finding(distance=9, evidence_kind="cited_prior_failure")))
+        self.assertEqual(r["verdict"], "FAIL")
+
+    def test_malformed_distance_does_not_block(self):
+        self.assertEqual(adjudicate.adjudicate(doc(finding(distance="soon")))["verdict"], "PASS")
+
+
+class SilenceAboutCoverage(unittest.TestCase):
+    def test_empty_cannot_falsify_is_invalid_not_pass(self):
+        """Two flagship gates printed PASS for weeks because ripgrep was missing."""
+        r = adjudicate.adjudicate(doc(finding(severity="nit"), cannot_falsify=()))
+        self.assertEqual(r["verdict"], "INVALID")
+
+    def test_whitespace_does_not_count_as_a_declaration(self):
+        r = adjudicate.adjudicate(doc(finding(severity="nit"), cannot_falsify=("   ",)))
+        self.assertEqual(r["verdict"], "INVALID")
+
+    def test_a_fail_also_needs_declared_blind_spots(self):
+        """A FAIL with unknown coverage is still a claim about the world."""
+        self.assertEqual(adjudicate.adjudicate(doc(finding(), cannot_falsify=()))["verdict"],
+                         "INVALID")
+
+
+class Unverifiable(unittest.TestCase):
+    def test_unverifiable_escalates_rather_than_vanishing(self):
+        """'We could not reproduce it' and 'it is not a problem' are different sentences."""
+        r = adjudicate.adjudicate(doc(finding(validated="unverifiable")))
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertEqual(r["counts"]["escalate"], 1)
+        self.assertEqual(r["counts"]["quarantined"], 0)
+
+
+class Termination(unittest.TestCase):
+    def test_a_clean_run_terminates(self):
+        """The whole point: review must be able to say it is fine."""
+        r = adjudicate.adjudicate(doc())
+        self.assertEqual(r["verdict"], "PASS")
+
+    def test_pass_survives_a_pile_of_nits(self):
+        """Nine nits do not add up to a blocker, however many passes produced them."""
+        r = adjudicate.adjudicate(doc(*[finding(severity="nit", summary=f"n{i}") for i in range(9)]))
+        self.assertEqual(r["verdict"], "PASS")
+        self.assertEqual(r["counts"]["quarantined"], 9)
+
+
+class Cli(unittest.TestCase):
+    def _run(self, payload, *args):
+        return subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "adjudicate.py"), "-", *args],
+            input=json.dumps(payload), capture_output=True, text=True)
+
+    def test_strict_exit_codes(self):
+        self.assertEqual(self._run(doc(), "--strict").returncode, 0)
+        self.assertEqual(self._run(doc(finding()), "--strict").returncode, 1)
+        self.assertEqual(self._run(doc(cannot_falsify=()), "--strict").returncode, 2)
+
+    def test_malformed_json_is_refused_not_ignored(self):
+        p = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "adjudicate.py"), "-", "--strict"],
+            input="{not json", capture_output=True, text=True)
+        self.assertEqual(p.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes part of #204.

## The problem

Review has no natural stopping condition. An agent asked to find problems answers *"can I find anything else?"*, never *"is this shippable?"*, and with enough passes the answer to the first is always yes. We recreated the human role of "reviewer" as an agent and threw away the institution around it: bounded authority, persistent reviewer identity, explicit acceptance criteria, severity semantics.

Evidence: `Vaults/_meta/reports/review-tax-evidence-2026-08-11.md`, from 13 real adversary transcripts across urban-atlas and paper-rooms, plus a 120-pass controlled experiment.

## What the evidence forced

**Flat severity selects for weak instruments.** Ten adversary phases each independently `= FAIL`. When every finding blocks, the cheapest way to keep shipping is an instrument that finds little. Confirmed three ways in paper-rooms, most starkly two flagship gates that pipe through `rg`, which is not installed, so the PR's own CI log reads `line 41: rg: command not found` followed immediately by `PASS agent infrastructure paths are portable`.

**A hard distance cutoff suppresses the best reviews.** The 2026-08-03 expert review concluded the entire product genre was wrong and forced a pivot. It is distance-3. So distance sets a **proof threshold**, never a veto ceiling.

**A claim-attacking adversary already terminates voluntarily** (*"I attacked all 6 claims from a clean worktree. Every one held."*). The predictor of termination is having something to measure against, not being narrowly scoped.

**The floor, measured.** 120 passes, sonnet, frozen artifact:

```
VARIANT           ARM    CLEAN%  FIND/PASS
A  correct patch  open      0%       3.7
A  correct patch  rtp     100%       0.0
N  DOCSTRING TYPO open      0%       4.6
```

On a change whose only content is a reworded docstring, the status-quo reviewer averaged **4.6 findings per pass and never once returned clean**, more than on the real patch. Findings-per-pass does not track defect density.

---

## What this PR builds

Mechanism, not prose. Doctrine nobody reads at 2am is not a control.

| Surface | Role |
|---|---|
| `scripts/adjudicate.py` | **the acceptance function.** The critic proposes findings; this decides the verdict. |
| `schemas/kernel.verdict.v1.schema.json` | types the finding. Untyped findings cannot be adjudicated at all: with everything a free-text string, no policy is computable and the last reviewer to speak wins by default. |
| `schemas/kernel.acceptance-profile.v1.schema.json` | **the context review judges against**, as structured dimensions. |
| `schemas/kernel.acceptance.v1.schema.json` | **finality.** Commit X was accepted under profile Y. |
| `hooks/scripts/verdict-gate.sh` | registered `fail-closed` PreToolUse gate. 6 corpus cases. |
| `tests/test_adjudicate.py` | 37 tests, each naming a defect that was live before this existed. |
| `agents/adversary.md`, `skills/review` | call the adjudicator instead of describing a bar in prose. |

### 1. The block bar

A finding blocks only with **all** of: pasted output · a cleared distance proof threshold · a named observable failure · a violation of the acceptance profile. Everything else quarantines and the run still returns PASS.

Distance sets how much proof is needed, never whether a finding may block. d0/d1 need pasted output; d2 adds a user-visible consequence; d3+ needs an executed demonstration, a cited prior failure, or an observed outcome. Taste never clears d3. A playtest record does. Distance saturates at 3 rather than rising forever.

### 2. Acceptance profiles: context decides weight

`blocks_at` gives the minimum blocking severity **per dimension** (correctness, security, privacy, data_loss, availability, performance, accessibility, maintainability). So one finding gets two different correct answers:

- a `major` performance finding **blocks** under a production profile and **quarantines** under a demo profile that sets `performance: never`
- a `minor` privacy finding **still blocks a demo**, because that demo's profile sets `privacy: minor`

**The `stage` label is descriptive and adjudication never reads it.** A demo handling real people's data still requires production-grade privacy; a production internal tool may tolerate ugly performance. Only the dimensions decide.

An omitted dimension defaults to `blocker`, the strictest real setting. Silence in a profile must never quietly widen what ships. A `failure_mode` already listed in `acceptable_failure_modes` quarantines however severe, because someone decided in writing before the review ran. Missing `required_evidence` is reported on the verdict rather than silently passing.

**One conflict the tests surfaced, resolved honestly.** The base bar hardcoded "only `blocker` blocks", which made the profile's per-dimension threshold unreachable. That constant was always a stand-in for a profile nobody had written, so where a profile exists the owner's declared threshold applies instead. Still one threshold, now declared rather than assumed. With no profile, the old constant still governs, so pre-profile behavior is preserved exactly.

### 3. Finality

An acceptance record freezes **one exact commit** under **one exact profile**, carrying its `cannot_falsify`, its known non-blockers, and its accepted tradeoffs. Findings against a frozen commit are still adjudicated and reported, but cannot produce a FAIL.

- Acceptance is **never inherited** by a descendant commit. Every fix invalidates part of the evidence gathered for the commit before it.
- A **changed profile voids it**, detected by hash. It answered a question nobody is asking any more.
- A concern already in `known_non_blockers` is **named as settled** rather than rediscovered.

### 4. Reopen conditions, a closed set

`new_failing_input` · `changed_dependency` · `missed_requirement` · `disproven_assumption` · `profile_changed` · `owner_promotion`

An event with no detail is refused. A fresh reviewer, a rephrased concern, or a different architectural preference is deliberately absent: those are exactly what an amnesiac critic produces for free, and letting them reopen settled work **is** the tax.

---

## Verification

**Full suite: 449 passed, 0 failed.** Corpus: 32 cases over 8 gates, all three checks green.

**Falsifying power proven, not assumed.** Six defects seeded on purpose, each confirmed to turn tests red, then restored:

| Seeded defect | Tests that went red |
|---|---|
| distance-3 evidence requirement removed | 1 |
| empty `cannot_falsify` allowed | 4 |
| profile tolerance (`blocks_at: never`) ignored | 1 |
| acceptance freeze bypassed | 2 |
| reopen-event whitelist opened | 1 |
| profile-hash invalidation disabled | 1 |

**Behavioral tests specifically requested, all present and passing:**

- `test_same_finding_blocks_in_production_and_quarantines_on_a_demo`
- `test_privacy_still_blocks_a_demo_because_the_profile_says_so`
- `test_stage_label_alone_never_decides`
- `test_an_accepted_commit_is_not_reopened_by_a_fresh_reviewer`
- `test_a_recognised_reopen_event_does_reopen_it`
- `test_an_unrecognised_reopen_event_is_refused`
- `test_changing_the_acceptance_profile_invalidates_the_old_acceptance`
- `test_acceptance_is_not_inherited_by_a_later_commit`
- plus a `PrinciplesHold` class asserting the extension did not erode the base: a profile cannot rescue a finding with no evidence, `cannot_falsify` stays mandatory under a profile and on a frozen commit, and distance still changes burden rather than scope.

### The corpus caught me three times

1. **A fail-dark bug in the fail-dark gate.** I extracted the payload with `jq` *before* checking whether the gate applied, so with `jq` missing the check passed silently and a verdict would have sailed through. That is the ripgrep defect, reproduced inside the fix for it. Arming is now dependency-free.
2. **A wrong degraded-mode declaration.** `fail-closed-when-armed` requires a repo fixture to arm it, and this gate is armed by payload. Corrected to `fail-closed`.
3. **A schema with no enforcement owners**, which forced me to write down which fields nothing mechanical actually checks.

Plus adapter drift: I had hand-edited a generated `hooks/hooks.json`. The binding now lives in `HOOK_BINDINGS` and both adapters regenerate from it.

## Honest limits

- **The changed adversary *prompt* is not behaviorally tested.** The adjudicator is. Still open on #204.
- **Variant M has never run.** The off-contract defect arm was added after the matrix started, so this says the acceptance contract terminates and says nothing about what it costs on a defect the contract does not name.
- **One pre-registered prediction was falsified.** I predicted open findings would mostly carry a null repro; 75-93% carried one. That field is self-reported and never executed, so the harness cannot distinguish a reproduction from a claim about one. Recorded as an instrument gap in my own experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPTUmxrdWvkCx8PTos9dfQ
