### PR TITLE
release: 9.5.0 - review gets a deterministic lane and a refutation pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Fences, not leashes: enforced boundaries for Claude Code in auto mode, and a review loop that can say yes",
-      "version": "9.4.0"
+      "version": "9.5.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: codex -->
-<kernel version="9.4.0">
+<kernel version="9.5.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.5.0] - 2026-08-14
+
+Review gets a deterministic lane and a refutation pass. Until now the review skill was
+judgment all the way down: no machine ground truth beneath the LLM's reading, and no
+systematic defense against plausible-but-wrong findings, which a field study of production
+review tooling (Trail of Bits skills, agent-review-panel, tag1 comprehensive-review) plus a
+mined corpus of 33 real false alarms showed to be the two highest-leverage gaps.
+
+### Added
+- **`scripts/deterministic-review.sh`** — the machines-first lane: gitleaks, semgrep
+  (p/security-audit), eslint, ruff, shellcheck, actionlint, zizmor, and osv-scanner run in
+  parallel, diff-scoped when a base ref is given, normalized to one findings TSV. Missing
+  tools skip their lane and are REPORTED as skipped, never silently dropped. Exit 1 only on
+  HIGH classes (secrets, security SAST, high CVEs). Validated by seeded-defect test:
+  planted secrets and an injection in an isolated repo, confirmed 3/3 caught and nonzero
+  exit. Notable calibration: semgrep's `p/ci` ruleset missed a textbook
+  `subprocess(shell=True)` injection; `p/security-audit` catches it, so that is the pinned
+  config.
+- **`skills/review/reference/refutation-patterns.md`** — 11 false-alarm families (fail-open
+  lookalikes, digest-vs-credential, platform-layer auth, settled-decision violations...),
+  the five refutation moves in cost order, severity gates (falsification check before
+  CRITICAL, consensus deflation, CVE authority-stripping, verify-the-judge), and an
+  anti-rationalization table. Distilled from real refuted findings; projects grow their own
+  corpus of refuted false alarms on top.
+
+### Changed
+- **`skills/review/SKILL.md`** — on_start now runs the deterministic lane before any diff
+  is read, and a `refute_before_report` phase checks every candidate finding against the
+  pattern families before it may enter the report. Refuted candidates ship in the report
+  WITH their refutations.
+
 ## [9.4.0] - 2026-08-12
 
 Review gets a termination protocol. Until now KERNEL could tell an agent to be thorough

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: claude -->
-<kernel version="9.4.0">
+<kernel version="9.5.0">
 
 
 <!-- ============================================ -->

--- a/scripts/deterministic-review.sh
+++ b/scripts/deterministic-review.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# deterministic-review.sh <repo-dir> [base-ref]
+#
+# The deterministic lane of a code review: runs every installed free analyzer in parallel,
+# normalizes findings to one TSV, and exits nonzero only on HIGH-signal classes (secrets,
+# security SAST, high CVEs, workflow injection). Missing tools skip their lane and are
+# REPORTED as skipped, never silently dropped — the LLM lane must know what was not checked.
+#
+# Diff mode (base-ref given): only changed files feed file-scoped lanes; semgrep uses
+# --baseline-commit so only NEW findings surface. Full-repo mode otherwise.
+#
+# Output: $OUT_DIR/findings.tsv (file<TAB>line<TAB>tool<TAB>severity<TAB>message),
+#         $OUT_DIR/lanes.txt (per-lane RAN/SKIPPED), both echoed to stdout.
+#
+# Install the lanes (all free; any subset works, missing ones are reported as SKIPPED):
+#   brew install gitleaks semgrep actionlint zizmor osv-scanner shellcheck jq
+# Licensing: semgrep Community rules are internal-use only (no resale/SaaS on top of them);
+# gitleaks/actionlint/zizmor MIT, osv-scanner Apache-2.0, shellcheck GPL-3.0 (tool-only).
+set -u
+
+REPO="${1:?usage: deterministic-review.sh <repo-dir> [base-ref]}"
+BASE="${2:-}"
+cd "$REPO" || exit 2
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repo: $REPO" >&2; exit 2; }
+
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/detreview.$$.XXXXXX")"
+T="$OUT_DIR/raw"; mkdir -p "$T"
+echo "output: $OUT_DIR"
+
+CHANGED=""
+if [ -n "$BASE" ]; then
+  CHANGED="$(git diff --name-only --diff-filter=d "$BASE"...HEAD 2>/dev/null || git diff --name-only --diff-filter=d "$BASE"..HEAD)"
+fi
+filter_ext() { # filter_ext 'regex' — changed files matching, or empty in full-repo mode
+  [ -n "$CHANGED" ] && printf '%s\n' "$CHANGED" | grep -E "$1" || true
+}
+
+LANES="$OUT_DIR/lanes.txt"; : > "$LANES"
+note() { printf '%-12s %s\n' "$1" "$2" >> "$LANES"; }
+
+# --- lanes, all backgrounded -----------------------------------------------------------
+if command -v gitleaks >/dev/null; then
+  ( if [ -n "$BASE" ]; then gitleaks git --no-banner -f json -r "$T/gitleaks.json" --log-opts="$BASE..HEAD" . >/dev/null 2>&1
+    else gitleaks detect --source . --no-banner -f json -r "$T/gitleaks.json" >/dev/null 2>&1; fi ) &
+  note gitleaks RAN
+else note gitleaks SKIPPED; fi
+
+if command -v semgrep >/dev/null; then
+  ( semgrep scan --config p/security-audit --json --quiet ${BASE:+--baseline-commit "$BASE"} > "$T/semgrep.json" 2>/dev/null ) &
+  note semgrep RAN
+else note semgrep SKIPPED; fi
+
+TS_FILES="$(filter_ext '\.(ts|tsx|js|jsx|mjs)$')"
+if npx --no-install eslint --version >/dev/null 2>&1 && { [ -z "$BASE" ] || [ -n "$TS_FILES" ]; }; then
+  ( if [ -n "$TS_FILES" ]; then printf '%s\n' "$TS_FILES" | xargs npx --no-install eslint -f json > "$T/eslint.json" 2>/dev/null
+    else npx --no-install eslint -f json . > "$T/eslint.json" 2>/dev/null; fi; true ) &
+  note eslint RAN
+else note eslint SKIPPED; fi
+
+PY_FILES="$(filter_ext '\.py$')"
+if command -v ruff >/dev/null && { [ -z "$BASE" ] || [ -n "$PY_FILES" ]; }; then
+  ( if [ -n "$PY_FILES" ]; then printf '%s\n' "$PY_FILES" | xargs ruff check --select E9,F,S,B --output-format json > "$T/ruff.json" 2>/dev/null
+    else ruff check --select E9,F,S,B --output-format json . > "$T/ruff.json" 2>/dev/null; fi; true ) &
+  note ruff RAN
+else note ruff SKIPPED; fi
+
+SH_FILES="$(filter_ext '\.(sh|bash)$')"
+if command -v shellcheck >/dev/null; then
+  if [ -n "$SH_FILES" ]; then ( printf '%s\n' "$SH_FILES" | xargs shellcheck -f json > "$T/shellcheck.json" 2>/dev/null; true ) & note shellcheck RAN
+  elif [ -z "$BASE" ]; then ( git ls-files '*.sh' '*.bash' | xargs -r shellcheck -f json > "$T/shellcheck.json" 2>/dev/null; true ) & note shellcheck RAN
+  else note shellcheck SKIPPED; fi
+else note shellcheck SKIPPED; fi
+
+if command -v actionlint >/dev/null && [ -d .github/workflows ]; then
+  ( actionlint -format '{{json .}}' > "$T/actionlint.json" 2>/dev/null; true ) &
+  note actionlint RAN
+else note actionlint SKIPPED; fi
+
+if command -v zizmor >/dev/null && [ -d .github/workflows ]; then
+  ( zizmor --format json .github/workflows > "$T/zizmor.json" 2>/dev/null; true ) &
+  note zizmor RAN
+else note zizmor SKIPPED; fi
+
+if command -v osv-scanner >/dev/null; then
+  ( osv-scanner scan --format json -r . > "$T/osv.json" 2>/dev/null; true ) &
+  note osv-scanner RAN
+else note osv-scanner SKIPPED; fi
+
+wait
+
+# --- normalize -------------------------------------------------------------------------
+F="$OUT_DIR/findings.tsv"; : > "$F"
+J() { command -v jq >/dev/null && [ -s "$1" ]; }
+
+J "$T/gitleaks.json" && jq -r '.[] | [.File, (.StartLine|tostring), "gitleaks", "HIGH", ("secret: " + .RuleID)] | @tsv' "$T/gitleaks.json" >> "$F" 2>/dev/null
+J "$T/semgrep.json" && jq -r '.results[]? | [.path, (.start.line|tostring), "semgrep", (if .extra.severity=="ERROR" then "HIGH" else "MED" end), .check_id] | @tsv' "$T/semgrep.json" >> "$F" 2>/dev/null
+J "$T/eslint.json" && jq -r '.[] | .filePath as $f | .messages[]? | [$f, ((.line//0)|tostring), "eslint", (if .severity==2 then "MED" else "LOW" end), (.ruleId // "parse") + ": " + .message] | @tsv' "$T/eslint.json" >> "$F" 2>/dev/null
+J "$T/ruff.json" && jq -r '.[] | [.filename, (.location.row|tostring), "ruff", (if (.code//"" | startswith("S")) then "HIGH" else "MED" end), (.code//"") + ": " + .message] | @tsv' "$T/ruff.json" >> "$F" 2>/dev/null
+J "$T/shellcheck.json" && jq -r '.[] | [.file, (.line|tostring), "shellcheck", (if .level=="error" then "MED" else "LOW" end), ("SC" + (.code|tostring) + ": " + .message)] | @tsv' "$T/shellcheck.json" >> "$F" 2>/dev/null
+J "$T/actionlint.json" && jq -r '.[] | [.filepath, (.line|tostring), "actionlint", "MED", .message] | @tsv' "$T/actionlint.json" >> "$F" 2>/dev/null
+J "$T/zizmor.json" && jq -r '.[]? | (.locations[0].symbolic.key.Local.given_path // "workflow") as $f | [$f, "0", "zizmor", (if .determinations.severity=="High" then "HIGH" else "MED" end), .ident] | @tsv' "$T/zizmor.json" >> "$F" 2>/dev/null
+J "$T/osv.json" && jq -r '.results[]?.packages[]? | .package.name as $p | .vulnerabilities[]? | [$p, "0", "osv-scanner", (if ((.database_specific.severity//"")|ascii_downcase)=="critical" or ((.database_specific.severity//"")|ascii_downcase)=="high" then "HIGH" else "MED" end), .id] | @tsv' "$T/osv.json" >> "$F" 2>/dev/null
+
+sort -t"$(printf '\t')" -k4,4 -k1,1 -o "$F" "$F"
+
+echo "=== lanes ==="; cat "$LANES"
+echo "=== findings ($(wc -l < "$F" | tr -d ' ')) ==="; cat "$F"
+
+grep -q "$(printf '\t')HIGH$(printf '\t')" "$F" && exit 1 || exit 0

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.4.0.
+Quick reference for KERNEL v9.5.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -41,6 +41,19 @@ git diff --staged          # For staged
 git diff HEAD~1            # For recent
 ```
 </identify_scope>
+
+<deterministic_lane>
+Machines first, then judgment. Run before reading a single diff hunk:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT:-.}/scripts/deterministic-review.sh" <repo-dir> [base-ref]
+```
+
+Parallel gitleaks / semgrep(p/security-audit) / eslint / ruff / shellcheck / actionlint /
+zizmor / osv-scanner — whatever is installed; diff-scoped when base-ref given; exit 1 on
+HIGH (secrets, security SAST, high CVEs). Feed findings.tsv into the review as ground
+truth. Lanes marked SKIPPED are reported as NOT CHECKED, never as clean.
+</deterministic_lane>
 </on_start>
 
 <confidence_threshold>
@@ -108,6 +121,16 @@ detection: grep -r "catch.*{}" (empty catch)
 - [ ] Appropriate caching
 </section>
 </checklist>
+
+<refute_before_report>
+Before a finding enters the report, check it against
+reference/refutation-patterns.md (11 false-alarm families + 5 refutation moves).
+A finding matching a family needs evidence distinguishing it from the refuted precedent.
+Severity gates from the same file apply: falsification check before CRITICAL, consensus
+deflation, authority stripping on CVEs, and the judge's own additions get refuted too.
+Refuted candidates go in the report WITH their refutations; if the project keeps a
+refutation-corpus file, append new refuted false alarms to it in the same session.
+</refute_before_report>
 
 <output_format>
 CODE REVIEW

--- a/skills/review/reference/refutation-patterns.md
+++ b/skills/review/reference/refutation-patterns.md
@@ -1,0 +1,103 @@
+# Refutation patterns: the false-alarm families
+
+A reviewer's precision instrument. Before reporting ANY candidate finding, check it against
+these families. Each was distilled from real reviews where a plausible-looking finding was
+refuted by one cheap check; the pattern names the trace that settles it. A finding that
+matches a family needs evidence distinguishing it from the refuted precedent, or it dies
+before it is reported.
+
+Derived from a 2026-08 field study of production review tooling (Trail of Bits skills,
+agent-review-panel, tag1 comprehensive-review) plus a mined corpus of 33 real false alarms.
+Projects should grow their OWN corpus file of refuted findings; this file carries only the
+generalizable patterns.
+
+## The five refutation moves, in cost order
+
+1. **Read the manifest.** The config/deployment manifest that supplies the "missing" value.
+2. **Trace the branch.** Does the suspect path actually execute with real inputs?
+3. **Probe.** One read-only command (a SELECT, a curl, a render) beats an hour of reasoning.
+4. **Find the settled decision.** Search decision notes/commissions before reporting a
+   "contract violation" — the contract may define the behavior you flagged.
+5. **Suspect the instrument.** When a checker's verdict is surprising, check the checker's
+   own timeline and inputs before trusting it.
+
+## Family 1: crypto-misuse lookalikes
+- Fast hash (SHA-256) over a HIGH-ENTROPY RANDOM input is fine; the defect requires a
+  low-entropy (human-chosen) input. Trace what is hashed, not which function hashes it.
+- A digest used to length-normalize input for a constant-time compare is a mitigation,
+  not storage crypto.
+
+## Family 2: fail-open lookalikes
+- `if (!secret) ...` is not a finding until you trace which branch the absent-config path
+  takes. Fail-CLOSED shapes look identical to fail-open at grep distance.
+- An unconfigured default that is the SECURE value, pinned by the only deployment
+  manifest, is not a finding. Read the manifest before scoring config-driven code.
+- A script that REFUSES to run without its secret is the opposite of an insecure default.
+
+## Family 3: permissive-access lookalikes
+- "No auth middleware" is not a finding when the endpoint has a written threat model with
+  compensating controls (single-use tokens, rate limits, uniform errors).
+- Auth enforced at the platform layer (gateway, service binding, access proxy) is invisible
+  to code-only grep. Trace the platform config.
+- A dynamic CORS/origin callback is not automatically permissive; enumerate what it admits.
+
+## Family 4: secret/credential lookalikes
+- Placeholder/example files (`*.example`, docs) are out of scope; confirm a file's role
+  before reporting a committed secret.
+- An env fallback is a finding only when the fallen-back value is security-bearing.
+  Classify the value, not the call.
+- Entropy scanners cannot tell a DIGEST from a CREDENTIAL. Ask what the string unlocks:
+  a hash of tracked content unlocks nothing.
+- Secret scanners match their own documentation. Read the hit's context.
+
+## Family 5: injection/XSS lookalikes
+- Escaping/encoding applied at the sink or template layer often lives one file away from
+  the flagged line. Trace the render path before filing.
+
+## Family 6: data-correctness lookalikes
+- Before blaming the algorithm, verify the data exists: an empty table explains "no
+  results" more often than a broken retriever. `SELECT COUNT(*)` first.
+
+## Family 7: settled-decision lookalikes
+- A literally-true "violation" can be the documented contract. Search decision records
+  before reporting; reopening a settled entry requires new evidence, not a new opinion.
+
+## Family 8: UI-measurement lookalikes
+- The interactive element's LIVE hit area (wrapping label, padding) is what matters, not
+  the inner control's declared size. Measure before flagging touch targets.
+
+## Family 9: platform-behavior lookalikes
+- "Missing" cleanup/handling that the platform guarantees (request isolation, GC,
+  transaction rollback) is not a leak. Cite the platform doc either way.
+
+## Family 10: instrument-was-wrong lookalikes
+- A surprising verdict from a checker warrants checking the checker: stale caches, wrong
+  working directory, and self-matching patterns produce confident nonsense.
+
+## Family 11: statistical/convention lookalikes
+- A metric or convention that looks wrong by general standards may be pinned by a
+  measured calibration. Look for the calibration record before re-deriving from first
+  principles.
+
+## Severity gates (apply after refutation)
+
+- **Falsification gate:** before any CRITICAL, name the single observation that would
+  falsify the finding. If one read-only command could falsify it and nobody ran it, cap
+  severity until verified.
+- **Consensus deflation:** N reviewers citing the same source lines are ONE source, not N
+  confirmations.
+- **Strip authority:** judge a dependency CVE by its technical description, not its
+  identifier or score.
+- **Verify the judge:** any finding the aggregator introduces that no lane reported gets
+  the same refutation pass as everything else. The aggregator is the last unverified
+  writer in the pipeline.
+
+## Anti-rationalization table (do not skip the checks)
+
+| Excuse | Why it's wrong |
+|---|---|
+| "Small diff, quick look" | Heartbleed was 2 lines. Classify by risk, not size. |
+| "The tools found nothing" | Tools that didn't run found nothing either. Check the skipped-lanes list. |
+| "This finding is obviously real" | Half the mined corpus was "obviously real". Run the refutation pass. |
+| "I know this codebase" | Familiarity is why context-blind review exists. |
+| "Refutation slows us down" | One SELECT has refuted an entire rebuild plan. It is the fast path. |


### PR DESCRIPTION
## What
Two upstreamed mechanisms from the 2026-08-14 review-tooling field study, now part of the kernel review skill instead of living as vault-local files.

**Deterministic lane** (`scripts/deterministic-review.sh`): gitleaks, semgrep (`p/security-audit`), eslint, ruff, shellcheck, actionlint, zizmor, osv-scanner in parallel; diff-scoped with a base ref; one normalized findings TSV; missing tools reported as SKIPPED, never silently dropped; exit 1 only on HIGH classes (secrets, security SAST, high CVEs).

**Refutation pass** (`skills/review/reference/refutation-patterns.md` + `refute_before_report` in the skill): 11 false-alarm families, five refutation moves in cost order, severity gates (falsification check before CRITICAL, consensus deflation, CVE authority-stripping, verify-the-judge), anti-rationalization table.

## Verification
- Seeded-defect test in an isolated repo: 2 planted secrets + 1 `subprocess(shell=True)` injection, 3/3 caught, exit 1 confirmed. First seed attempt honestly failed (AWS's documented example key is scanner-allowlisted; `p/ci` too thin) — fixed seeds, pinned `p/security-audit`.
- Real diff-mode run on a production monorepo: 13 findings, sane noise, one corpus-grade false positive (a sha256 pin flagged as an api key — now family 4 material).
- `bash tests/run-tests.sh`: 449/449, including version-sync after `bump-version.sh 9.5.0`.

## Provenance
Field study of Trail of Bits skills, agent-review-panel, and tag1 comprehensive-review, plus a 33-entry corpus of real false alarms mined from private project history. Only the generalizable patterns ship here; no project-specific details.