### PR TITLE
agentdb and session-start: two timestamp defects that mislead the retrospective and the startup banner

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
   "author": {
     "name": "Aria Han",

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -183,7 +183,7 @@ if [ -f "$VAULTS/_meta/agentdb/agent.db" ]; then
   echo ""
 
   # Prune stale learnings (0 hits, >30 days old)
-  "$AGENTDB" query "DELETE FROM learnings WHERE hit_count = 0 AND ts < datetime('now', '-30 days');" 2>/dev/null || true
+  "$AGENTDB" query "DELETE FROM learnings WHERE hit_count = 0 AND ts < strftime('%Y-%m-%dT%H:%M:%fZ','now','-30 days');" 2>/dev/null || true
 
   # (Top-learnings surfacing folded into the --lean dump above — no separate section.)
 
@@ -222,14 +222,14 @@ if [ -f "$VAULTS/_meta/agentdb/agent.db" ]; then
   # Check for stale contracts (>24h with no checkpoint)
   # `agentdb query` prints a formatted table (header + separator + value), so pull the
   # last numeric line and coerce to an int (+0) before any `-gt` comparison.
-  STALE_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM context WHERE type='contract' AND ts < datetime('now', '-1 day') AND contract_id NOT IN (SELECT COALESCE(contract_id, '') FROM context WHERE type='verdict');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
+  STALE_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM context WHERE type='contract' AND ts < strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 day') AND contract_id NOT IN (SELECT COALESCE(contract_id, '') FROM context WHERE type='verdict');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
   STALE_COUNT=${STALE_COUNT:-0}
   if [ "$STALE_COUNT" -gt 0 ]; then
     BLOCKERS="${BLOCKERS}\n- $STALE_COUNT stale contract(s) >24h without verdict"
   fi
 
   # Check for recent errors (>3 in last hour)
-  ERROR_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM errors WHERE ts > datetime('now', '-1 hour');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
+  ERROR_COUNT=$("$AGENTDB" query "SELECT COUNT(*) FROM errors WHERE ts > strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 hour');" 2>/dev/null | awk '/^[0-9]/{v=$1} END{print v+0}')
   ERROR_COUNT=${ERROR_COUNT:-0}
   if [ "$ERROR_COUNT" -gt 3 ]; then
     BLOCKERS="${BLOCKERS}\n- $ERROR_COUNT errors in last hour (possible loop)"

--- a/orchestration/agentdb/agentdb
+++ b/orchestration/agentdb/agentdb
@@ -733,7 +733,7 @@ cmd_learn() {
   local existing
   existing=$(db_exec "SELECT id FROM learnings WHERE insight LIKE '%${safe_substr}%' AND type='$safe_type' LIMIT 1;" 2>/dev/null || echo "")
   if [ -n "$existing" ]; then
-    db_exec "UPDATE learnings SET hit_count = hit_count + 1 WHERE id='$existing';"
+    db_exec "UPDATE learnings SET hit_count = hit_count + 1, last_hit = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id='$existing';"
     # Observation: a near-identical insight recurred and reinforced an existing row.
     emit_memory_event reinforced "$existing" "learn dedup: near-identical insight recurred" \
       "{\"type\":\"$(json_escape "$type")\",\"domain\":\"$(json_escape "$domain")\"}"


### PR DESCRIPTION
Two small fixes found by a retrospective on 2026-08-26.

1. `agentdb learn` dedup path bumped hit_count without stamping last_hit, so the retrospective stale predicate `COALESCE(last_hit, ts) < now-30d` listed the most reinforced rows (a 125-hit gotcha with NULL last_hit) as archival candidates.
2. `session-start.sh` compared ISO `T`-format timestamps against `datetime('now', ...)` output (space-separated). `T` sorts above space, so every row from today passed a one-hour cutoff: the 'possible loop' banner reported 13 unrelated errors spanning 17 hours. Proof: old query 15, fixed query 5 on the same DB.

No em dashes.