### PR TITLE
Aim the repo's front door at the agent reading it: llms.txt, agent-first README, agent-searchable manifests (9.5.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel-marketplace",
-  "description": "Fences, not leashes: enforced boundaries for Claude Code in auto mode, and a review loop that can say yes",
+  "description": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
   "owner": {
     "name": "Aria Han"
   },
@@ -8,8 +8,8 @@
     {
       "name": "kernel",
       "source": "./",
-      "description": "Fences, not leashes: enforced boundaries for Claude Code in auto mode, and a review loop that can say yes",
-      "version": "9.5.1"
+      "description": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
+      "version": "9.5.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "9.5.1",
-  "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
+  "version": "9.5.2",
+  "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"
@@ -10,10 +10,18 @@
   "repository": "https://github.com/ariaxhan/kernel-claude",
   "license": "MIT",
   "keywords": [
-    "adaptive-execution",
+    "claude-code",
+    "codex",
+    "plugin",
+    "hooks",
+    "guardrails",
+    "agent-memory",
     "agentdb",
-    "memory",
+    "verification",
+    "auto-mode",
     "safety",
+    "adaptive-execution",
+    "memory",
     "orchestration",
     "handoff",
     "methodology"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kernel",
-  "version": "9.5.1",
-  "description": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
+  "version": "9.5.2",
+  "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",
     "url": "https://github.com/ariaxhan"
@@ -10,10 +10,18 @@
   "repository": "https://github.com/ariaxhan/kernel-claude",
   "license": "MIT",
   "keywords": [
-    "adaptive-execution",
+    "claude-code",
+    "codex",
+    "plugin",
+    "hooks",
+    "guardrails",
+    "agent-memory",
     "agentdb",
-    "memory",
+    "verification",
+    "auto-mode",
     "safety",
+    "adaptive-execution",
+    "memory",
     "orchestration",
     "handoff",
     "methodology"
@@ -21,8 +29,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "KERNEL",
-    "shortDescription": "Fences, not leashes: enforced boundaries for Claude Code in auto mode, and a review loop that can say yes",
-    "longDescription": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
+    "shortDescription": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
+    "longDescription": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
     "developerName": "Aria Han",
     "category": "Engineering",
     "capabilities": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: codex -->
-<kernel version="9.5.1">
+<kernel version="9.5.2">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.5.2] - 2026-08-26
+
+The reader this repo optimises for is now an agent deciding whether to install it.
+
+### Added
+- **`llms.txt`** (llmstxt.org format, under 150 lines): what KERNEL is in mechanism terms,
+  the exact install command sequence for Claude Code and for Codex, every hook, skill, and
+  agent with its `/kernel:<name>` and `$kernel:<name>` invocation form, what to run first,
+  and when not to use it. Stated limits ride along with the pitch: the hooks are a tripwire,
+  not a sandbox, and remote Claude Code sessions cannot load plugins at all.
+- **`README.md` `## For agents`**, the first section under the title: two fenced blocks an
+  agent can execute verbatim, one per host, and a pointer to `llms.txt`. The human pitch
+  keeps its place directly below.
+
+### Changed
+- **`governance/hosts.json`** interface descriptions are written for agent search rather than
+  for a human browsing a marketplace listing. "Fences, not leashes" was a good line and a bad
+  index entry: it names no host, no mechanism, and no artifact. The replacements name Claude
+  Code, Codex, hooks, agentdb, verification, and auto mode, which are the words an agent
+  actually queries.
+- **`scripts/generate-adapters.py`** keywords now lead with `claude-code`, `codex`, `plugin`,
+  `hooks`, `guardrails`, `agent-memory`, `agentdb`, `verification`, `auto-mode`, and `safety`.
+  The previous seven are kept, not replaced. Both plugin manifests and the marketplace
+  manifest are regenerated from those two sources, so no manifest was hand-edited.
+
 ## [9.5.1] - 2026-08-26
 
 Two timestamp defects that misled the tools meant to catch defects.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 4dc9ff3280df7c20087e7a5a9d837cc21df69ff85de0513a1fcacc8edfb44d26; adapter: claude -->
-<kernel version="9.5.1">
+<kernel version="9.5.2">
 
 
 <!-- ============================================ -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # KERNEL
 
+## For agents
+
+If you are an agent deciding whether to install this, the machine-readable summary is
+[llms.txt](llms.txt): what it is, what it adds, and when not to use it.
+
+Claude Code (in a session, `/plugin marketplace add ariaxhan/kernel-claude` then
+`/plugin install kernel@kernel-marketplace`):
+
+```bash
+claude plugin marketplace add ariaxhan/kernel-claude
+claude plugin install kernel@kernel-marketplace
+~/.claude/plugins/marketplaces/kernel-marketplace/scripts/kernel-setup.sh
+```
+
+Codex:
+
+```bash
+codex plugin marketplace add ariaxhan/kernel-claude
+codex plugin add kernel@kernel-marketplace
+```
+
+Restart the host, then run `/kernel:help` on Claude Code or `$kernel:help` on Codex to confirm the
+install and list every skill. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+
+---
+
 **Stop approving everything your AI does. It's making you less safe.**
 
 Auto mode is the default now, and the data behind that decision is brutal: humans reviewing

--- a/governance/hosts.json
+++ b/governance/hosts.json
@@ -88,8 +88,8 @@
   },
   "interface": {
     "displayName": "KERNEL",
-    "shortDescription": "Fences, not leashes: enforced boundaries for Claude Code in auto mode, and a review loop that can say yes",
-    "longDescription": "KERNEL fences your Claude Code agent instead of leashing it. Destructive commands are blocked by hooks, not approved by tired humans; irreversible operations require a one-time token only a human can open; independent verifiers check finished work without seeing the builder's reasoning; every claim carries a receipt. And the fences learn: mistakes a session survives become durable memory that blocks them next time. Review outcomes, not keystrokes.",
+    "shortDescription": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
+    "longDescription": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
     "developerName": "Aria Han",
     "category": "Engineering",
     "capabilities": [

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,149 @@
+# KERNEL
+
+> A Claude Code plugin, also loadable by Codex, that replaces per-action approval prompts with
+> enforced boundaries: hooks that block destructive commands, a one-time human token for
+> irreversible operations, verifier agents blind to the builder's reasoning, and a SQLite memory
+> that carries lessons between sessions.
+
+Repository: https://github.com/ariaxhan/kernel-claude
+License: MIT. Version 9.5.2. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+
+## What it is
+
+Auto mode removes the per-action prompt. KERNEL supplies what the prompt was supposed to do: the
+agent runs without per-action confirmation, inside boundaries enforced by hook scripts rather than
+by instructions the model could talk itself past.
+
+- Shell commands and writes are classified by how hard they are to undo. Recoverable mistakes get
+  a warning the model can act on; destructive ones are blocked in a PreToolUse hook.
+- Irreversible operations require a one-time approval token that a prompt-injected command cannot
+  forge, because only a human can open it.
+- High-consequence work is checked by a separate agent that receives the diff and the acceptance
+  record but never the builder's reasoning.
+- Session state persists as schema-validated JSON manifests, so a resume reconstructs the pinned
+  state instead of inheriting a transcript. Failures recorded to `agentdb` in one session are
+  recalled by keyword in the next.
+
+Ambient context cost to a plugin user is about 4,600 tokens: ~1,900 from the SessionStart hook and
+~2,700 from skill frontmatter the host keeps visible for routing. This repo's `CLAUDE.md` is not
+loaded for plugin users.
+
+Limits stated by the project: the hooks are a tripwire, not a sandbox (`docs/safety.md`), and the
+model-routing and builder-is-not-verifier rules are checked when receipt validation runs, not on
+every request.
+
+## Install for Claude Code
+
+From a shell (in-session equivalents: `/plugin marketplace add ariaxhan/kernel-claude` then
+`/plugin install kernel@kernel-marketplace`):
+
+```bash
+claude plugin marketplace add ariaxhan/kernel-claude
+claude plugin install kernel@kernel-marketplace
+~/.claude/plugins/marketplaces/kernel-marketplace/scripts/kernel-setup.sh
+```
+
+`kernel-setup.sh` creates the AgentDB, writes one row and reads it back by keyword as proof, and
+exits non-zero naming which half failed if it cannot. It asks before writing and never touches
+shell configuration. Terminal, Desktop (local and SSH), and VS Code support plugins; remote Claude
+Code sessions do not.
+
+## Install for Codex
+
+Codex CLI and the Codex app load the same package through the Claude-marketplace compatibility
+loader:
+
+```bash
+codex plugin marketplace add ariaxhan/kernel-claude
+codex plugin add kernel@kernel-marketplace
+```
+
+Restart Codex, then invoke `$kernel:init`. Two differences: Codex does not implement
+`PostToolUseFailure`, so `capture-error.sh` is unbound and tool-error recording degrades to what
+`PostToolUse` observes; and Codex maps KERNEL's agent roles onto its own rather than registering
+the Claude Code agent definitions natively. Matrix: `docs/kernel-9/HOST-CAPABILITIES.md`.
+
+## What it adds
+
+Skills are namespaced per host: Claude Code invokes `/kernel:<name>`, Codex invokes
+`$kernel:<name>`.
+
+### Hooks (`hooks.json`, scripts in `hooks/scripts/`)
+
+Bound to SessionStart, PreToolUse, PermissionRequest, PostToolUse, UserPromptSubmit, Stop,
+PreCompact, SessionEnd.
+
+- `guard-bash.sh` classifies bash commands by reversibility and blocks the destructive ones.
+- `detect-secrets.sh` blocks writes that would commit a credential; `guard-config.sh` restricts
+  edits to agent-configuration paths.
+- `guard-context.sh` enforces the active manifest's context policy (sealed, bounded, advisory).
+- `session-start.sh` delivers the ambient methodology and the AgentDB recall banner; `session-end.sh`
+  writes the session record; `pre-compact-commit.sh` checkpoints before compaction.
+- `test-gate.sh` and `verdict-gate.sh` hold work at the declared quality gate; `circuit-breaker.sh`
+  stops a session looping on the same failure.
+
+### Memory (`agentdb`, `orchestration/agentdb/agentdb`)
+
+A SQLite database at `_meta/agentdb/agent.db` in the selected Vaults directory. FTS5 keyword recall by default; local semantic search is opt-in and makes no network calls.
+
+```bash
+agentdb recall "<concrete nouns, files, symbols, errors>"   # before acting
+agentdb learn failure|pattern|gotcha "<what>" "<evidence>"  # after discovering
+```
+
+### Skills (27, `skills/<name>/SKILL.md`)
+
+- `/kernel:ingest` · `$kernel:ingest`: entry point for new and resumed work: research, classify, scope, execute, or resume from a manifest.
+- `/kernel:help` · `$kernel:help`: KERNEL reference plus live plugin status.
+- `/kernel:build` · `$kernel:build`: generate two or three approaches before implementing, take the simplest.
+- `/kernel:debug` · `$kernel:debug`: reproduce, hypothesize, isolate by binary search, fix root cause, add a regression test.
+- `/kernel:diagnose` · `$kernel:diagnose`: diagnosis before prescription for bugs and refactors.
+- `/kernel:review` · `$kernel:review`: code review with a deterministic scanner lane and a refutation pass; APPROVE, REQUEST CHANGES, or COMMENT.
+- `/kernel:tearitapart` · `$kernel:tearitapart`: pre-implementation critique; PROCEED, REVISE, or RETHINK.
+- `/kernel:ship` · `$kernel:ship`: release gate: validate, review, publish, tag.
+- `/kernel:handoff` · `$kernel:handoff`: compile a `kernel.handoff/v1` manifest for bounded resume.
+- `/kernel:checkpoint` · `$kernel:checkpoint`: mid-task `kernel.checkpoint/v1` manifest for a safe context reset.
+- `/kernel:retrospective` · `$kernel:retrospective`: cross-session synthesis; promotes lessons to hook, agent, or skill.
+- `/kernel:metrics` · `$kernel:metrics`: session, agent, hook, and learning-health dashboard.
+- `/kernel:architecture` · `$kernel:architecture`: modular design, interface stability, coupling analysis.
+- `/kernel:orchestration` · `$kernel:orchestration`: multi-agent lane contracts and fault tolerance.
+- `/kernel:context-mgmt` · `$kernel:context-mgmt`: compaction strategy, progressive disclosure, token budget.
+- `/kernel:knowledge-graph` · `$kernel:knowledge-graph`: deterministic local code graph to cut orientation-token cost.
+- `/kernel:eval` · `$kernel:eval`: eval-driven development: pass@k, capability and regression evals.
+- `/kernel:human-pass` · `$kernel:human-pass`: the acceptance pass a human runs against a real build.
+- `/kernel:frontend` · `$kernel:frontend`: art direction derived from product and audience, not a house style.
+- `/kernel:marketing-site` · `$kernel:marketing-site`: marketing and client-site methodology.
+- `/kernel:app-dev` · `$kernel:app-dev`: fastlane-first mobile and web build and store submission.
+- `/kernel:dream` · `$kernel:dream`: competing approaches stress-tested by a four-persona council.
+- `/kernel:init` · `$kernel:init`: one-time machine setup (explicit invocation only).
+- `/kernel:forge` · `$kernel:forge`: autonomous build loop; requires `max_budget_usd` (explicit only).
+- `/kernel:experiment` · `$kernel:experiment`: treat each rule as a hypothesis: seed, test, graduate, kill (explicit only).
+- `/kernel:landing-page` · `$kernel:landing-page`: landing-page build and deploy operator (explicit only).
+- `/kernel:governance-sync` · `$kernel:governance-sync`: audit or sync `CLAUDE.md` and `AGENTS.md` across repositories (explicit only).
+
+### Agents (10, `agents/<name>.md`)
+
+- `surgeon`: minimal-diff implementation, touches only contract-listed files.
+- `adversary`: QA that assumes the code is broken until evidence says otherwise.
+- `reviewer`: PR review against logic, security, performance, maintainability.
+- `researcher`: pre-implementation research on unfamiliar tech and package choices.
+- `deep-diver`: failure-mode research map before non-trivial infrastructure or schema work.
+- `scout`: codebase reconnaissance: structure, tooling, conventions, risk zones.
+- `blind-evaluator`: receives the problem and rubric only, never the solution.
+- `lane-worker`: one file-disjoint slice of a parallel burn; never commits.
+- `transcript-archaeologist`: read-only forensic mining of session logs and git history.
+- `dreamer`: minimalist, maximalist, and pragmatist positions on the same problem.
+
+## First thing to run after install
+
+`/kernel:help` in Claude Code, `$kernel:help` in Codex. It prints the skill inventory, the state
+operations, and live plugin status, so it doubles as an install check.
+
+## When not to use it
+
+- You want an agent with no boundaries. KERNEL's whole surface is boundaries.
+- You want a sandbox. The hooks are a tripwire in the agent's own process, not isolation.
+- You want a replacement for tests, code review, and reading the diff. It gates those, it does not
+  replace them.
+- You run Claude Code only in remote sessions, which do not support plugins, or your environment
+  cannot provide `sqlite3`, `jq`, and `python3`, without which the memory will not start.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,6 +10,7 @@
 #   governance/kernel.md.tmpl         <kernel version="X.Y.Z">
 #   AGENTS.md + CLAUDE.md             generated from the canonical template
 #   skills/help/SKILL.md              KERNEL vX.Y.Z
+#   llms.txt                          Version X.Y.Z
 #
 # NOT touched here (human-authored per release, intentionally version-specific prose):
 #   - plugin.json / marketplace.json `description` highlight (v7.x: ...)
@@ -41,6 +42,7 @@ sub('.claude-plugin/plugin.json',      r'("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(
 sub('.claude-plugin/marketplace.json', r'("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(")',     rf'\g<1>{new}\g<2>')
 sub('.codex-plugin/plugin.json',       r'("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(")',     rf'\g<1>{new}\g<2>')
 sub('skills/help/SKILL.md',            r'(KERNEL v)[0-9]+\.[0-9]+\.[0-9]+',               rf'\g<1>{new}')
+sub('llms.txt',                        r'(Version )[0-9]+\.[0-9]+\.[0-9]+',              rf'\g<1>{new}')
 # NOTE: governance/kernel.md.tmpl no longer carries a hardcoded version — it uses the
 # {{VERSION}} token, which generate-governance.py derives from plugin.json below. So the
 # template is not stamped here; regenerating governance is what propagates the version.

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -151,8 +151,9 @@ def build_plugin_manifest(host_key: str, host: dict, spec: dict) -> dict:
         "repository": base.get("repository"),
         "license": base.get("license", "MIT"),
         "keywords": [
-            "adaptive-execution", "agentdb", "memory", "safety",
-            "orchestration", "handoff", "methodology",
+            "claude-code", "codex", "plugin", "hooks", "guardrails",
+            "agent-memory", "agentdb", "verification", "auto-mode", "safety",
+            "adaptive-execution", "memory", "orchestration", "handoff", "methodology",
         ],
     }
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.5.1.
+Quick reference for KERNEL v9.5.2.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2401,6 +2401,7 @@ test_version_sync_all() {
   grep -qF "<kernel version=\"$v\">" "$PLUGIN_ROOT/AGENTS.md"       || { echo "FAIL: AGENTS.md <kernel version> != $v"; fail=1; }
   grep -qF "<kernel version=\"$v\">" "$PLUGIN_ROOT/CLAUDE.md"      || { echo "FAIL: CLAUDE.md <kernel version> != $v"; fail=1; }
   grep -qF "KERNEL v$v" "$PLUGIN_ROOT/skills/help/SKILL.md"            || { echo "FAIL: skills/help/SKILL.md KERNEL version != $v"; fail=1; }
+  grep -qF "Version $v." "$PLUGIN_ROOT/llms.txt"                       || { echo "FAIL: llms.txt Version != $v"; fail=1; }
   return $fail
 }
 


### PR DESCRIPTION
👀 in review

Point the repo's front door at the reader who actually opens it: an agent deciding whether to install KERNEL.

| Change | Consequence |
| --- | --- |
| `llms.txt` at the root, 149 lines | An agent gets install commands, the full skill and agent inventory with invocation forms, and the honest limits, without crawling `docs/` |
| README `## For agents` first section | Two fenced blocks, one per host, executable verbatim. The human pitch keeps its place directly below |
| Manifest descriptions and keywords rewritten for agent search | "Fences, not leashes" names no host, no mechanism, no artifact. The replacements name Claude Code, Codex, hooks, agentdb, verification, auto mode |
| `llms.txt` version wired into `bump-version.sh` + the sync test | The new version surface cannot drift silently |
| 9.5.1 → 9.5.2 | Patch release, docs and metadata only. No runtime behaviour changed |

## Checks

- [x] `claude plugin validate .` passes
- [x] `scripts/generate-adapters.py --check`: all 7 generated adapters in sync
- [x] `scripts/generate-governance.py --check`: governance current
- [x] `scripts/check-orphans.py`: no new orphans
- [x] `tests/run-tests.sh`: green

## What is not here

No hook, skill, agent, or script behaviour changed. Every manifest was regenerated from
`governance/hosts.json` and `scripts/generate-adapters.py`; none was hand-edited.

<details>
<summary>Why the manifests were not edited directly</summary>

`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json`
are all generated by `scripts/generate-adapters.py` from `governance/hosts.json`
(`interface.shortDescription` and `interface.longDescription`) plus the keyword list in the
generator. Editing them by hand would have been reverted by the next `--check` run.

</details>

<details>
<summary>Version surfaces touched</summary>

Matching the previous bump (266273a), plus one new one:

- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `.codex-plugin/plugin.json`
- `AGENTS.md` and `CLAUDE.md` (generated from `governance/kernel.md.tmpl`)
- `skills/help/SKILL.md`
- `CHANGELOG.md`
- `llms.txt` (new; added to `scripts/bump-version.sh` and `test_version_sync_all`)

`git grep -n "9\.5\.1" | grep -v CHANGELOG` returns nothing.

</details>
