### PR TITLE
9.6.0: simplify, a complexity number the model cannot skip

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
-      "version": "9.5.4"
+      "version": "9.6.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.5.4",
+  "version": "9.6.0",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.5.4",
+  "version": "9.6.0",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: ce05c64af2e12ec0147774edd9c9166dcbc7fec2e63f241ecc9afdc894b206b3; adapter: codex -->
-<kernel version="9.5.4">
+<kernel version="9.6.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.6.0] - 2026-08-27
+
+A skill is only as strong as the one measurement it refuses to let the model skip.
+
+Adapted from saurabhkumar8112/cyclomatic-complexity-skill (Apache-2.0), a 60-line skill whose
+only non-generic line is "don't game the metric". KERNEL's review check 5 asked two yes/no
+questions about complexity; a model answering questions about its own code is not a
+measurement. Now it runs lizard.
+
+### Added
+- `/kernel:simplify`: cyclomatic complexity per function via lizard (from PATH or `uvx`, no
+  install), refactor worst first, explicit anti-gaming rule, and the before/after table is
+  re-measured by a verifier that never saw the builder's reasoning. The builder never signs
+  "behavior verified".
+- `scripts/complexity.sh <repo> [base-ref]`: TSV of functions at or over `CCN_MAX` (default
+  15), worst first. Exit 0 clean, 1 hotspots, 3 no tool (reported, never a silent pass).
+
+### Changed
+- `review` check `5_complexity` now cites `complexity.sh` output instead of "functions > 30
+  lines?".
+- `deterministic-review.sh` gains a `complexity` lane at MED severity. It never gates: a new
+  lane that breaks a build on first run is worse than no lane.
+
 ## [9.5.4] - 2026-08-26
 
 Guards that refuse teach nothing; hooks that correct teach in the same turn.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: ce05c64af2e12ec0147774edd9c9166dcbc7fec2e63f241ecc9afdc894b206b3; adapter: claude -->
-<kernel version="9.5.4">
+<kernel version="9.6.0">
 
 
 <!-- ============================================ -->

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ codex plugin marketplace add ariaxhan/kernel-claude
 codex plugin add kernel@kernel-marketplace
 ```
 
-Gemini CLI (methodology only: the 27 skills and `llms.txt` as ambient context; the hooks, the
+Gemini CLI (methodology only: the 28 skills and `llms.txt` as ambient context; the hooks, the
 approval token, and agentdb do not run on this host):
 
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -119,7 +119,7 @@ was removed.
 
 ## Codex behavior boundaries
 
-Codex loads all 27 KERNEL skills, with explicit calls written as `$kernel:<name>`.
+Codex loads all 28 KERNEL skills, with explicit calls written as `$kernel:<name>`.
 Use `$kernel:governance-sync` (or Claude's `/kernel:governance-sync`) to audit native
 instruction coverage. Writes require explicit confirmation and a backup directory.
 Explicit-only skills (5): `experiment`, `forge`, `governance-sync`, `init`,

--- a/docs/daily-use.md
+++ b/docs/daily-use.md
@@ -18,7 +18,7 @@ In Codex, replace the leading `/` with `$`, for example `$kernel:validate`.
   `marketing-site`, and more
 - Setup/reference: `init`, `help`, `landing-page`
 
-There are 27 skills and 10 specialized Claude Code agent definitions in this release. Use
+There are 28 skills and 10 specialized Claude Code agent definitions in this release. Use
 `/kernel:help` in Claude Code or `$kernel:help` in Codex for the live index and plugin
 status.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.5.4",
+  "version": "9.6.0",
   "description": "KERNEL's methodology layer for Gemini CLI: 27 software-engineering agent skills plus llms.txt as ambient context. Skills cover systematic debugging (reproduce, isolate, regression-test), generating competing approaches before implementing, pre-implementation critique, code review, bounded context handoff and resume, multi-agent orchestration, eval-driven development, release gating, and context-led frontend design. Gemini CLI gets the methodology only. KERNEL's enforcement layer does not run here: the PreToolUse hooks that block destructive commands and secret writes, the one-time human approval token for irreversible operations, and the agentdb SQLite memory recalled at session start are Claude Code and Codex only. `gemini extensions install` fetches a curated release bundle that carries just this manifest, llms.txt, and skills/, so no Claude-format hook or agent definition is loaded. Source, safety limits, and the host capability matrix: https://github.com/ariaxhan/kernel-claude",
   "contextFileName": "llms.txt"
 }

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 > that carries lessons between sessions.
 
 Repository: https://github.com/ariaxhan/kernel-claude
-License: MIT. Version 9.5.4. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+License: MIT. Version 9.6.0. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
 
 ## What it is
 
@@ -113,6 +113,7 @@ agentdb learn failure|pattern|gotcha "<what>" "<evidence>"  # after discovering
 - `/kernel:build` · `$kernel:build`: generate two or three approaches before implementing, take the simplest.
 - `/kernel:debug` · `$kernel:debug`: reproduce, hypothesize, isolate by binary search, fix root cause, add a regression test.
 - `/kernel:diagnose` · `$kernel:diagnose`: diagnosis before prescription for bugs and refactors.
+- `/kernel:simplify` · `$kernel:simplify`: reduce cyclomatic complexity, measured by lizard, worst function first, before/after table re-measured by a verifier.
 - `/kernel:review` · `$kernel:review`: code review with a deterministic scanner lane and a refutation pass; APPROVE, REQUEST CHANGES, or COMMENT.
 - `/kernel:tearitapart` · `$kernel:tearitapart`: pre-implementation critique; PROCEED, REVISE, or RETHINK.
 - `/kernel:ship` · `$kernel:ship`: release gate: validate, review, publish, tag.

--- a/llms.txt
+++ b/llms.txt
@@ -69,7 +69,7 @@ the Claude Code agent definitions natively. Matrix: `docs/kernel-9/HOST-CAPABILI
 gemini extensions install https://github.com/ariaxhan/kernel-claude
 ```
 
-Gemini CLI gets the methodology layer only: the 27 skills and this file as ambient context. It does
+Gemini CLI gets the methodology layer only: the 28 skills and this file as ambient context. It does
 not get the enforcement layer. Gemini CLI 0.44.1 implements no `PreToolUse`, `PostToolUse`,
 `UserPromptSubmit`, `Stop`, `PreCompact`, `PermissionRequest`, or `PostToolUseFailure` event, which
 is where every KERNEL guardrail binds, and it does not substitute `${CLAUDE_PLUGIN_ROOT}` in a hook

--- a/scripts/complexity.sh
+++ b/scripts/complexity.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# complexity.sh <repo-dir> [base-ref]
+#
+# Cyclomatic complexity per function, worst first. The measurement lane behind
+# /kernel:simplify and the review skill's complexity check: a number a tool produced, not a
+# question the model answers about itself.
+#
+# Uses lizard (polyglot: Python, JS/TS, Go, Rust, Swift, Java, C, ...). Runs it from PATH,
+# else via `uvx lizard` (no install). Neither present: prints SKIPPED and exits 3, never a
+# silent pass.
+#
+# Diff mode (base-ref given): only files changed since base-ref are measured.
+# Threshold: $CCN_MAX (default 15). A project linter config with its own complexity
+# threshold outranks this default; the caller passes it through CCN_MAX.
+#
+# Output: TSV to stdout, file<TAB>line<TAB>function<TAB>ccn<TAB>nloc, sorted by ccn desc,
+#         only functions at or above CCN_MAX. Exit 0 if none, 1 if any, 3 if no tool.
+set -u
+
+REPO="${1:?usage: complexity.sh <repo-dir> [base-ref]}"
+BASE="${2:-}"
+CCN_MAX="${CCN_MAX:-15}"
+cd "$REPO" || exit 2
+
+if command -v lizard >/dev/null; then LIZ=(lizard)
+elif command -v uvx >/dev/null; then LIZ=(uvx --quiet lizard)
+else echo "lizard SKIPPED (install: pip install lizard, or have uvx on PATH)" >&2; exit 3; fi
+
+EXCL=(-x '*/node_modules/*' -x '*/dist/*' -x '*/build/*' -x '*/.venv/*' -x '*/venv/*'
+      -x '*/.svelte-kit/*' -x '*/.next/*' -x '*/vendor/*' -x '*/graphify-out/*' -x '*.min.js')
+
+TARGETS=()
+if [ -n "$BASE" ]; then
+  while IFS= read -r f; do [ -n "$f" ] && [ -f "$f" ] && TARGETS+=("$f"); done < <(
+    git diff --name-only --diff-filter=d "$BASE"...HEAD 2>/dev/null || git diff --name-only --diff-filter=d "$BASE"..HEAD)
+  [ "${#TARGETS[@]}" -eq 0 ] && exit 0
+else
+  TARGETS=(.)
+fi
+
+# lizard -w prints one warning per function over the threshold:
+#   path:line: warning: name has N NLOC, M CCN, ...
+OUT="$("${LIZ[@]}" -w -C "$CCN_MAX" "${EXCL[@]}" "${TARGETS[@]}" 2>/dev/null \
+  | sed -E 's#^\./##; s/^([^:]+):([0-9]+): warning: (.+) has ([0-9]+) NLOC, ([0-9]+) CCN.*$/\1\t\2\t\3\t\5\t\4/' \
+  | awk -F'\t' 'NF==5 && $2 ~ /^[0-9]+$/ && $4 ~ /^[0-9]+$/' \
+  | sort -t"$(printf '\t')" -k4,4nr -k1,1)"
+[ -z "$OUT" ] && exit 0
+printf '%s\n' "$OUT"
+exit 1

--- a/scripts/deterministic-review.sh
+++ b/scripts/deterministic-review.sh
@@ -14,6 +14,7 @@
 #
 # Install the lanes (all free; any subset works, missing ones are reported as SKIPPED):
 #   brew install gitleaks semgrep actionlint zizmor osv-scanner shellcheck jq
+#   pip install lizard   (or have uvx on PATH; complexity lane, MED severity, never gates)
 # Licensing: semgrep Community rules are internal-use only (no resale/SaaS on top of them);
 # gitleaks/actionlint/zizmor MIT, osv-scanner Apache-2.0, shellcheck GPL-3.0 (tool-only).
 set -u
@@ -86,6 +87,12 @@ if command -v osv-scanner >/dev/null; then
   note osv-scanner RAN
 else note osv-scanner SKIPPED; fi
 
+CX_SH="$(dirname "$0")/complexity.sh"
+if [ -x "$CX_SH" ] && { command -v lizard >/dev/null || command -v uvx >/dev/null; }; then
+  ( "$CX_SH" . ${BASE:+"$BASE"} > "$T/complexity.tsv" 2>/dev/null; true ) &
+  note complexity RAN
+else note complexity SKIPPED; fi
+
 wait
 
 # --- normalize -------------------------------------------------------------------------
@@ -100,6 +107,8 @@ J "$T/shellcheck.json" && jq -r '.[] | [.file, (.line|tostring), "shellcheck", (
 J "$T/actionlint.json" && jq -r '.[] | [.filepath, (.line|tostring), "actionlint", "MED", .message] | @tsv' "$T/actionlint.json" >> "$F" 2>/dev/null
 J "$T/zizmor.json" && jq -r '.[]? | (.locations[0].symbolic.key.Local.given_path // "workflow") as $f | [$f, "0", "zizmor", (if .determinations.severity=="High" then "HIGH" else "MED" end), .ident] | @tsv' "$T/zizmor.json" >> "$F" 2>/dev/null
 J "$T/osv.json" && jq -r '.results[]?.packages[]? | .package.name as $p | .vulnerabilities[]? | [$p, "0", "osv-scanner", (if ((.database_specific.severity//"")|ascii_downcase)=="critical" or ((.database_specific.severity//"")|ascii_downcase)=="high" then "HIGH" else "MED" end), .id] | @tsv' "$T/osv.json" >> "$F" 2>/dev/null
+
+[ -s "$T/complexity.tsv" ] && awk -F'\t' 'BEGIN{OFS="\t"} {print $1, $2, "complexity", "MED", $3 " CCN " $4 " (>= " CCN_MAX ")"}' CCN_MAX="${CCN_MAX:-15}" "$T/complexity.tsv" >> "$F"
 
 sort -t"$(printf '\t')" -k4,4 -k1,1 -o "$F" "$F"
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.5.4.
+Quick reference for KERNEL v9.6.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>
@@ -56,6 +56,7 @@ agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global
 | `/kernel:forge` | Autonomous engine, heat/hammer/quench/anneal | Run overnight. Iterates until antifragile or reports why not. |
 | `/kernel:dream` | Creative exploration, 3 perspectives + stress test | When you need competing approaches before committing. |
 | `/kernel:diagnose` | Systematic debugging + refactor analysis | Bugs, regressions, or before refactoring. Diagnosis before prescription. |
+| `/kernel:simplify` | Cut cyclomatic complexity, measured by lizard, verified by re-measure | Jungle code, god functions, after any AI-written branchy function. A number, not an opinion. |
 
 ## Quality & Review (kind: validator)
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -95,8 +95,10 @@ detection: grep -r "catch.*{}" (empty catch)
 </check>
 
 <check id="5_complexity">
-- Functions > 30 lines?
+- Any function with cyclomatic complexity >= 15? A number, not a guess.
 - Nested ternaries > 2 levels?
+detection: ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo> <base-ref>  (exit 1 = hotspots listed, exit 3 = no tool, say so)
+fix: /kernel:simplify on the listed functions
 </check>
 </big5>
 

--- a/skills/simplify/SKILL.md
+++ b/skills/simplify/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: simplify
+description: "Reduce cyclomatic complexity with a number, not an opinion. Measures every function with lizard, refactors the worst first, refuses to game the metric, and hands the before/after table to a verifier that re-measures. Triggers: simplify, refactor, complexity, spaghetti, nested, god function, untangle."
+user-invocable: true
+allowed-tools: Agent, Bash, Read, Edit, Write, Grep, Glob
+kernel:
+  kind: workflow
+  version: 1
+  side_effects: writes_source
+  confirmation: none
+---
+
+<skill id="simplify">
+
+<purpose>
+AI-written code works but branches like a jungle. This skill forces one measurement the model
+cannot skip (cyclomatic complexity per function, from a tool) and names the one way it will
+cheat (hiding branches in dense one-liners). Prose about "cleaner code" is not accepted; the
+number is.
+
+Adapted from saurabhkumar8112/cyclomatic-complexity-skill (Apache-2.0), with one change:
+the refactoring model never signs its own before/after table. A verifier re-measures.
+</purpose>
+
+<on_start>
+agentdb recall "simplify complexity <files/symbols>" --global
+</on_start>
+
+<measure>
+```bash
+# whole repo, worst first (TSV: file, line, function, ccn, nloc)
+${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo-dir>
+# only what this branch changed
+${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo-dir> <base-ref>
+```
+The project's own linter config wins. If eslint `complexity`, radon, sonar, or golangci
+sets a threshold, pass it: `CCN_MAX=<n> scripts/complexity.sh ...`. No config: default 15.
+
+Exit 3 means no lizard and no uvx. Say so and count by hand (decision points + 1:
+`if`, `elif`, `case`, loops, `catch`, ternary, `&&`/`||` in conditions). Never skip silently.
+
+Ladder (default, project config outranks it):
+- 1 to 5: leave alone
+- 6 to 10: refactor only if already touching
+- 11 to 15: refactor now
+- over 15: must split
+</measure>
+
+<workflow>
+1. Measure. Print the table before touching anything. Rank by CCN descending.
+2. Confirm tests exist and pass. None: say so, refactor conservatively, propose one test per
+   extracted function.
+3. Refactor worst first, one function at a time, commit each working state.
+4. Re-measure the same command. Print before/after.
+5. Hand off to the verifier (below). Its re-measure is the record, not yours.
+</workflow>
+
+<tactics order="preference">
+1. Guard clauses: invert, return early, kill nesting.
+2. Extract function. The name says what, not how. Names are documentation.
+3. Lookup table or map instead of if/else or switch chains.
+4. Named predicates: `if is_eligible_for_refund(order)` beats a four-clause boolean.
+5. Polymorphism or strategy for switch-on-type, only when the switch appears in 2+ places.
+6. Flatten loops: extract the body, `continue` instead of nested `if`.
+</tactics>
+
+<hard_rules>
+- Preserve behavior. Tests before and after. Same inputs, same outputs, same errors.
+- Do not game the metric. A dense one-liner hiding six branches is worse than the honest
+  if-chain it replaced. Complexity moves into named units; it never disappears into cleverness.
+  A CCN drop with a rising token count per line is the tell.
+- Do not change public APIs or exported signatures without asking.
+- One responsibility per function. If the name needs "and", split again.
+- Small functions with clear names beat few functions with section comments.
+</hard_rules>
+
+<verify>
+Spawn a verifier that never saw this session's reasoning. It receives: the diff, the before
+table, the claimed after table, the test command, and this contract:
+
+```
+ACCEPTANCE: every function in the before table is at or under the after value claimed
+ACCEPT WHEN: complexity.sh re-run matches the claimed after table; tests pass; no exported signature changed
+CHECK: ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo> <base-ref>; <test command>; git diff <base-ref> -- <files> | grep -E '^[-+](def |export |func |pub fn )'
+ESCALATE IF: any function's re-measured CCN exceeds the claim, or a one-liner replaced a branch without a name
+DISCOVERY AXIS: invariant
+```
+Builder and verifier identities go on the receipt. The builder never fills in "behavior verified".
+</verify>
+
+<output>
+End with, and nothing after it:
+```
+## Complexity report
+| Function | Before | After |
+|----------|--------|-------|
+| parse_order | 14 | 4 |
+
+Extracted: validate_header, resolve_discount
+Tests: <command> <pass/fail before> -> <pass/fail after>
+Verified by: <verifier identity> (re-measured: match | mismatch)
+```
+Keep prose minimal. Numbers and diffs do the talking.
+</output>
+
+</skill>

--- a/skills/simplify/SKILL.md
+++ b/skills/simplify/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: simplify
-description: "Reduce cyclomatic complexity with a number, not an opinion. Measures every function with lizard, refactors the worst first, refuses to game the metric, and hands the before/after table to a verifier that re-measures. Triggers: simplify, refactor, complexity, spaghetti, nested, god function, untangle."
+description: "Cut cyclomatic complexity: lizard measures, worst first, a verifier re-measures. Triggers: simplify, refactor, complexity, spaghetti, god function."
 user-invocable: true
-allowed-tools: Agent, Bash, Read, Edit, Write, Grep, Glob
+allowed-tools: Agent, Bash, Read, Edit, Grep, Glob
 kernel:
   kind: workflow
   version: 1

--- a/skills/simplify/SKILL.md
+++ b/skills/simplify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simplify
-description: "Cut cyclomatic complexity: lizard measures, worst first, a verifier re-measures. Triggers: simplify, refactor, complexity, spaghetti, god function."
+description: "Lower cyclomatic complexity: lizard measures, a verifier re-measures. Triggers: simplify, refactor, complexity, spaghetti."
 user-invocable: true
 allowed-tools: Agent, Bash, Read, Edit, Grep, Glob
 kernel:


### PR DESCRIPTION
🔧 ready to merge

One line: `/kernel:simplify` measures cyclomatic complexity with lizard, refactors worst first, and a verifier re-measures the before/after table. The review skill now cites that number instead of asking "functions > 30 lines?".

| What | Consequence |
|---|---|
| `scripts/complexity.sh <repo> [base]` | TSV of functions at or over `CCN_MAX` (15). Exit 3 when no tool, never a silent pass |
| `/kernel:simplify` | Worst first, anti-gaming rule, builder never signs "behavior verified" |
| review check 5 | a measurement, not a question |
| deterministic-review lane | MED severity only, never breaks a build |

<details><summary>Evidence</summary>

Source: https://github.com/saurabhkumar8112/cyclomatic-complexity-skill (Apache-2.0).

Run on this repo: `scripts/governance-sync.py classify` CCN 33, `hooks/scripts/autocorrect-tool-input.py main` CCN 57.

Tests: 482 passed. `test_contributor_ambient_within_budget` fails on main before this branch (12175 tok vs 11000 ratchet); not addressed here.
</details>
