### PR TITLE
9.6.1: the hook stops saying grep has no -P once a shim makes it work, plus three noise fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
-      "version": "9.6.0"
+      "version": "9.6.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: ce05c64af2e12ec0147774edd9c9166dcbc7fec2e63f241ecc9afdc894b206b3; adapter: codex -->
-<kernel version="9.6.0">
+<kernel version="9.6.1">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.6.1] - 2026-08-27
+
+A note that is not probed outlives the fix that made it false.
+
+The day after `install-agent-compat.sh` shimmed `grep -P` on the operator's Mac, the autocorrect
+hook was still telling the model "macOS grep has no -P". The model believed it and rewrote a
+working script with awk (#226). Three smaller noise sources rode along.
+
+### Fixed
+- `autocorrect-bash` R6 probes `grep -P` on the host before speaking, like R7 already did with
+  `have()`. Silent where a shim, GNU grep, or ugrep makes it work.
+- `autocorrect-bash` R2b no longer reads `2>/dev/null`, `&>x`, or the target of `cat > file`
+  as a missing path, and expands `~` before joining with cwd.
+- `syntax-coach` only coaches `command not found` from a whole output line; the phrase inside
+  quoted text (an issue body, a transcript) no longer coaches a curl that never ran.
+
+### Added
+- `autocorrect-bash` R14: under a zsh tool shell, top-level `${PIPESTATUS[n]}` becomes
+  `${pipestatus[n+1]}` (zsh is lowercase and 1-indexed; `PIPESTATUS` expands to nothing there).
+  Heredoc bodies are untouched: they run under bash. Four tests.
+
+### Changed
+- `docs/upgrading.md` and the ship skill: upgrading the plugin deletes the old cache directory
+  while sessions started before the upgrade still resolve hook paths into it, so every hook
+  in those sessions exits 127 until they restart. Check `pgrep -fl codex` first and say who
+  needs a restart.
+
 ## [9.6.0] - 2026-08-27
 
 A skill is only as strong as the one measurement it refuses to let the model skip.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: ce05c64af2e12ec0147774edd9c9166dcbc7fec2e63f241ecc9afdc894b206b3; adapter: claude -->
-<kernel version="9.6.0">
+<kernel version="9.6.1">
 
 
 <!-- ============================================ -->

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -74,6 +74,15 @@ codex plugin marketplace upgrade kernel-marketplace
 Restart Codex after the upgrade. Current Codex refreshes the installed plugin cache as part
 of the marketplace upgrade; there is no `codex plugin update` command.
 
+Restart every Codex session that was open during the upgrade, not just new ones. The upgrade
+deletes the previous version's cache directory
+(`~/.codex/plugins/cache/kernel-marketplace/kernel/<old>/`), and a session that started
+before the upgrade has already resolved its hook paths into that directory. Every hook in
+that session then fails with `hook exited with code 127` (path not found) until it restarts.
+Check first: `pgrep -fl codex` lists what is live. Seen 2026-08-27 on the 9.5.4 to 9.6.0
+upgrade: three UserPromptSubmit failures per prompt in every pre-upgrade session, while the
+same scripts ran clean from the new directory.
+
 Start a new session if Claude Code says a component or monitor could not reload. VS Code may
 show a restart banner.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "KERNEL's methodology layer for Gemini CLI: 27 software-engineering agent skills plus llms.txt as ambient context. Skills cover systematic debugging (reproduce, isolate, regression-test), generating competing approaches before implementing, pre-implementation critique, code review, bounded context handoff and resume, multi-agent orchestration, eval-driven development, release gating, and context-led frontend design. Gemini CLI gets the methodology only. KERNEL's enforcement layer does not run here: the PreToolUse hooks that block destructive commands and secret writes, the one-time human approval token for irreversible operations, and the agentdb SQLite memory recalled at session start are Claude Code and Codex only. `gemini extensions install` fetches a curated release bundle that carries just this manifest, llms.txt, and skills/, so no Claude-format hook or agent definition is loaded. Source, safety limits, and the host capability matrix: https://github.com/ariaxhan/kernel-claude",
   "contextFileName": "llms.txt"
 }

--- a/hooks/scripts/autocorrect-bash.py
+++ b/hooks/scripts/autocorrect-bash.py
@@ -113,9 +113,9 @@ def first_line_segments(command):
             if line.strip() == in_doc:
                 in_doc = None
             continue
-        m = re.search(r"<<-?\s*'?([A-Za-z_][A-Za-z0-9_]*)'?", line)
+        m = re.search(r"<<-?\s*(?:'([A-Za-z_][A-Za-z0-9_]*)'|\"([A-Za-z_][A-Za-z0-9_]*)\"|\\?([A-Za-z_][A-Za-z0-9_]*))", line)
         if m:
-            in_doc = m.group(1)
+            in_doc = m.group(1) or m.group(2) or m.group(3)
         yield i, line
 
 
@@ -309,6 +309,7 @@ def rule_read_paths(command, cwd, project_dir, notes):
     # A file this same command creates (`... > out.txt; wc -l out.txt`) does not exist yet at
     # hook time and must not be reported missing.
     created = set(m.group(1).strip("\"'") for m in re.finditer(r"(?:^|[^<>])>{1,2}\s*([^\s;&|]+)", command))
+    created |= set(m.group(1).strip("\"'") for m in re.finditer(r"(?:^|[|;&(]\s*|\s)tee\s+(?:-[a-z]+\s+)*([^\s;&|]+)", command))
     for i, line in first_line_segments(command):
         for seg in re.split(r"\s*(?:&&|\|\||;|\|)\s*", line):
             toks = seg.strip().split()
@@ -400,7 +401,15 @@ def rule_pipestatus_zsh(command, notes):
     lines = command.split("\n")
     changed = False
     noted = False
+    # A string handed to another interpreter runs THERE, not in the tool shell: bash -c, sh -c,
+    # ssh, sudo, env, xargs, script. Leave the whole line alone (the blind verifier's bash -c
+    # reproducer printed rc= instead of rc=1 after a rewrite).
+    other_shell = re.compile(r"(^|[|;&(]\s*|\s)(bash|sh|zsh|dash|ksh|ssh|sudo|env|xargs|script|nohup|caffeinate)(\s|$)")
     for i, line in first_line_segments(command):
+        if other_shell.search(line):
+            if "${PIPESTATUS[" in line:
+                noted = True
+            continue
         def fix(m):
             nonlocal changed, noted
             idx = m.group(1)
@@ -412,7 +421,11 @@ def rule_pipestatus_zsh(command, notes):
                 return "${pipestatus[" + str(int(idx) + 1) + "]"
             noted = True
             return m.group(0)
-        new = re.sub(r"\$\{PIPESTATUS\[([^\]]+)\]", fix, line)
+        # Single-quoted spans are literal text in every shell; rewrite only outside them.
+        parts = re.split(r"('[^']*')", line)
+        for k in range(0, len(parts), 2):
+            parts[k] = re.sub(r"\$\{PIPESTATUS\[([^\]]+)\]", fix, parts[k])
+        new = "".join(parts)
         if new != line:
             lines[i] = new
     if changed:
@@ -420,13 +433,13 @@ def rule_pipestatus_zsh(command, notes):
                      "array is lowercase and 1-indexed and `PIPESTATUS` expands to nothing. Inside a script run "
                      "by bash, keep `PIPESTATUS` (0-indexed) or use `set -o pipefail`.")
     if noted:
-        notes.append("R14 `${PIPESTATUS[<expr>]}` under zsh expands to nothing; the array is `pipestatus`, 1-indexed. Not rewritten (index is not a literal).")
+        notes.append("R14 `${PIPESTATUS[...]}` left alone (non-literal index, or the line hands a string to another shell such as bash -c / ssh, where PIPESTATUS is correct). In this zsh tool shell the array is `pipestatus`, 1-indexed.")
     return "\n".join(lines) if changed else command
 
 
 def rule_notes_only(command, notes):
     """R6/R7: things we will not rewrite, but the model should hear about BEFORE the call fails."""
-    if is_macos() and re.search(r"(^|[|;&(]\s*|\s)grep\s+-[a-zA-Z]*P", command) and not grep_has_P():
+    if is_macos() and re.search(r"(^|[|;&(]\s*|\s)grep\s+(-[a-zA-Z]*P|--perl-regexp)", command) and not grep_has_P():
         notes.append("R6 grep on this host has no -P (PCRE) and no shim is installed. Use `rg -P '<pattern>'`, "
                      "or `grep -E` for an ERE pattern.")
     for tool, alt in (("timeout", "gtimeout (brew install coreutils) or the Bash tool's own `timeout` parameter"),
@@ -443,9 +456,11 @@ def main():
         data = json.load(sys.stdin)
     except Exception:
         return
+    if not isinstance(data, dict):
+        return
     if data.get("tool_name") not in (None, "Bash"):
         return
-    ti = data.get("tool_input") if isinstance(data, dict) else None
+    ti = data.get("tool_input")
     if not isinstance(ti, dict):
         return
     command = ti.get("command")

--- a/hooks/scripts/autocorrect-bash.py
+++ b/hooks/scripts/autocorrect-bash.py
@@ -34,9 +34,16 @@ Rules (each one names the evidence that earned it):
   R5  `sed -i 's/...'` GNU in-place form on BSD sed                     -> `sed -i '' 's/...'`
       (2 occurrences: `invalid command code`)
   R6  `grep -P` on BSD grep: NOT rewritten (ERE and PCRE differ), note only, points at `rg -P`.
+      Probed, not assumed: silent when `grep -P` works on this host (a shim, GNU grep, ugrep).
+      A static note outlived the shim that fixed it and taught a model to rewrite working code
+      (kernel #226, 2026-08-27).
   R7  `timeout N`, `shuf`, `tac` missing: NOT rewritten, note only, points at coreutils/gtimeout.
       (42 blocks; the vault fix is `brew install coreutils` + shims, this note is for other hosts)
+  R14 `${PIPESTATUS[n]}` at top level when the tool shell is zsh          -> `${pipestatus[n+1]}`
+      (zsh spells it lowercase and indexes from 1; `PIPESTATUS` expands to nothing there, so the
+      exit code printed blank and a working script got blamed, kernel #226)
 """
+import subprocess
 import json
 import os
 import re
@@ -77,6 +84,20 @@ def log(rec):
 
 def have(cmd):
     return shutil.which(cmd) is not None
+
+
+def grep_has_P():
+    """True when `grep -P` works on this host (GNU grep, ugrep, or a shim over rg). Probed,
+    because the answer changed under the old static note the day a shim was installed."""
+    try:
+        r = subprocess.run(["grep", "-P", "a"], input=b"a\n", capture_output=True, timeout=2)
+        return r.returncode == 0 and r.stdout.strip() == b"a"
+    except Exception:
+        return False
+
+
+def tool_shell_is_zsh():
+    return os.path.basename(os.environ.get("SHELL", "")) == "zsh"
 
 
 def is_macos():
@@ -285,19 +306,33 @@ def rule_read_paths(command, cwd, project_dir, notes):
     87 'file guessed wrong' failures in 14 days; most were a wrong directory for a real file."""
     lines = command.split("\n")
     changed = False
+    # A file this same command creates (`... > out.txt; wc -l out.txt`) does not exist yet at
+    # hook time and must not be reported missing.
+    created = set(m.group(1).strip("\"'") for m in re.finditer(r"(?:^|[^<>])>{1,2}\s*([^\s;&|]+)", command))
     for i, line in first_line_segments(command):
         for seg in re.split(r"\s*(?:&&|\|\||;|\|)\s*", line):
             toks = seg.strip().split()
             if not toks or os.path.basename(toks[0]) not in READ_CMDS:
                 continue
+            skip_next = False
             for tok in toks[1:]:
+                if skip_next:
+                    skip_next = False
+                    continue  # the target of a bare `>` / `>>` / `<`: a write target is never a read path
+                if tok in (">", ">>", "<"):
+                    skip_next = True
+                    continue
                 if tok.startswith("-") or "$" in tok or "*" in tok or "{" in tok or tok in ("|", ">", ">>"):
                     continue
+                if re.match(r"^[0-9&]*[<>]", tok):
+                    continue  # a redirection (`2>/dev/null`, `>out`, `&>x`), not a path
                 if not ("/" in tok or tok.endswith((".md", ".py", ".ts", ".js", ".json", ".sh", ".txt", ".yaml", ".yml", ".toml"))):
                     continue
-                p = tok.strip("\"'")
-                full = p if p.startswith("/") else os.path.join(cwd, p)
-                if os.path.exists(os.path.expanduser(full)):
+                p = os.path.expanduser(tok.strip("\"'"))
+                if tok.strip("\"'") in created:
+                    continue
+                full = p if os.path.isabs(p) else os.path.join(cwd, p)
+                if os.path.exists(full):
                     continue
                 hits = find_by_basename(p, project_dir)
                 if len(hits) == 1:
@@ -307,7 +342,7 @@ def rule_read_paths(command, cwd, project_dir, notes):
                 elif hits:
                     notes.append(f"R2b `{p}` does not exist. Same name elsewhere: {', '.join(hits[:4])}. Not rewritten.")
                 else:
-                    parent = os.path.dirname(os.path.expanduser(full))
+                    parent = os.path.dirname(full)
                     sib = sorted(os.listdir(parent))[:8] if os.path.isdir(parent) else []
                     notes.append(f"R2b `{p}` does not exist" + (f"; {parent} holds: {', '.join(sib)}" if sib else f" and neither does {parent}") + ". Not rewritten.")
     return "\n".join(lines) if changed else command
@@ -355,10 +390,45 @@ def rule_shell_shape_notes(command, notes):
         notes.append("R13 `${x:-{}}` closes at the first `}` and corrupts the payload; assign the default first (`x=${x:-'{}'}`).")
 
 
+def rule_pipestatus_zsh(command, notes):
+    """R14: the Bash tool runs the login shell. Under zsh `PIPESTATUS` expands to nothing and the
+    array is `pipestatus`, indexed from 1. Literal indexes shift by one; `[@]` and `[*]` pass
+    through; a non-literal index gets a note, never a guess. Top-level lines only: a heredoc
+    body is a script that will run under bash."""
+    if not tool_shell_is_zsh():
+        return command
+    lines = command.split("\n")
+    changed = False
+    noted = False
+    for i, line in first_line_segments(command):
+        def fix(m):
+            nonlocal changed, noted
+            idx = m.group(1)
+            if idx in ("@", "*"):
+                changed = True
+                return "${pipestatus[" + idx + "]"
+            if idx.isdigit():
+                changed = True
+                return "${pipestatus[" + str(int(idx) + 1) + "]"
+            noted = True
+            return m.group(0)
+        new = re.sub(r"\$\{PIPESTATUS\[([^\]]+)\]", fix, line)
+        if new != line:
+            lines[i] = new
+    if changed:
+        notes.append("R14 rewrote `${PIPESTATUS[n]}` -> `${pipestatus[n+1]}`: this tool shell is zsh, where the "
+                     "array is lowercase and 1-indexed and `PIPESTATUS` expands to nothing. Inside a script run "
+                     "by bash, keep `PIPESTATUS` (0-indexed) or use `set -o pipefail`.")
+    if noted:
+        notes.append("R14 `${PIPESTATUS[<expr>]}` under zsh expands to nothing; the array is `pipestatus`, 1-indexed. Not rewritten (index is not a literal).")
+    return "\n".join(lines) if changed else command
+
+
 def rule_notes_only(command, notes):
     """R6/R7: things we will not rewrite, but the model should hear about BEFORE the call fails."""
-    if is_macos() and re.search(r"(^|[|;&(]\s*|\s)grep\s+-[a-zA-Z]*P", command):
-        notes.append("R6 macOS grep has no -P (PCRE). Use `rg -P '<pattern>'`, or `grep -E` for an ERE pattern.")
+    if is_macos() and re.search(r"(^|[|;&(]\s*|\s)grep\s+-[a-zA-Z]*P", command) and not grep_has_P():
+        notes.append("R6 grep on this host has no -P (PCRE) and no shim is installed. Use `rg -P '<pattern>'`, "
+                     "or `grep -E` for an ERE pattern.")
     for tool, alt in (("timeout", "gtimeout (brew install coreutils) or the Bash tool's own `timeout` parameter"),
                       ("shuf", "gshuf (brew install coreutils) or `sort -R`"),
                       ("tac", "gtac (brew install coreutils) or `tail -r`")):
@@ -396,6 +466,7 @@ def main():
     new = rule_backticks_in_text_args(new, notes)
     new = rule_house_forms(new, notes)
     new = rule_read_paths(new, cwd, project_dir, notes)
+    new = rule_pipestatus_zsh(new, notes)
     rule_shell_shape_notes(new, notes)
     rule_notes_only(new, notes)
 

--- a/hooks/scripts/autocorrect-tool-input.py
+++ b/hooks/scripts/autocorrect-tool-input.py
@@ -37,6 +37,8 @@ def main():
         data = json.load(sys.stdin)
     except Exception:
         return
+    if not isinstance(data, dict):
+        return
     tool = data.get("tool_name") or ""
     ti = data.get("tool_input") or {}
     if not isinstance(ti, dict):

--- a/hooks/scripts/syntax-coach.py
+++ b/hooks/scripts/syntax-coach.py
@@ -108,9 +108,9 @@ def main():
         data = json.load(sys.stdin)
     except Exception:
         return
-    if data.get("tool_name") not in (None, "Bash"):
-        return
     if not isinstance(data, dict):
+        return
+    if data.get("tool_name") not in (None, "Bash"):
         return
     ti = data.get("tool_input")
     command = (ti.get("command") if isinstance(ti, dict) else None) or ""
@@ -130,8 +130,8 @@ def main():
 
     # Whole-line shapes only. Unanchored, `not found: curl` inside quoted text (an issue body, a
     # transcript excerpt) coached a curl that was never run (kernel #226).
-    for m in re.finditer(r"^(?:[A-Za-z0-9_./-]+:(?: ?\d+:)? ?)?(?:command not found: |not found: )([A-Za-z0-9_.-]+)\s*$"
-                         r"|^(?:[A-Za-z0-9_./-]+:(?: ?\d+:)? ?)?([A-Za-z0-9_.-]+): (?:command )?not found\s*$", outp, re.M):
+    for m in re.finditer(r"^\s*(?:[A-Za-z0-9_./-]+:(?: ?(?:line )?\d+:)? ?)?(?:command not found: |not found: )([A-Za-z0-9_.-]+)\s*$"
+                         r"|^\s*(?:[A-Za-z0-9_./-]+:(?: ?(?:line )?\d+:)? ?)?([A-Za-z0-9_.-]+): (?:command )?not found\s*$", outp, re.M):
         name = m.group(1) or m.group(2)
         if not name:
             continue

--- a/hooks/scripts/syntax-coach.py
+++ b/hooks/scripts/syntax-coach.py
@@ -128,7 +128,10 @@ def main():
             if re.search(pat, outp):
                 notes.append(fix)
 
-    for m in re.finditer(r"(?:command not found: |not found: |: command not found)\s*([A-Za-z0-9_.-]+)|^(?:zsh|bash|sh): ([A-Za-z0-9_.-]+): command not found", outp, re.M):
+    # Whole-line shapes only. Unanchored, `not found: curl` inside quoted text (an issue body, a
+    # transcript excerpt) coached a curl that was never run (kernel #226).
+    for m in re.finditer(r"^(?:[A-Za-z0-9_./-]+:(?: ?\d+:)? ?)?(?:command not found: |not found: )([A-Za-z0-9_.-]+)\s*$"
+                         r"|^(?:[A-Za-z0-9_./-]+:(?: ?\d+:)? ?)?([A-Za-z0-9_.-]+): (?:command )?not found\s*$", outp, re.M):
         name = m.group(1) or m.group(2)
         if not name:
             continue

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 > that carries lessons between sessions.
 
 Repository: https://github.com/ariaxhan/kernel-claude
-License: MIT. Version 9.6.0. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+License: MIT. Version 9.6.1. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
 
 ## What it is
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.6.0.
+Quick reference for KERNEL v9.6.1.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -40,6 +40,17 @@ sentence in a doc is honor-system; an artifact fires on its own.
      recalled) is older than 30 days. Load-bearing predicate:
      `COALESCE(last_hit, ts) < datetime('now', '-30 days')`. A recently recalled
      learning is not stale even when its original `ts` is old.
+     **`last_hit` alone is not sufficient evidence to delete.** Two mechanisms deliver a
+     learning without ever stamping it: an injection rule that fires it into every session,
+     and `agentdb learn`'s dedup path, which bumps `hit_count` and leaves `last_hit` null.
+     So before archiving ANY row, subtract the two protected sets:
+     - referenced by a `learning_id` in the project's injection rules, and
+     - `hit_count >= 5`, which is a recall record the stamp failed to reflect.
+     Measured on 2026-08-27 in Vaults: the bare predicate named 22 rows, 11 of them
+     protected, including the most-recalled row in the database (`hit_count` 125) and three
+     rows injected into every session. Archiving on the bare predicate is silent and
+     irreversible. A reference implementation of the subtraction is
+     `_meta/services/agentdb-archive-guard.py`.
    - **Promotable**: Identify patterns worth encoding as artifacts (hit_count 2+, OR hit_count 1x
      when the failure mode is quiet/expensive, don't wait for a third burn on a costly lesson)
    - **Project fit**: Audit the host project's `.claude/` against its actual work. A recurring

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -59,6 +59,11 @@ kernel:
      proven compatibility loader, record the limitation, and defer the native
      manifest until both schemas can be satisfied.
    - Tag (only if user requested a tagged release): `git tag -l` to avoid clobber → `git tag -a v{X.Y.Z} -m "{summary}"` → `git push origin v{X.Y.Z}`.
+   - Before upgrading the installed plugin on this machine: `pgrep -fl codex`. The upgrade
+     deletes the old cache directory under a live session's feet and every hook in that
+     session exits 127 until it restarts. Name the live sessions in the handoff and say
+     they need a restart; never report "upgraded" as if it covered them
+     (docs/upgrading.md, 2026-08-27).
 
 6. **Human pass** *(any user-facing release: app build, deploy, anything a person will touch)*
    - Load `skills/human-pass/SKILL.md` and write the guide for THIS build: literal

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1508,6 +1508,35 @@ test_autocorrect_bash_heredoc_body_untouched() {
   local out; out=$(_hook autocorrect-bash.py "{\"tool_name\":\"Bash\",\"cwd\":\"$PLUGIN_ROOT\",\"tool_input\":{\"command\":\"cat > n.md <<'EOF'\\nrecall this later :!_meta\\nEOF\"}}")
   if printf '%s' "$out" | grep -q 'updatedInput'; then assert_equals "no rewrite" "rewrite" "R9/R10 never rewrite inside a heredoc body"; else assert_equals 0 0 "ok"; fi
 }
+# kernel #226: a static note outlived the shim that fixed it; the model rewrote working code.
+test_autocorrect_bash_grep_P_probes_host() {
+  local out; out=$(_hook autocorrect-bash.py '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"grep -P x f"}}')
+  if printf 'a\n' | grep -P a >/dev/null 2>&1; then assert_equals "" "$out" "R6 stays silent where grep -P works"; else assert_contains "$out" 'R6' "R6 fires where grep -P fails"; fi
+  local off; off=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"grep -P x f"}}' | PATH=/usr/bin:/bin KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
+  if [ "$(uname)" = "Darwin" ]; then assert_contains "$off" 'R6' "R6 fires on a bare BSD PATH"; else assert_equals 0 0 "ok"; fi
+}
+test_autocorrect_bash_redirect_and_tilde_are_not_paths() {
+  local out; out=$(_hook autocorrect-bash.py '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat /etc/hosts 2>/dev/null; cat > new-file.md <<EOF\nx\nEOF"}}')
+  assert_equals "" "$out" "a redirection or a write target is never a missing read path"
+  out=$(_hook autocorrect-bash.py '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat ~/.kernel-does-not-exist.md"}}')
+  if printf '%s' "$out" | grep -q '/~/'; then assert_equals "expanded" "joined" "~ must be expanded before joining with cwd"; else assert_equals 0 0 "ok"; fi
+}
+test_autocorrect_bash_pipestatus_under_zsh() {
+  local out; out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"a | b; echo ${PIPESTATUS[0]}"}}' | SHELL=/bin/zsh KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
+  assert_contains "$out" 'echo ${pipestatus[1]}' "zsh: PIPESTATUS[0] becomes pipestatus[1]"
+  out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"a | b; echo ${PIPESTATUS[0]}"}}' | SHELL=/bin/bash KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
+  assert_equals "" "$out" "bash: PIPESTATUS is left alone"
+  out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat > s.sh <<'"'"'EOF'"'"'\na | b\n[ ${PIPESTATUS[1]} -eq 0 ]\nEOF"}}' | SHELL=/bin/zsh KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
+  if printf '%s' "$out" | grep -q 'pipestatus'; then assert_equals "untouched" "rewritten" "a heredoc body runs under bash; never rewrite it"; else assert_equals 0 0 "ok"; fi
+}
+test_syntax_coach_not_found_needs_a_whole_line() {
+  local out; out=$(_hook syntax-coach.py '{"tool_name":"Bash","tool_input":{"command":"gh issue view 47"},"tool_response":"`not found: curl` from a zsh exec_command while /usr/bin/curl exists"}')
+  assert_equals "" "$out" "not found inside quoted text is not a failed command"
+  out=$(_hook syntax-coach.py '{"tool_name":"Bash","tool_input":{"command":"curl x"},"tool_response":"zsh: command not found: curl"}')
+  assert_contains "$out" 'curl' "a real zsh not-found still coaches"
+  out=$(_hook syntax-coach.py '{"tool_name":"Bash","tool_input":{"command":"python x"},"tool_response":"sh: 1: python: not found"}')
+  assert_contains "$out" 'python' "a real sh not-found still coaches"
+}
 test_hooks_survive_non_dict_tool_input() {
   printf '{"tool_name":"Bash","tool_input":"ls"}' | python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" >/dev/null 2>&1; local a=$?
   printf '{"tool_name":"Bash","tool_input":"ls","tool_response":"x"}' | python3 "$PLUGIN_ROOT/hooks/scripts/syntax-coach.py" >/dev/null 2>&1; local b=$?
@@ -5521,6 +5550,10 @@ run_test_suite() {
       run_test "autocorrect-bash inserts && after cd" test_autocorrect_bash_cd_separator
       run_test "autocorrect-bash rewrites cat -A on macOS" test_autocorrect_bash_cat_A
       run_test "autocorrect-bash is silent on a clean command" test_autocorrect_bash_silent
+      run_test "autocorrect-bash R6 probes grep -P instead of assuming (#226)" test_autocorrect_bash_grep_P_probes_host
+      run_test "autocorrect-bash R2b ignores redirections, write targets and ~ (#226)" test_autocorrect_bash_redirect_and_tilde_are_not_paths
+      run_test "autocorrect-bash R14 PIPESTATUS -> pipestatus under zsh (#226)" test_autocorrect_bash_pipestatus_under_zsh
+      run_test "syntax-coach not-found needs a whole line (#226)" test_syntax_coach_not_found_needs_a_whole_line
       run_test "syntax-coach names the fix for a usage banner" test_syntax_coach_usage
       run_test "syntax-coach is silent on a clean run" test_syntax_coach_silent
       run_test "autocorrect-tool-input adds WebFetch prompt" test_autocorrect_webfetch_prompt

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1511,31 +1511,42 @@ test_autocorrect_bash_heredoc_body_untouched() {
 # kernel #226: a static note outlived the shim that fixed it; the model rewrote working code.
 test_autocorrect_bash_grep_P_probes_host() {
   local out; out=$(_hook autocorrect-bash.py '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"grep -P x f"}}')
-  if printf 'a\n' | grep -P a >/dev/null 2>&1; then assert_equals "" "$out" "R6 stays silent where grep -P works"; else assert_contains "$out" 'R6' "R6 fires where grep -P fails"; fi
+  if printf 'a\n' | grep -P a >/dev/null 2>&1; then assert_equals "" "$out" "R6 stays silent where grep -P works" || return 1; else assert_contains "$out" 'R6' "R6 fires where grep -P fails" || return 1; fi || return 1
   local off; off=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"grep -P x f"}}' | PATH=/usr/bin:/bin KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
-  if [ "$(uname)" = "Darwin" ]; then assert_contains "$off" 'R6' "R6 fires on a bare BSD PATH"; else assert_equals 0 0 "ok"; fi
+  if [ "$(uname)" = "Darwin" ]; then assert_contains "$off" 'R6' "R6 fires on a bare BSD PATH" || return 1; fi || return 1
 }
 test_autocorrect_bash_redirect_and_tilde_are_not_paths() {
   local out; out=$(_hook autocorrect-bash.py '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat /etc/hosts 2>/dev/null; cat > new-file.md <<EOF\nx\nEOF"}}')
-  assert_equals "" "$out" "a redirection or a write target is never a missing read path"
+  assert_equals "" "$out" "a redirection or a write target is never a missing read path" || return 1
   out=$(_hook autocorrect-bash.py '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat ~/.kernel-does-not-exist.md"}}')
-  if printf '%s' "$out" | grep -q '/~/'; then assert_equals "expanded" "joined" "~ must be expanded before joining with cwd"; else assert_equals 0 0 "ok"; fi
+  if printf '%s' "$out" | grep -q '/~'; then echo "FAIL: ~ must be expanded before joining with cwd: $out"; return 1; fi || return 1
 }
 test_autocorrect_bash_pipestatus_under_zsh() {
   local out; out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"a | b; echo ${PIPESTATUS[0]}"}}' | SHELL=/bin/zsh KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
-  assert_contains "$out" 'echo ${pipestatus[1]}' "zsh: PIPESTATUS[0] becomes pipestatus[1]"
+  assert_contains "$out" 'echo ${pipestatus[1]}' "zsh: PIPESTATUS[0] becomes pipestatus[1]" || return 1
   out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"a | b; echo ${PIPESTATUS[0]}"}}' | SHELL=/bin/bash KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
-  assert_equals "" "$out" "bash: PIPESTATUS is left alone"
+  assert_equals "" "$out" "bash: PIPESTATUS is left alone" || return 1
   out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat > s.sh <<'"'"'EOF'"'"'\na | b\n[ ${PIPESTATUS[1]} -eq 0 ]\nEOF"}}' | SHELL=/bin/zsh KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
-  if printf '%s' "$out" | grep -q 'pipestatus'; then assert_equals "untouched" "rewritten" "a heredoc body runs under bash; never rewrite it"; else assert_equals 0 0 "ok"; fi
+  if printf '%s' "$out" | grep -q 'pipestatus'; then echo "FAIL: a heredoc body runs under bash; never rewrite it: $out"; return 1; fi
+  out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"bash -c '"'"'a | b; echo ${PIPESTATUS[0]}'"'"'; echo '"'"'${PIPESTATUS[0]}'"'"'"}}' | SHELL=/bin/zsh KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
+  if printf '%s' "$out" | grep -q 'updatedInput'; then echo "FAIL: a string handed to bash -c or a single-quoted literal is never rewritten: $out"; return 1; fi
+  out=$(printf '%s' '{"tool_name":"Bash","cwd":"/","tool_input":{"command":"cat <<\"EOF\"\n${PIPESTATUS[0]}\nEOF"}}' | SHELL=/bin/zsh KERNEL_AUTOCORRECT_LOG="$TEST_DIR/autocorrect.jsonl" python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" 2>/dev/null)
+  if printf '%s' "$out" | grep -q 'pipestatus'; then echo "FAIL: a double-quoted heredoc delimiter still marks a body: $out"; return 1; fi
+}
+test_hooks_survive_non_dict_json() {
+  local a b c
+  printf 'null' | python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" >/dev/null 2>&1; a=$?
+  printf '[1,2]' | python3 "$PLUGIN_ROOT/hooks/scripts/syntax-coach.py" >/dev/null 2>&1; b=$?
+  printf '"x"' | python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-tool-input.py" >/dev/null 2>&1; c=$?
+  assert_equals "0 0 0" "$a $b $c" "advisory hooks exit 0 on top-level non-dict JSON" || return 1
 }
 test_syntax_coach_not_found_needs_a_whole_line() {
   local out; out=$(_hook syntax-coach.py '{"tool_name":"Bash","tool_input":{"command":"gh issue view 47"},"tool_response":"`not found: curl` from a zsh exec_command while /usr/bin/curl exists"}')
-  assert_equals "" "$out" "not found inside quoted text is not a failed command"
+  assert_equals "" "$out" "not found inside quoted text is not a failed command" || return 1
   out=$(_hook syntax-coach.py '{"tool_name":"Bash","tool_input":{"command":"curl x"},"tool_response":"zsh: command not found: curl"}')
-  assert_contains "$out" 'curl' "a real zsh not-found still coaches"
+  assert_contains "$out" 'curl' "a real zsh not-found still coaches" || return 1
   out=$(_hook syntax-coach.py '{"tool_name":"Bash","tool_input":{"command":"python x"},"tool_response":"sh: 1: python: not found"}')
-  assert_contains "$out" 'python' "a real sh not-found still coaches"
+  assert_contains "$out" 'python' "a real sh not-found still coaches" || return 1
 }
 test_hooks_survive_non_dict_tool_input() {
   printf '{"tool_name":"Bash","tool_input":"ls"}' | python3 "$PLUGIN_ROOT/hooks/scripts/autocorrect-bash.py" >/dev/null 2>&1; local a=$?
@@ -5554,6 +5565,7 @@ run_test_suite() {
       run_test "autocorrect-bash R2b ignores redirections, write targets and ~ (#226)" test_autocorrect_bash_redirect_and_tilde_are_not_paths
       run_test "autocorrect-bash R14 PIPESTATUS -> pipestatus under zsh (#226)" test_autocorrect_bash_pipestatus_under_zsh
       run_test "syntax-coach not-found needs a whole line (#226)" test_syntax_coach_not_found_needs_a_whole_line
+      run_test "advisory hooks survive top-level non-dict JSON (#226)" test_hooks_survive_non_dict_json
       run_test "syntax-coach names the fix for a usage banner" test_syntax_coach_usage
       run_test "syntax-coach is silent on a clean run" test_syntax_coach_silent
       run_test "autocorrect-tool-input adds WebFetch prompt" test_autocorrect_webfetch_prompt


### PR DESCRIPTION
🔧 **Ready to review**

**In one line:** the autocorrect hook now probes `grep -P` instead of assuming, three noise sources are silenced, and `PIPESTATUS` is rewritten for the zsh tool shell. Closes #226.

| | |
|---|---|
| Fixed | R6 probe, R2b redirect/tilde/created-file, syntax-coach whole-line not-found |
| Added | R14 `${PIPESTATUS[n]}` to `${pipestatus[n+1]}` under zsh, top level only |
| Docs | upgrading a live Codex install exits every hook 127 until sessions restart |
| Tests | 4 new, suite 487 passed locally; the ambient ratchet test is 2 tokens over from the live session-start card (branch name and dirty count), byte-identical instruction files and frontmatter to main |

<details><summary>Proof</summary>

Issue #226 carries the reproducers and CHECK lines. Blind instrument-breaker verdict is posted as a comment when it lands.

Local suite: 487 passed, 1 failed (`test_contributor_ambient_within_budget`, 11002 vs 11000). `measure()` runs `session-start.sh` live; the card differs from main only in branch name and uncommitted count. CLAUDE.md, AGENTS.md and all skill frontmatter are byte-identical to main.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
