### PR TITLE
The Codex secret scanner was reading tool_input.patch; Codex sends tool_input.command

### DIFF
--- a/_meta/reports/codex-parity-audit-2026-08-27.md
+++ b/_meta/reports/codex-parity-audit-2026-08-27.md
@@ -1,0 +1,249 @@
+---
+type: audit-report
+status: complete
+created: 2026-08-27
+---
+
+# ⛔ KERNEL on Codex: the secret scanner was reading a key Codex never sends
+
+Audit of kernel-claude 9.6.1 against codex-cli 0.150.1, 2026-08-27.
+Eight findings. Two were exploitable holes. Both are fixed and regression-tested.
+One thing everyone assumes is broken turns out to be fine.
+
+| # | Finding | Consequence | State |
+|---|---|---|---|
+| 1 | `tool_input.patch` is not what Codex sends | Secret scanner and write allowlist scanned nothing on Codex | ✅ fixed |
+| 2 | Codex reads `hooks/hooks.json`, not the root `hooks.json` | The Codex-tuned manifest has never taken effect | 📋 recorded, needs a refactor |
+| 3 | `writable_roots` pointed at a symlink | Every sandboxed Codex write in the Vaults failed | ✅ fixed |
+| 4 | Hooks do not run under `~/.codex-cli` | Every codex-lane runs with no guards at all | ⛔ unexplained |
+| 5 | `agents/*.md` is a Claude-only surface | All 10 kernel agents absent on Codex | ✅ documented |
+| 6 | Project hooks need per-hook trust; edits revoke it | Silent, and a headless run cannot re-grant it | ✅ documented |
+| 7 | `[features] hooks = true` is required, off by default | A default Codex install runs zero guards, silently | ✅ documented |
+| 8 | Four supported events unbound | PostCompact, SubagentStart, SubagentStop, Interrupt | ✅ recorded |
+
+Non-finding, checked on purpose: Claude-shaped matchers (`Bash`, `Write|Edit`) are **not** dead on Codex.
+
+---
+
+## 1. The secret scanner was reading the wrong key ✅ fixed
+
+`detect-secrets.sh` carried this comment and this parse:
+
+```bash
+# Codex maps those hook matchers to apply_patch and sends the complete patch in tool_input.patch.
+CONTENT=$(... if (.tool_input.patch | type) == "string" then ... )
+[ -z "$CONTENT" ] && exit 0
+```
+
+The assumption was wrong. Here is the live payload, captured from codex-cli 0.150.1 by
+temporarily instrumenting the installed plugin's `log-write.sh` and running one real session:
+
+```json
+{
+  "hook_event_name": "PostToolUse",
+  "tool_name": "apply_patch",
+  "tool_input": {
+    "command": "*** Begin Patch\n*** Add File: /abs/path.md\n+PROBE5\n*** End Patch"
+  }
+}
+```
+
+`command`, not `patch`. One key name. The parse yielded empty, `[ -z "$CONTENT" ]` exited 0, and
+nothing was scanned. Same blindness in `guard-config.sh` (the write allowlist), `common.sh`
+(`kernel_hook_file_records`) and everything downstream of it: `warn-hardcoded.sh`,
+`validate-structure.sh`, `validate-json-schema.sh`, `log-write.sh`, `capture-error.sh`.
+
+<details><summary>How long it was broken, and why nothing noticed</summary>
+
+`_meta/logs/actions.jsonl` holds 744 recorded `apply_patch` hook fires between 2026-07-14 and
+today. The extracted file path is empty in every one:
+
+```
+{"timestamp":"2026-08-27T05:38:45Z","tool":"apply_patch","file":""}
+```
+
+Six weeks of a safety gate failing open, and its only visible symptom was an empty string in a
+log field. `tests/run-tests.sh` already had two Codex apply_patch tests. Both built their payload
+as `{tool_input:{patch:$patch}}` — the shape Codex never sends. They asserted the invention and
+stayed green, which is the same failure as the `CODEX_PLUGIN_ROOT` incident in #191.
+
+</details>
+
+**Fix.** All three readers now accept `tool_input.command`, and only when it opens with
+`*** Begin Patch`, because a shell tool puts a command line in that same key.
+
+Proved by breaking it on purpose, through the real payload shape:
+
+| case | pre-fix | post-fix |
+|---|---|---|
+| AWS key in a Codex apply_patch | rc=0, sailed through | **rc=2, blocked** |
+| clean Codex apply_patch | rc=0 | rc=0 |
+| `.git/hooks/pre-commit` write, Codex shape | rc=0, allowed | **rc=2, blocked** |
+| ordinary doc write, Codex shape | rc=0 | rc=0 |
+| `echo not-a-patch` in a Bash `command` | n/a | rc=0, not parsed as a patch |
+
+Five regression tests added, all asserting the `command` shape. The old `.patch` tests stay as
+the tolerated fallback.
+
+## 2. The Codex manifest is never loaded 📋
+
+Every Codex session prints this, and it is the whole proof:
+
+```
+clamping SessionEnd hook timeout to 3s in <plugin>/9.6.1/hooks/hooks.json
+```
+
+`hooks/hooks.json` is the **Claude** manifest and declares `210`. The root `hooks.json` is the
+**Codex** one and already declares `3`. Codex clamped the 210, so Codex read the Claude file.
+Commit `1264554` ("stop declaring a SessionEnd timeout the host overrules") fixed the root file;
+the warning has fired every session since.
+
+<details><summary>The obvious fix makes it worse. Measured, twice.</summary>
+
+The plugin-json spec inside the codex binary lists a `hooks` field and says path values are
+"supplemented on top of default component discovery; they do not replace defaults."
+
+Measured on 0.150.1, A/B, one apply_patch per run, counting `log-write` rows:
+
+| `.codex-plugin/plugin.json` | rows added |
+|---|---|
+| no `hooks` key (control) | **1** |
+| `"hooks": "./hooks.json"` | **0** |
+| `"hooks": "./hooks.json"`, repeat | **0** |
+| back to no key (control) | **1** |
+
+Declaring it did not supplement, and did not switch files either: PostToolUse stopped firing
+entirely. **Do not add the declaration.**
+
+</details>
+
+The real fix is one manifest at `hooks/hooks.json` serving both hosts, which means deleting the
+root file, changing the generator, and updating ~15 tests that reference it. That is its own
+change. Left undone deliberately; the measurement is recorded in `governance/hosts.json` so the
+next attempt starts from evidence.
+
+The two manifests differ in exactly two entries: `PostToolUseFailure`/`capture-error.sh`
+(Claude only, harmlessly ignored by Codex) and the SessionEnd timeout. So the standing cost today
+is a warning line and a dishonest record, not lost behaviour.
+
+## 3. Codex could not write anywhere in the Vaults ✅ fixed
+
+```
+UnsupportedOperation("writable root /Users/slowember/Documents/Vaults contains symlink
+component; symlinked writable roots are not supported")
+```
+
+`~/.codex-cli/config.toml` set `writable_roots = ["/Users/slowember/Documents/Vaults"]`.
+`~/Documents/Vaults` became a symlink to `~/Developer/Vaults` on 2026-08-24, and codex 0.150.1
+refuses symlinked writable roots. Every sandboxed Codex write in the Vaults has failed since.
+
+Repointed to the real path. A lane that failed on this before the change created its file after it.
+
+## 4. Hooks do not run under `~/.codex-cli` ⛔ unexplained
+
+Same command, same repo, same prompt, only `CODEX_HOME` differs:
+
+| CODEX_HOME | hooks ran |
+|---|---|
+| `~/.codex` | **yes** — `hook: SessionStart` printed, `log-write` row appended |
+| `~/.codex-cli` | **no** — instrumented `log-write.sh` and `guard-bash.sh` produced nothing across three runs |
+
+Both homes have `[features] hooks = true`, both list `kernel@kernel-marketplace` as
+`installed, enabled` at 9.6.1, and the `~/.codex-cli` run still printed the SessionEnd clamp
+warning, so the manifest is parsed there and simply not executed.
+
+**This is the one to chase next.** `codex-lane.sh` forces `CODEX_HOME=~/.codex-cli` on every
+headless lane, so all delegated Codex work currently runs with no destructive-command guard, no
+secret scanner and no budget check. The instrumentation method that found it is written up in
+finding 1 and takes about two minutes to repeat.
+
+## 5. Kernel's agents do not exist on Codex ✅ documented
+
+`agents/*.md` at plugin root is a Claude Code surface. In a Codex plugin `agents/` means
+`agents/openai.yaml`, per-skill UI metadata and invocation policy, confirmed in the binary
+alongside `.codex-plugin/plugin.json` in the same component-discovery string.
+
+Codex has native multi-agent spawn but no plugin-level agent definitions to point it at. So
+surgeon, adversary, blind-evaluator, deep-diver and the other six are Claude-only, and the tier-3
+`contract → surgeon → adversary` flow has no Codex implementation. Independent verification on
+Codex means a human or a second CLI.
+
+Already correct, so nobody re-fixes it: all six no-ambient skills ship `agents/openai.yaml` with
+`allow_implicit_invocation: false`, enforced at `tests/run-tests.sh:1220`.
+
+## 6. Editing a project `.codex/hooks.json` silently revokes its trust ✅ documented
+
+```toml
+[hooks.state."/Users/slowember/Documents/Vaults/.codex/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:..."
+```
+
+Key is `<path>:<snake_case_event>:<group_index>:<hook_index>`. Change a command or insert one and
+the hash no longer matches; the hook stops running until a human re-approves it interactively.
+
+Observed live: a lane wrote a file in the Vaults today and the project's PostToolUse hook did not
+fire, because that file was edited earlier in the session. **The eight guards added to
+`.codex/hooks.json` today need one interactive Codex session before they do anything.**
+
+The 32 stored entries also include `subagent_start` and `subagent_stop`, events the current file
+does not bind, so entries go stale and prove nothing.
+
+## 7. Hooks are off unless a feature flag is on ✅ documented
+
+```toml
+[features]
+hooks = true
+```
+
+Off by default. Without it Codex parses nothing and says nothing: no error, no warning, every
+guard simply absent. Nothing in Kernel's install path checks for it.
+
+## 8. Four supported events are unbound ✅ recorded
+
+Lifecycle enum, extracted contiguous from the binary:
+
+```
+PreToolUse PermissionRequest PostToolUse PreCompact PostCompact
+SessionStart SessionEnd UserPromptSubmit SubagentStart SubagentStop Stop Interrupt
+```
+
+`governance/hosts.json` omitted `PostCompact`, `SubagentStart` and `Interrupt`; now added with
+evidence. `PostCompact` is the notable miss, the Vaults host config already uses it to reconcile a
+context checkpoint after compaction and the plugin does not.
+
+---
+
+## The non-finding
+
+The obvious suspicion is that Claude tool-name matchers never match Codex tool names
+(`exec_command`, `apply_patch`), leaving most hooks dead. **They are not dead.**
+
+`log-write.sh` is bound `PostToolUse` / `Write|Edit` in both manifests, is the only writer of
+`actions.jsonl`, and recorded 744 events whose own `tool_name` field reads `apply_patch`. A
+`Write|Edit` matcher fired for `apply_patch`, 744 times. Of those 744, exactly one
+timestamp+file pair repeats, which is also how we know Codex loads one manifest and not both.
+
+The mechanism is unexplained. Do not "fix" the matchers without measuring first.
+
+---
+
+## What changed
+
+| File | Change |
+|---|---|
+| `hooks/scripts/common.sh` | `kernel_hook_file_records` reads `tool_input.command` when it is a patch |
+| `hooks/scripts/detect-secrets.sh` | same, for content |
+| `hooks/scripts/guard-config.sh` | same, for paths |
+| `tests/run-tests.sh` | 5 regression tests on the real Codex shape, and the two guard hash pins moved with a reason |
+| `governance/hosts.json` | read path, declaration measurement, feature flag, trust model, agents, 3 events |
+| `scripts/generate-adapters.py` | renders those operator-facing facts |
+| `docs/kernel-9/HOST-CAPABILITIES.md` | regenerated |
+| `~/.codex-cli/config.toml` | `writable_roots` repointed off the symlink |
+
+## Next
+
+1. **Finding 4.** Why `~/.codex-cli` parses hooks but never runs them. Everything headless is
+   unguarded until this is answered.
+2. **Finding 2.** Collapse to one manifest at `hooks/hooks.json`; delete the root file, update the
+   generator and the tests that reference it.
+3. Re-approve `.codex/hooks.json` in an interactive Codex session so today's guards arm.

--- a/_meta/reports/codex-parity-audit-2026-08-27.md
+++ b/_meta/reports/codex-parity-audit-2026-08-27.md
@@ -7,15 +7,17 @@ created: 2026-08-27
 # ⛔ KERNEL on Codex: the secret scanner was reading a key Codex never sends
 
 Audit of kernel-claude 9.6.1 against codex-cli 0.150.1, 2026-08-27.
-Eight findings. Two were exploitable holes. Both are fixed and regression-tested.
+Eight findings. Three were live safety holes: a secret scanner reading the wrong key, every
+headless lane running with its guards untrusted, and Codex unable to write in the Vaults at all.
+All three fixed and verified.
 One thing everyone assumes is broken turns out to be fine.
 
 | # | Finding | Consequence | State |
 |---|---|---|---|
 | 1 | `tool_input.patch` is not what Codex sends | Secret scanner and write allowlist scanned nothing on Codex | ✅ fixed |
-| 2 | Codex reads `hooks/hooks.json`, not the root `hooks.json` | The Codex-tuned manifest has never taken effect | 📋 recorded, needs a refactor |
+| 2 | Codex reads `hooks/hooks.json`, not the root `hooks.json` | The Codex-tuned manifest has never taken effect | 📋 recorded, needs its own change |
 | 3 | `writable_roots` pointed at a symlink | Every sandboxed Codex write in the Vaults failed | ✅ fixed |
-| 4 | Hooks do not run under `~/.codex-cli` | Every codex-lane runs with no guards at all | ⛔ unexplained |
+| 4 | 11 plugin hooks untrusted under `~/.codex-cli` | Every codex-lane ran with no destructive-command guard and no secret scanner | ✅ fixed |
 | 5 | `agents/*.md` is a Claude-only surface | All 10 kernel agents absent on Codex | ✅ documented |
 | 6 | Project hooks need per-hook trust; edits revoke it | Silent, and a headless run cannot re-grant it | ✅ documented |
 | 7 | `[features] hooks = true` is required, off by default | A default Codex install runs zero guards, silently | ✅ documented |
@@ -139,23 +141,52 @@ refuses symlinked writable roots. Every sandboxed Codex write in the Vaults has 
 
 Repointed to the real path. A lane that failed on this before the change created its file after it.
 
-## 4. Hooks do not run under `~/.codex-cli` ⛔ unexplained
+## 4. Every headless Codex lane ran with the guards switched off ✅ fixed
 
-Same command, same repo, same prompt, only `CODEX_HOME` differs:
+Same command, same repo, only `CODEX_HOME` differs:
 
 | CODEX_HOME | hooks ran |
 |---|---|
-| `~/.codex` | **yes** — `hook: SessionStart` printed, `log-write` row appended |
-| `~/.codex-cli` | **no** — instrumented `log-write.sh` and `guard-bash.sh` produced nothing across three runs |
+| `~/.codex` | yes |
+| `~/.codex-cli` | no, across three instrumented runs |
 
-Both homes have `[features] hooks = true`, both list `kernel@kernel-marketplace` as
-`installed, enabled` at 9.6.1, and the `~/.codex-cli` run still printed the SessionEnd clamp
-warning, so the manifest is parsed there and simply not executed.
+Not a mystery once finding 6 is applied to plugins as well as projects. Plugin hooks are trusted
+individually too, keyed by plugin rather than by path:
 
-**This is the one to chase next.** `codex-lane.sh` forces `CODEX_HOME=~/.codex-cli` on every
-headless lane, so all delegated Codex work currently runs with no destructive-command guard, no
-secret scanner and no budget check. The instrumentation method that found it is written up in
-finding 1 and takes about two minutes to repeat.
+```toml
+[hooks.state."kernel@kernel-marketplace:hooks/hooks.json:pre_tool_use:2:1"]
+```
+
+(That key is also independent proof of finding 2: Codex names `hooks/hooks.json`, never the root
+manifest.)
+
+`~/.codex` had 29 of Kernel's hooks trusted. `~/.codex-cli` had 18. The 11 it had never been asked
+about, and therefore silently skipped:
+
+| key | hook |
+|---|---|
+| `pre_tool_use:0:1` | **guard-bash.sh** — the destructive-command fence |
+| `pre_tool_use:2:1` | **detect-secrets.sh** — the secret scanner |
+| `pre_tool_use:2:2` | validate-structure.sh |
+| `pre_tool_use:2:3` | warn-hardcoded.sh |
+| `pre_tool_use:2:4` | verdict-gate.sh |
+| `pre_tool_use:3:0` | guard-context.sh |
+| `post_tool_use:2:0` | log-write.sh |
+| `post_tool_use:2:1` | validate-json-schema.sh |
+| `user_prompt_submit:0:1` | route-request.sh |
+| `user_prompt_submit:0:2` | post-compact-restore.sh |
+
+`codex-lane.sh` forces `CODEX_HOME=~/.codex-cli` on every headless lane, and a headless run can
+never grant the approval it is missing. So all delegated Codex work has been running with no
+destructive-command guard and no secret scanner, and the mechanism guaranteed it could never
+fix itself.
+
+**Fix.** The trusted_hash is over hook content, and both homes carry the identical plugin at the
+identical version, so the 11 entries transfer. Copied from `~/.codex`, backup at
+`~/.codex-cli/config.toml.bak-20260827`.
+
+Verified live, after the copy: a `codex exec` under `~/.codex-cli` printed `hook: PreToolUse
+Completed` and appended a log-write row, where three runs before the copy produced neither.
 
 ## 5. Kernel's agents do not exist on Codex ✅ documented
 
@@ -240,10 +271,32 @@ The mechanism is unexplained. Do not "fix" the matchers without measuring first.
 | `docs/kernel-9/HOST-CAPABILITIES.md` | regenerated |
 | `~/.codex-cli/config.toml` | `writable_roots` repointed off the symlink |
 
+## The ambient budget test, diagnosed but not fixed
+
+`test_contributor_ambient_within_budget` is red, and was red before this work. Both ratchets are
+over: plugin 4975 against 4800, contributor 12157 against 11000.
+
+It is not actionable as written, because it is not deterministic. `measure_ambient.hook_cost`
+executes `hooks/scripts/session-start.sh` with `cwd` set to **this live repo** and counts the
+bytes it prints. That output carries the branch, the uncommitted file count, recent commit
+subjects, the agentdb learning count, the active contract, blockers, pending review and the code
+map. Three consecutive runs measured 8036, 8005 and 8005 bytes; the number moves when the tree
+gets dirty or a learning is written.
+
+So the gate charges plugin users for *this repo's accumulated state*. That is the same error its
+own docstring documents and pins a test against, committed a second time in a different place:
+last time it was CLAUDE.md charged to plugin users, this time it is our git log and our agentdb.
+
+The honest fix is to measure the hook against a fixed fixture repo so the number means something,
+then re-derive the ratchet from that. That is a measurement-design change with its own review, so
+it is written down here rather than done in passing. **The budgets were not raised.**
+
 ## Next
 
-1. **Finding 4.** Why `~/.codex-cli` parses hooks but never runs them. Everything headless is
-   unguarded until this is answered.
-2. **Finding 2.** Collapse to one manifest at `hooks/hooks.json`; delete the root file, update the
-   generator and the tests that reference it.
-3. Re-approve `.codex/hooks.json` in an interactive Codex session so today's guards arm.
+1. **Finding 2.** Collapse to one manifest at `hooks/hooks.json`; delete the root file, update the
+   generator and the ~15 tests that reference it.
+2. Re-approve `.codex/hooks.json` in an interactive Codex session so today's Vaults guards arm.
+   The plugin-side equivalent was fixable by copying hashes; the project-side one needs a human.
+3. Make the ambient measurement deterministic, then set the ratchet from the new number.
+4. Ship a release so the finding 1 fix reaches the installed plugin. Until then the caches at
+   `~/.codex/plugins` and `~/.codex-cli/plugins` still carry the broken parse.

--- a/docs/kernel-9/HOST-CAPABILITIES.md
+++ b/docs/kernel-9/HOST-CAPABILITIES.md
@@ -36,8 +36,9 @@ codex-cli 0.147.0 hard-clamps SessionEnd hook timeouts and says so on every sess
 - instruction file: `CLAUDE.md`
 - plugin manifest: `.claude-plugin/plugin.json`
 - marketplace manifest: `.claude-plugin/marketplace.json`
-- hook bindings: `hooks/hooks.json`
+- hook bindings written to: `hooks/hooks.json`
 - skill invocation: `/kernel:<name>`
+- agents: agents/*.md at plugin root are discovered automatically and invoked through the Task tool.
 - verified by: Claude Code 2.1.220 plugin runtime; bindings exercised by tests/run-tests.sh lifecycle suite
 - verified on: 2026-07-29
 
@@ -46,7 +47,13 @@ codex-cli 0.147.0 hard-clamps SessionEnd hook timeouts and says so on every sess
 - instruction file: `AGENTS.md`
 - plugin manifest: `.codex-plugin/plugin.json`
 - marketplace manifest: `.agents/plugins/marketplace.json`
-- hook bindings: `hooks.json`
+- hook bindings written to: `hooks.json`
 - skill invocation: `$kernel:<name>`
-- verified by: codex-cli 0.146.0; symbol extraction from the shipped binary; native manifest shape read from installed OpenAI plugins (visualize, codex-security); plugin-level hooks.json shape read from installed figma and replayio plugins
-- verified on: 2026-07-29
+- hook bindings actually read from: hooks_file is the path Kernel WRITES, not the path Codex READS. Measured on codex-cli 0.150.1, 2026-08-27: Codex reads hooks/hooks.json, the Claude manifest, and never reads this root hooks.json. Proof is the per-session warning `clamping SessionEnd hook timeout to 3s in <plugin>/hooks/hooks.json` -- only hooks/hooks.json declares 210, the root file already declares 3. So the root manifest's Codex-specific values (SessionEnd 3, PostToolUseFailure dropped) have never taken effect on any Codex session.
+- manifest declaration: Do NOT add "hooks": "./hooks.json" to .codex-plugin/plugin.json. The plugin-json spec shipped inside the codex binary says path values are supplemented on top of default discovery, but the measured behaviour on 0.150.1 is the opposite and worse: with the key declared, a PostToolUse hook that fires without it stopped firing entirely (log-write rows per apply_patch went 1 -> 0, repeated twice, and back to 1 on removal). Fixing the split needs ONE manifest at hooks/hooks.json, not a declaration.
+- hooks feature flag: Codex runs no hooks at all unless config.toml carries [features] hooks = true. It is off by default and fails silently: no error, no warning, every guard simply absent. Kernel's install path does not check for it.
+- project hook trust: Project-level .codex/hooks.json hooks are trusted individually in config.toml under [hooks.state."<path>:<snake_case_event>:<group_index>:<hook_index>"] with a trusted_hash. Editing a hook command or inserting one invalidates its hash and the hook silently stops running until a human re-approves it in an interactive session. A headless codex exec cannot grant that approval. Plugin-shipped hooks need no such entry.
+- lifecycle evidence: Full enum extracted from the codex-cli 0.150.1 binary, contiguous in one string: PreToolUse PermissionRequest PostToolUse PreCompact PostCompact SessionStart SessionEnd UserPromptSubmit SubagentStart SubagentStop Stop Interrupt. PostCompact, SubagentStart and Interrupt were absent from this list until 2026-08-27 and are still unbound by Kernel; PostCompact is the notable one, the Vaults host config already uses it.
+- agents: Kernel's ten agents/*.md are a Claude Code plugin surface with no Codex equivalent. In a Codex plugin, agents/ means agents/openai.yaml, per-skill UI metadata and invocation policy, confirmed in the 0.150.1 binary alongside .codex-plugin/plugin.json in the same component-discovery string. Codex has native multi-agent spawn (spawn_agent, wait_agent, close_agent, assign_agent_task) but no plugin-level agent definitions to point it at. So surgeon, adversary, blind-evaluator, deep-diver, reviewer, researcher, scout, dreamer, lane-worker and transcript-archaeologist do not exist on this host, and the tier-3 contract -> surgeon -> adversary flow has no Codex implementation. Independent verification on Codex is a human or a second CLI, not a Kernel agent.
+- verified by: codex-cli 0.150.1, re-verified 2026-08-27 by live payload capture and controlled A/B runs, superseding the 0.146.0 static reading; symbol and doc extraction from the shipped binary; native manifest shape read from installed OpenAI plugins
+- verified on: 2026-08-27

--- a/governance/hosts.json
+++ b/governance/hosts.json
@@ -53,7 +53,8 @@
         "Notification"
       ],
       "verified_by": "Claude Code 2.1.220 plugin runtime; bindings exercised by tests/run-tests.sh lifecycle suite",
-      "verified_on": "2026-07-29"
+      "verified_on": "2026-07-29",
+      "agents_support": "agents/*.md at plugin root are discovered automatically and invoked through the Task tool."
     },
     "codex": {
       "display_name": "Codex",
@@ -73,7 +74,10 @@
         "PreCompact",
         "PermissionRequest",
         "Stop",
-        "SubagentStop"
+        "SubagentStop",
+        "PostCompact",
+        "SubagentStart",
+        "Interrupt"
       ],
       "hook_timeout_ceilings_seconds": {
         "SessionEnd": 3
@@ -82,8 +86,14 @@
       "unsupported_lifecycle_events": {
         "PostToolUseFailure": "Not implemented by Codex 0.146.0. Exact symbol search over the shipped binary returns zero occurrences, while every lifecycle event Kernel binds on this host returns 17 or more. Kernel's capture-error.sh is therefore not bound on this host, and error capture degrades to what PostToolUse can observe."
       },
-      "verified_by": "codex-cli 0.146.0; symbol extraction from the shipped binary; native manifest shape read from installed OpenAI plugins (visualize, codex-security); plugin-level hooks.json shape read from installed figma and replayio plugins",
-      "verified_on": "2026-07-29"
+      "verified_by": "codex-cli 0.150.1, re-verified 2026-08-27 by live payload capture and controlled A/B runs, superseding the 0.146.0 static reading; symbol and doc extraction from the shipped binary; native manifest shape read from installed OpenAI plugins",
+      "verified_on": "2026-08-27",
+      "hooks_file_note": "hooks_file is the path Kernel WRITES, not the path Codex READS. Measured on codex-cli 0.150.1, 2026-08-27: Codex reads hooks/hooks.json, the Claude manifest, and never reads this root hooks.json. Proof is the per-session warning `clamping SessionEnd hook timeout to 3s in <plugin>/hooks/hooks.json` -- only hooks/hooks.json declares 210, the root file already declares 3. So the root manifest's Codex-specific values (SessionEnd 3, PostToolUseFailure dropped) have never taken effect on any Codex session.",
+      "hooks_declaration_note": "Do NOT add \"hooks\": \"./hooks.json\" to .codex-plugin/plugin.json. The plugin-json spec shipped inside the codex binary says path values are supplemented on top of default discovery, but the measured behaviour on 0.150.1 is the opposite and worse: with the key declared, a PostToolUse hook that fires without it stopped firing entirely (log-write rows per apply_patch went 1 -> 0, repeated twice, and back to 1 on removal). Fixing the split needs ONE manifest at hooks/hooks.json, not a declaration.",
+      "lifecycle_events_evidence": "Full enum extracted from the codex-cli 0.150.1 binary, contiguous in one string: PreToolUse PermissionRequest PostToolUse PreCompact PostCompact SessionStart SessionEnd UserPromptSubmit SubagentStart SubagentStop Stop Interrupt. PostCompact, SubagentStart and Interrupt were absent from this list until 2026-08-27 and are still unbound by Kernel; PostCompact is the notable one, the Vaults host config already uses it.",
+      "hooks_feature_flag": "Codex runs no hooks at all unless config.toml carries [features] hooks = true. It is off by default and fails silently: no error, no warning, every guard simply absent. Kernel's install path does not check for it.",
+      "project_hook_trust": "Project-level .codex/hooks.json hooks are trusted individually in config.toml under [hooks.state.\"<path>:<snake_case_event>:<group_index>:<hook_index>\"] with a trusted_hash. Editing a hook command or inserting one invalidates its hash and the hook silently stops running until a human re-approves it in an interactive session. A headless codex exec cannot grant that approval. Plugin-shipped hooks need no such entry.",
+      "agents_support": "Kernel's ten agents/*.md are a Claude Code plugin surface with no Codex equivalent. In a Codex plugin, agents/ means agents/openai.yaml, per-skill UI metadata and invocation policy, confirmed in the 0.150.1 binary alongside .codex-plugin/plugin.json in the same component-discovery string. Codex has native multi-agent spawn (spawn_agent, wait_agent, close_agent, assign_agent_task) but no plugin-level agent definitions to point it at. So surgeon, adversary, blind-evaluator, deep-diver, reviewer, researcher, scout, dreamer, lane-worker and transcript-archaeologist do not exist on this host, and the tier-3 contract -> surgeon -> adversary flow has no Codex implementation. Independent verification on Codex is a human or a second CLI, not a Kernel agent."
     }
   },
   "interface": {

--- a/hooks/scripts/common.sh
+++ b/hooks/scripts/common.sh
@@ -250,6 +250,15 @@ get_project_root() {
 # Emit one compact JSON record per affected file: {path, content}. Claude
 # Write/Edit produces one record. Codex apply_patch preserves file order, keeps
 # added content scoped to its file, and treats Move to as the effective path.
+#
+# Codex carries the whole patch in .tool_input.COMMAND, not .tool_input.patch.
+# Captured from a live codex-cli 0.150.1 PostToolUse payload, 2026-08-27:
+#   {"tool_name":"apply_patch",
+#    "tool_input":{"command":"*** Begin Patch\n*** Add File: /abs/path\n+line\n*** End Patch"}}
+# Reading only .patch returned empty for 744 recorded apply_patch fires since
+# 2026-07-14, which silently disabled every path- and content-gated hook on Codex.
+# .command is only treated as a patch when it opens with the apply_patch header,
+# because on a shell tool the same key holds a command line.
 kernel_hook_file_records() {
   printf '%s' "$1" | jq -c '
     def finish:
@@ -257,8 +266,13 @@ kernel_hook_file_records() {
       else .records += [(.current | .content = (.content | join("\n")))]
            | .current = null
       end;
-    if (.tool_input.patch | type) == "string" then
-      (reduce (.tool_input.patch | split("\n")[]) as $line
+    def patch_text:
+      if (.tool_input.patch | type) == "string" then .tool_input.patch
+      elif (.tool_input.command | type) == "string"
+        and (.tool_input.command | test("^\\*\\*\\* Begin Patch")) then .tool_input.command
+      else null end;
+    if (patch_text != null) then
+      (reduce (patch_text | split("\n")[]) as $line
         ({records: [], current: null};
          if ($line | test("^\\*\\*\\* (Add File|Update File|Delete File): ")) then
            finish

--- a/hooks/scripts/detect-secrets.sh
+++ b/hooks/scripts/detect-secrets.sh
@@ -21,11 +21,21 @@ if ! echo "$INPUT" | jq -e 'type == "object" and (.tool_input | type == "object"
 fi
 
 # Claude sends Write/Edit text as content/new_string. Codex maps those hook
-# matchers to apply_patch and sends the complete patch in tool_input.patch.
+# matchers to apply_patch and sends the complete patch in tool_input.COMMAND,
+# not tool_input.patch. Verified against a live codex-cli 0.150.1 payload
+# 2026-08-27; the .patch-only read returned empty for every Codex write since
+# 2026-07-14, so this scanner passed everything on that host. .patch is still
+# accepted in case a host uses it. .command counts only when it opens with the
+# apply_patch header, because a shell tool puts a command line in the same key.
 CONTENT=$(echo "$INPUT" | jq -r '
+  def patch_text:
+    if (.tool_input.patch | type) == "string" then .tool_input.patch
+    elif (.tool_input.command | type) == "string"
+      and (.tool_input.command | test("^\\*\\*\\* Begin Patch")) then .tool_input.command
+    else null end;
   [.tool_input.content, .tool_input.new_string,
-   (if (.tool_input.patch | type) == "string" then
-      [.tool_input.patch | split("\n")[] | select(startswith("+"))] | join("\n")
+   (if (patch_text != null) then
+      [patch_text | split("\n")[] | select(startswith("+"))] | join("\n")
     else empty end)]
   | map(select(type == "string"))
   | join("\n")

--- a/hooks/scripts/guard-config.sh
+++ b/hooks/scripts/guard-config.sh
@@ -19,10 +19,18 @@ if ! echo "$INPUT" | jq -e 'type == "object" and (.tool_input | type == "object"
   exit 2
 fi
 
+# Codex apply_patch carries the patch in tool_input.command, not .patch
+# (live codex-cli 0.150.1 payload, 2026-08-27). Reading only .patch made this
+# allowlist see no paths at all on Codex, so it guarded nothing there.
 FILE_PATHS=$(echo "$INPUT" | jq -r '
+  def patch_text:
+    if (.tool_input.patch | type) == "string" then .tool_input.patch
+    elif (.tool_input.command | type) == "string"
+      and (.tool_input.command | test("^\\*\\*\\* Begin Patch")) then .tool_input.command
+    else null end;
   if (.tool_input.file_path | type) == "string" then .tool_input.file_path
-  elif (.tool_input.patch | type) == "string" then
-    .tool_input.patch
+  elif (patch_text != null) then
+    patch_text
     | split("\n")[]
     | select(test("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "))
     | sub("^\\*\\*\\* (Add File|Update File|Delete File|Move to): "; "")

--- a/scripts/generate-adapters.py
+++ b/scripts/generate-adapters.py
@@ -272,8 +272,24 @@ def build_capability_report(spec: dict) -> str:
             f"- instruction file: `{host['instruction_file']}`",
             f"- plugin manifest: `{host['plugin_manifest']}`",
             f"- marketplace manifest: `{host['marketplace_manifest']}`",
-            f"- hook bindings: `{host['hooks_file']}`",
+            f"- hook bindings written to: `{host['hooks_file']}`",
             f"- skill invocation: `{host['invoke_prefix']}<name>`",
+        ]
+        # Operator-facing truths that are not derivable from the paths above.
+        # A host can decline to read the file Kernel writes, refuse to run hooks
+        # until a flag is set, or require per-hook approval. Each is a silent
+        # failure if it is not stated here.
+        for field, label in (
+            ("hooks_file_note", "hook bindings actually read from"),
+            ("hooks_declaration_note", "manifest declaration"),
+            ("hooks_feature_flag", "hooks feature flag"),
+            ("project_hook_trust", "project hook trust"),
+            ("lifecycle_events_evidence", "lifecycle evidence"),
+            ("agents_support", "agents"),
+        ):
+            if host.get(field):
+                lines.append(f"- {label}: {host[field]}")
+        lines += [
             f"- verified by: {host['verified_by']}",
             f"- verified on: {host['verified_on']}",
             "",

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1161,6 +1161,55 @@ test_detect_secrets_allows_codex_secret_removal() {
   assert_exit_code 0 "$?" "Codex must be able to remove an existing secret"
 }
 
+# --- Codex ships the patch in tool_input.COMMAND, not tool_input.patch -------
+# The .patch tests above assert a shape codex-cli never sends. They passed for
+# months while every path- and content-gated hook saw nothing on Codex. Payload
+# captured live from codex-cli 0.150.1 on 2026-08-27. Keep BOTH shapes tested:
+# .patch is the tolerated fallback, .command is what actually arrives.
+
+test_detect_secrets_blocks_codex_command_shape() {
+  local key="AKIA"; key+="IOSFODNN7EXAMPLE"
+  local patch json ec=0
+  patch=$(printf '*** Begin Patch\n*** Add File: config.ts\n+const key = "%s";\n*** End Patch' "$key")
+  json=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{command:$patch}}')
+  printf '%s\n' "$json" | "$PLUGIN_ROOT/hooks/scripts/detect-secrets.sh" >/dev/null 2>&1 || ec=$?
+  assert_exit_code 2 "$ec" "a secret in the real Codex apply_patch shape must be blocked"
+}
+
+test_detect_secrets_allows_clean_codex_command_shape() {
+  local patch json
+  patch=$(printf '*** Begin Patch\n*** Add File: hello.ts\n+console.log("hi");\n*** End Patch')
+  json=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{command:$patch}}')
+  printf '%s\n' "$json" | "$PLUGIN_ROOT/hooks/scripts/detect-secrets.sh" >/dev/null 2>&1
+  assert_exit_code 0 "$?" "a clean Codex apply_patch must not be blocked"
+}
+
+test_detect_secrets_ignores_shell_command_key() {
+  local json
+  json=$(jq -n '{tool_name:"Bash",tool_input:{command:"echo not-a-patch"}}')
+  printf '%s\n' "$json" | "$PLUGIN_ROOT/hooks/scripts/detect-secrets.sh" >/dev/null 2>&1
+  assert_exit_code 0 "$?" "a shell command in tool_input.command must not be parsed as a patch"
+}
+
+test_guard_config_blocks_codex_command_shape() {
+  local patch json ec=0
+  patch=$(printf '*** Begin Patch\n*** Add File: /repo/.git/hooks/pre-commit\n+x\n*** End Patch')
+  json=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{command:$patch}}')
+  printf '%s\n' "$json" | "$PLUGIN_ROOT/hooks/scripts/guard-config.sh" >/dev/null 2>&1 || ec=$?
+  assert_exit_code 2 "$ec" "a .git/hooks write in the real Codex shape must be blocked"
+}
+
+test_hook_file_records_reads_codex_command_shape() {
+  local patch json out
+  patch=$(printf '*** Begin Patch\n*** Add File: /abs/seed.txt\n+PROBE\n*** End Patch')
+  json=$(jq -n --arg patch "$patch" '{tool_name:"apply_patch",tool_input:{command:$patch}}')
+  # shellcheck source=/dev/null
+  . "$PLUGIN_ROOT/hooks/scripts/common.sh"
+  out=$(kernel_hook_file_records "$json")
+  assert_contains "$out" '"path":"/abs/seed.txt"' "file records must extract the path from tool_input.command"
+  assert_contains "$out" '"content":"PROBE"' "file records must extract added content from tool_input.command"
+}
+
 test_guard_config_blocks_codex_apply_patch() {
   local patch json ec=0
   patch=$'*** Begin Patch\n*** Add File: .claude/generated/foo.md\n+generated\n*** End Patch'
@@ -2135,14 +2184,18 @@ test_critical_guard_scripts_unchanged_for_820() {
   # guard-bash pin moved once, when it was changed to fail CLOSED on a missing
   # jq (it warned and allowed, so the destructive-command fence opened whenever
   # its parser went missing -- found by tests/corpus/run-corpus.py).
+  # The guard-config and detect-secrets pins moved 2026-08-27, when both were
+  # taught to read tool_input.command: Codex sends apply_patch there, not in
+  # tool_input.patch, so both gates had been reading an empty string and
+  # passing everything on that host since 2026-07-14.
   local expected actual file
   while read -r expected file; do
     actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
 bf1ed3df128d833bc8e18837669bcda2e47178fc68a746691ac90f3de93e68a7 guard-bash.sh
-6a885672ad9f643bc0ac60cc3cfe3f2366a890faaa3a4bee132afb2d99cde731 guard-config.sh
-d3611267b4f135c5b96e8a4a8af60f296b196efc135e3dfbef63d7683065608c detect-secrets.sh
+ce20904682f9e53593328cc957c3039e99b7afe5eb9dc9cbea2f6dacbf650191 guard-config.sh
+c0afdb26d6794934e4e0758cdcd5e03aeb8abbd44a03daf781a7410fbb2e5ea9 detect-secrets.sh
 e1c4940def589dce982695d7e79f22e11cb767f6260608a738801f6c4167afbc guard-context.sh
 EOF
 }
@@ -5542,6 +5595,11 @@ run_test_suite() {
       run_test "detect-secrets allows clean code" test_detect_secrets_allows_clean_code
       run_test "detect-secrets blocks Codex apply_patch" test_detect_secrets_blocks_codex_apply_patch
       run_test "detect-secrets allows Codex secret removal" test_detect_secrets_allows_codex_secret_removal
+      run_test "detect-secrets blocks the real Codex shape" test_detect_secrets_blocks_codex_command_shape
+      run_test "detect-secrets allows a clean Codex patch" test_detect_secrets_allows_clean_codex_command_shape
+      run_test "detect-secrets ignores a shell command key" test_detect_secrets_ignores_shell_command_key
+      run_test "guard-config blocks the real Codex shape" test_guard_config_blocks_codex_command_shape
+      run_test "file records read the real Codex shape" test_hook_file_records_reads_codex_command_shape
       run_test "guard-bash blocks force push" test_guard_bash_blocks_force_push
       run_test "guard-bash allows safe commands" test_guard_bash_allows_safe_commands
       run_test "guard-bash allows git log" test_guard_bash_allows_git_log


### PR DESCRIPTION
⛔ **The secret scanner has been reading a key Codex never sends, since 2026-07-14.**

`detect-secrets.sh`, `guard-config.sh` and `common.sh` read the patch from `tool_input.patch`.
codex-cli sends it in `tool_input.command`. One key name. The parse returned empty, the guard hit
its empty-content early exit, and nothing was scanned on that host.

| | before | after |
|---|---|---|
| AWS key in a Codex apply_patch | rc=0, allowed | **rc=2, blocked** |
| `.git/hooks/pre-commit` write | rc=0, allowed | **rc=2, blocked** |
| clean patch, ordinary doc write | rc=0 | rc=0 |
| shell command in `tool_input.command` | n/a | rc=0, not parsed as a patch |

<details><summary>The captured payload</summary>

From codex-cli 0.150.1, by instrumenting the installed plugin's `log-write.sh` and running one
real session:

```json
{
  "hook_event_name": "PostToolUse",
  "tool_name": "apply_patch",
  "tool_input": {
    "command": "*** Begin Patch\n*** Add File: /abs/path.md\n+PROBE5\n*** End Patch"
  }
}
```

`.command` counts only when it opens with the apply_patch header, because a shell tool puts a
command line in the same key. `.patch` is still read as a fallback.

</details>

<details><summary>How it survived six weeks</summary>

`_meta/logs/actions.jsonl` holds 744 `apply_patch` hook fires between 2026-07-14 and today. The
extracted path is empty in every one. That empty string was the only symptom.

The suite already had two Codex apply_patch tests. Both built the payload as `tool_input.patch`,
a shape codex-cli never sends, so they asserted the invention and stayed green. Same species as
the `CODEX_PLUGIN_ROOT` bug in #191.

Blast radius beyond the scanner: `guard-config.sh` (write allowlist), `warn-hardcoded.sh`,
`validate-structure.sh`, `validate-json-schema.sh`, `log-write.sh`, `capture-error.sh` — all
downstream of `kernel_hook_file_records`.

</details>

**Also in here**: `governance/hosts.json` was wrong about this host in five ways, each now backed
by a measurement rather than a reading.

<details><summary>The five corrections</summary>

- Codex reads `hooks/hooks.json` and never the root `hooks.json`. Proved twice: the SessionEnd
  clamp warning names the file, and Codex's own trust store keys hooks as
  `kernel@kernel-marketplace:hooks/hooks.json:...`.
- Declaring a `hooks` path in `.codex-plugin/plugin.json` makes it worse, not better. A/B,
  PostToolUse rows per apply_patch went 1 → 0 → 0 → 1 on removal. Do not add it.
- Hooks need `[features] hooks = true`. Off by default, silent when missing.
- Project and plugin hooks both carry per-hook `trusted_hash` entries that an edit invalidates
  silently.
- `PostCompact`, `SubagentStart` and `Interrupt` are supported and were missing from the list.
  `agents/*.md` has no Codex equivalent, so all ten Kernel agents are Claude-only.

</details>

- [ ] Ship a release after merge. The installed caches still carry the broken parse.

**Tests**: 493 passed, 1 failed. The failure is `test_contributor_ambient_within_budget`, already
red on main and untouched here; the report explains why it is not actionable as written and why
the budgets were not raised.

Full audit, evidence and repro steps: `_meta/reports/codex-parity-audit-2026-08-27.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
