### PR TITLE
release: 9.6.2 - the Codex secret scanner reads the key Codex actually sends

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Safety guardrails, hooks, and agentdb memory for Claude Code and Codex in auto mode, with independent verification",
-      "version": "9.6.1"
+      "version": "9.6.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: ce05c64af2e12ec0147774edd9c9166dcbc7fec2e63f241ecc9afdc894b206b3; adapter: codex -->
-<kernel version="9.6.1">
+<kernel version="9.6.2">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.6.2] - 2026-08-27
+
+The secret scanner read `tool_input.patch`. Codex sends `tool_input.command`.
+
+One key name, and every content- and path-gated hook saw an empty string on that host from
+2026-07-14 until today. The scanner scanned nothing; the write allowlist guarded nothing. The
+symptom was 744 rows in a log with an empty `file` field, and two tests that built the payload
+in a shape codex-cli has never sent and therefore passed.
+
+### Fixed
+- `detect-secrets.sh`, `guard-config.sh` and `common.sh` read the patch from
+  `tool_input.command`, captured live from codex-cli 0.150.1. `.command` counts only when it
+  opens with the apply_patch header, because a shell tool puts a command line in the same key.
+  `.patch` is still read as a fallback. Fails-before/passes-after on the real shape: an AWS key
+  and a `.git/hooks/pre-commit` write both went rc=0 to rc=2, clean writes unaffected.
+- Five regression tests on the captured shape, plus one asserting a shell command in that key is
+  not parsed as a patch. The `guard-config` and `detect-secrets` hash pins move with the reason
+  recorded beside them.
+
+### Changed
+- `governance/hosts.json` corrects five claims about Codex, each now backed by a measurement
+  rather than a reading: Codex reads `hooks/hooks.json` and never the root `hooks.json`, proved
+  twice over; declaring a `hooks` path in `.codex-plugin/plugin.json` suppresses PostToolUse
+  rather than supplementing discovery, so do not add it; hooks require `[features] hooks = true`,
+  off by default and silent when missing; project and plugin hooks both carry per-hook
+  `trusted_hash` entries an edit invalidates in silence; `PostCompact`, `SubagentStart` and
+  `Interrupt` are supported and were missing from the list.
+- `agents/*.md` has no Codex equivalent, so all ten KERNEL agents are Claude-only and the tier-3
+  contract → surgeon → adversary flow has no Codex implementation. Stated rather than implied.
+- `HOST-CAPABILITIES.md` now renders the operator-facing facts a path alone cannot carry: what
+  the host actually reads, what flag it needs, and what it will silently decline to run.
+
+Audit, evidence and repro steps: `_meta/reports/codex-parity-audit-2026-08-27.md` (#230).
+
 ## [9.6.1] - 2026-08-27
 
 A note that is not probed outlives the fix that made it false.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: ce05c64af2e12ec0147774edd9c9166dcbc7fec2e63f241ecc9afdc894b206b3; adapter: claude -->
-<kernel version="9.6.1">
+<kernel version="9.6.2">
 
 
 <!-- ============================================ -->

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "description": "KERNEL's methodology layer for Gemini CLI: 27 software-engineering agent skills plus llms.txt as ambient context. Skills cover systematic debugging (reproduce, isolate, regression-test), generating competing approaches before implementing, pre-implementation critique, code review, bounded context handoff and resume, multi-agent orchestration, eval-driven development, release gating, and context-led frontend design. Gemini CLI gets the methodology only. KERNEL's enforcement layer does not run here: the PreToolUse hooks that block destructive commands and secret writes, the one-time human approval token for irreversible operations, and the agentdb SQLite memory recalled at session start are Claude Code and Codex only. `gemini extensions install` fetches a curated release bundle that carries just this manifest, llms.txt, and skills/, so no Claude-format hook or agent definition is loaded. Source, safety limits, and the host capability matrix: https://github.com/ariaxhan/kernel-claude",
   "contextFileName": "llms.txt"
 }

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 > that carries lessons between sessions.
 
 Repository: https://github.com/ariaxhan/kernel-claude
-License: MIT. Version 9.6.1. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+License: MIT. Version 9.6.2. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
 
 ## What it is
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.6.1.
+Quick reference for KERNEL v9.6.2.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>


### PR DESCRIPTION
🔧 **Ships the #230 fix to installed plugins.** Until this lands, every Codex cache still runs a secret scanner that reads a key Codex never sends.

Version bump across the eight canonical declarations plus the CHANGELOG entry. No behaviour change beyond what #230 already merged.

| | |
|---|---|
| Fix | `detect-secrets.sh`, `guard-config.sh`, `common.sh` read `tool_input.command` |
| Broken since | 2026-08-27 minus six weeks (2026-07-14) |
| Proof | AWS key and a `.git/hooks` write both go rc=0 → rc=2 on the real payload |

- [ ] Tag `v9.6.2` after merge
- [ ] Refresh both Codex caches (`~/.codex`, `~/.codex-cli`) and the Claude cache

**Tests**: 493 passed, 1 failed. The failure is `test_contributor_ambient_within_budget`, red on main before this branch and unrelated to it. It is red locally and green in CI for the same reason: `measure_ambient` runs `session-start.sh` against the live repo and counts output that carries the branch, commit log, agentdb learnings and code map. Diagnosed in `_meta/reports/codex-parity-audit-2026-08-27.md`; the budgets were deliberately not raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
