### PR TITLE
Enforce complexity budgets and regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.7.1] - 2026-09-01
+
+Complexity is a project gate, not a table the builder can omit.
+
+### Added
+- `.ccnrc` per-function budgets and justified selector skips. Unknown keys, invalid budgets,
+  and skips without reasons fail closed.
+- `complexity.sh --all`, `--diff`, and `--check-baseline`: fresh verifier diffs report
+  reduced/unchanged/regressed counts; duplicate function names remain distinct; the CI ratchet
+  rejects changed debt and new violations.
+
+### Changed
+- JS/TS complexity uses the project's ESLint AST when available, including methods inside
+  returned object literals. Lizard remains the polyglot fallback and now declares its JS/TS
+  blind spot instead of presenting a false function table as proof.
+- `simplify` requires the project-owned gate in `npm run verify`, Make/just verify, or the
+  existing pre-commit path, plus a seeded red/green probe. `review` treats manual-only checks
+  and non-AST object-method scans as `NOT CHECKED`.
+- Deterministic review reports analyzer failures as `NOT_CHECKED`; `.ccnrc` budgets replace
+  the old one-number complexity message. Fatal ESLint parser results block instead of becoming
+  an empty passing complexity report.
+
 ## [9.7.0] - 2026-09-01
 
 Retrospective extracts intelligence, not hygiene; every assert grades.

--- a/_meta/chronicles/2026/2026-09-01-complexity-enforcement.md
+++ b/_meta/chronicles/2026/2026-09-01-complexity-enforcement.md
@@ -1,0 +1,27 @@
+---
+type: chronicle
+status: active
+created: 2026-09-01
+---
+
+# Lizard's false table became an AST-aware project gate
+
+**What mattered:** Matra's “all complexity reduced” receipt was false: ESLint's AST found 66
+functions over 15 and every returned-object method lizard omitted. Manual measurement could not
+prevent recurrence, so simplify now ends only when the project's normal verify path owns the gate.
+
+**Shipped**
+- `scripts/complexity.{sh,py}`: ESLint AST, lizard fallback disclosure, `.ccnrc`, diffs, CI ratchet.
+- `skills/{simplify,review}/SKILL.md`: per-function budgets, regression record, seeded armed gate.
+- Ten focused regressions plus deterministic-review `NOT_CHECKED` analyzer failures.
+
+**Verified how:** focused complexity 10/10; tokens 8/8; kernel9 1/1; real Matra scan listed
+`createKnowledgeRepo` plus all 23 returned methods. Full suite: 506 pass, one unrelated existing
+portable test failure; it writes `~/Vaults` in the real home, loses to existing
+`~/Documents/Vaults`, then returns before cleanup. Exact empty residue removed.
+
+**Wrong or surprising**
+- A complete Matra AST snapshot is 7,336 functions/428 KB; the enforceable baseline needs only
+  the 66 current over-budget rows. New over-budget functions are caught without a giant ledger.
+
+**Open:** merge/release state and independent verifier verdict are recorded on the PR/AgentDB.

--- a/_meta/commissions/2026-09-01-complexity-enforcement.md
+++ b/_meta/commissions/2026-09-01-complexity-enforcement.md
@@ -1,0 +1,27 @@
+---
+type: commission
+status: active
+created: 2026-09-01
+---
+
+# Complexity enforcement
+
+## Goal
+
+Make `simplify` and `review` enforce measured complexity: AST-aware TypeScript scanning,
+explicit exceptions, per-function budgets, regression diffs, and project verify wiring.
+
+## Boundaries
+
+- Kernel skill, analyzer, deterministic-review, tests, changelog, plan, review, chronicle only.
+- Preserve existing public CLI behavior unless a new flag is used.
+- No target-project mutation or new dependency.
+
+## Done when
+
+- Object-literal methods are measured through an installed ESLint parser; lizard remains fallback.
+- `.ccnrc` and `--skip` support named budgets and justified exceptions.
+- Baseline comparison emits reduced, unchanged, regressed counts and fails regressions.
+- Both skills require a checked project verify/pre-commit path.
+- Seeded fixtures, focused suite, real Matra probe, diff check, and full suite run are evidenced;
+  unrelated existing red is isolated and reported.

--- a/_meta/plans/complexity-enforcement.md
+++ b/_meta/plans/complexity-enforcement.md
@@ -1,0 +1,26 @@
+---
+type: note
+status: active
+created: 2026-09-01
+---
+
+# Complexity enforcement
+
+## Contract
+
+- Goal: complexity becomes an AST-aware, configurable, regression-tracked build gate.
+- Inputs: `.ccnrc`, source tree, optional base ref or baseline TSV.
+- Outputs: budget violations or a per-function regression diff.
+- Done: commission acceptance checks pass.
+
+## Options
+
+1. Lizard filters only: smallest; object-literal blindness remains. Rejected.
+2. Existing ESLint AST for JS/TS, lizard fallback, stdlib config/diff layer. Chosen.
+3. Custom TypeScript AST analyzer: full control; duplicates maintained parser logic. Rejected.
+
+## Check
+
+`tests/run-tests.sh complexity`; seeded object-method probe; `.ccnrc` budget/skip probes;
+baseline regression probe; real Matra `knowledge-repo.ts` method scan; `tests/run-tests.sh`;
+`git diff --check`.

--- a/_meta/reviews/complexity-enforcement-teardown.md
+++ b/_meta/reviews/complexity-enforcement-teardown.md
@@ -1,0 +1,25 @@
+---
+type: review
+status: complete
+created: 2026-09-01
+tier: 2
+scope: 7 source/test files
+---
+
+# Tear Down: complexity enforcement
+
+## Big 5
+
+input_validation: revise, config and selectors need strict validation
+edge_cases: revise, missing analyzer, renamed functions, anonymous functions, deleted files
+error_handling: revise, parser failure must block rather than fall back silently
+duplication: pass, one analyzer owns simplify and review
+complexity: pass, stdlib coordinator plus installed analyzers
+
+## Verdict: REVISE, then proceed
+
+- Reject unknown config keys and unjustified skips.
+- Keep old positional CLI; new modes explicit.
+- ESLint parse/config errors exit non-zero. Lizard fallback is declared, never presented as AST-complete.
+- Diff names removed/added functions separately; regression count covers matched functions only.
+- Seed the object-literal failure and regression failure before trusting the gate.

--- a/llms.txt
+++ b/llms.txt
@@ -113,7 +113,7 @@ agentdb learn failure|pattern|gotcha "<what>" "<evidence>"  # after discovering
 - `/kernel:build` · `$kernel:build`: generate two or three approaches before implementing, take the simplest.
 - `/kernel:debug` · `$kernel:debug`: reproduce, hypothesize, isolate by binary search, fix root cause, add a regression test.
 - `/kernel:diagnose` · `$kernel:diagnose`: diagnosis before prescription for bugs and refactors.
-- `/kernel:simplify` · `$kernel:simplify`: reduce cyclomatic complexity, measured by lizard, worst function first, before/after table re-measured by a verifier.
+- `/kernel:simplify` · `$kernel:simplify`: reduce cyclomatic complexity with AST-aware JS/TS measurement, per-function budgets, regression diffs, and a project-owned verify gate.
 - `/kernel:review` · `$kernel:review`: code review with a deterministic scanner lane and a refutation pass; APPROVE, REQUEST CHANGES, or COMMENT.
 - `/kernel:tearitapart` · `$kernel:tearitapart`: pre-implementation critique; PROCEED, REVISE, or RETHINK.
 - `/kernel:ship` · `$kernel:ship`: release gate: validate, review, publish, tag.

--- a/scripts/complexity.py
+++ b/scripts/complexity.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Project complexity gate: AST-aware JS/TS, budgets, skips, and baseline diffs."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+import fnmatch
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+JS_EXTS = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}
+LIZARD_EXTS = JS_EXTS | {
+    ".c", ".cc", ".cpp", ".cs", ".go", ".h", ".hpp", ".java", ".kt", ".kts",
+    ".m", ".mm", ".php", ".py", ".rb", ".rs", ".scala", ".sh", ".swift",
+}
+EXCLUDED_PARTS = {
+    ".git", ".next", ".svelte-kit", ".venv", ".wrangler", "build", "coverage",
+    "dist", "graphify-out", "node_modules", "test-results", "vendor", "venv",
+}
+CONFIG_KEYS = {"version", "default", "budgets", "skip", "engine"}
+
+
+class GateError(Exception):
+    pass
+
+
+class AnalyzerUnavailable(GateError):
+    pass
+
+
+@dataclass(frozen=True)
+class Record:
+    file: str
+    line: int
+    function: str
+    ccn: int
+    nloc: int
+
+    @property
+    def key(self) -> str:
+        return f"{self.file}:{self.function}"
+
+
+def run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def git_lines(repo: Path, args: list[str]) -> list[str]:
+    proc = run(["git", *args], repo)
+    if proc.returncode != 0:
+        raise GateError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def is_source(rel: str) -> bool:
+    path = Path(rel)
+    return path.suffix.lower() in LIZARD_EXTS and not any(part in EXCLUDED_PARTS for part in path.parts)
+
+
+def targets(repo: Path, base: str | None) -> list[str]:
+    in_git = run(["git", "rev-parse", "--git-dir"], repo).returncode == 0
+    if in_git:
+        if base:
+            bases = git_lines(repo, ["merge-base", base, "HEAD"])
+            if not bases:
+                raise GateError(f"no merge base with {base}")
+            names = git_lines(repo, ["diff", "--name-only", "--diff-filter=d", bases[0]])
+            names += git_lines(repo, ["ls-files", "--others", "--exclude-standard"])
+        else:
+            names = git_lines(repo, ["ls-files", "--cached", "--others", "--exclude-standard"])
+        return sorted({name for name in names if is_source(name) and (repo / name).is_file()})
+
+    found: list[str] = []
+    for root, dirs, files in os.walk(repo):
+        dirs[:] = [name for name in dirs if name not in EXCLUDED_PARTS]
+        for name in files:
+            path = Path(root, name)
+            rel = path.relative_to(repo).as_posix()
+            if is_source(rel):
+                found.append(rel)
+    return sorted(found)
+
+
+def validate_budgets(path: Path, budgets: object) -> dict[str, int]:
+    if not isinstance(budgets, dict):
+        raise GateError(f"invalid config {path}: budgets must be an object")
+    for selector, limit in budgets.items():
+        valid_limit = isinstance(limit, int) and not isinstance(limit, bool) and limit >= 1
+        if not isinstance(selector, str) or not selector or not valid_limit:
+            raise GateError(f"invalid config {path}: every budget needs a selector and positive integer")
+    return budgets
+
+
+def validate_skips(path: Path, skips: object) -> dict[str, str]:
+    if not isinstance(skips, dict):
+        raise GateError(f"invalid config {path}: skip must be an object")
+    for selector, reason in skips.items():
+        valid_reason = isinstance(reason, str) and bool(reason.strip())
+        if not isinstance(selector, str) or not selector or not valid_reason:
+            raise GateError(f"invalid config {path}: every skip needs a selector and reason")
+    return skips
+
+
+def load_config(path: Path) -> dict:
+    if not path.exists():
+        return {"version": 1, "default": 15, "budgets": {}, "skip": {}, "engine": "auto"}
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GateError(f"invalid config {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise GateError(f"invalid config {path}: root must be an object")
+    unknown = sorted(set(value) - CONFIG_KEYS)
+    if unknown:
+        raise GateError(f"invalid config {path}: unknown keys: {', '.join(unknown)}")
+    if value.get("version", 1) != 1:
+        raise GateError(f"invalid config {path}: version must be 1")
+    default = value.get("default", 15)
+    if not isinstance(default, int) or isinstance(default, bool) or default < 1:
+        raise GateError(f"invalid config {path}: default must be a positive integer")
+    budgets = validate_budgets(path, value.get("budgets", {}))
+    skips = validate_skips(path, value.get("skip", {}))
+    engine = value.get("engine", "auto")
+    if engine not in {"auto", "eslint", "lizard"}:
+        raise GateError(f"invalid config {path}: engine must be auto, eslint, or lizard")
+    return {"version": 1, "default": default, "budgets": budgets, "skip": skips, "engine": engine}
+
+
+def eslint_binary(repo: Path) -> str | None:
+    local = repo / "node_modules" / ".bin" / "eslint"
+    if local.is_file() and os.access(local, os.X_OK):
+        return str(local)
+    return shutil.which("eslint")
+
+
+def has_eslint_config(repo: Path) -> bool:
+    names = ("eslint.config.js", "eslint.config.mjs", "eslint.config.cjs", "eslint.config.ts",
+             ".eslintrc", ".eslintrc.js", ".eslintrc.cjs", ".eslintrc.json", ".eslintrc.yml", ".eslintrc.yaml")
+    return any((repo / name).exists() for name in names)
+
+
+def arrow_name(repo: Path, rel: str, line: int) -> str:
+    try:
+        source = (repo / rel).read_text().splitlines()[line - 1]
+    except (OSError, IndexError, UnicodeDecodeError):
+        return f"(anonymous@{line})"
+    match = re.search(r"(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b.*=>", source)
+    if match:
+        return match.group(1)
+    match = re.search(r"\b([A-Za-z_$][\w$]*)\s*:\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>", source)
+    return match.group(1) if match else f"(anonymous@{line})"
+
+
+def eslint_name(repo: Path, rel: str, line: int, message: str) -> str:
+    match = re.search(r"(?:function|method) '([^']+)' has a complexity", message, re.IGNORECASE)
+    if match:
+        return match.group(1)
+    return arrow_name(repo, rel, line)
+
+
+def analyze_eslint(repo: Path, files: list[str], binary: str) -> list[Record]:
+    records: list[Record] = []
+    for start in range(0, len(files), 100):
+        batch = files[start:start + 100]
+        proc = run([binary, *batch, "--rule", "complexity: [error, 0]", "--format", "json"], repo)
+        if proc.returncode not in {0, 1}:
+            raise GateError(f"eslint analysis failed: {proc.stderr.strip() or proc.stdout.strip()}")
+        try:
+            reports = json.loads(proc.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            raise GateError(f"eslint returned invalid JSON: {exc}") from exc
+        for report in reports:
+            try:
+                rel = Path(report["filePath"]).resolve().relative_to(repo).as_posix()
+            except (KeyError, ValueError) as exc:
+                raise GateError("eslint returned a file outside the repository") from exc
+            for message in report.get("messages", []):
+                if message.get("fatal"):
+                    detail = message.get("message", "fatal parser error")
+                    raise GateError(f"eslint could not parse {rel}:{message.get('line', 0)}: {detail}")
+                if message.get("ruleId") != "complexity":
+                    continue
+                found = re.search(r"complexity of (\d+)", message.get("message", ""))
+                if not found:
+                    raise GateError(f"eslint complexity output changed: {message.get('message', '')}")
+                line = int(message.get("line", 0))
+                name = eslint_name(repo, rel, line, message["message"])
+                records.append(Record(rel, line, name, int(found.group(1)), 0))
+    return records
+
+
+LIZARD_LINE = re.compile(r"^(.*?):(\d+): warning: (.+) has (\d+) NLOC, (\d+) CCN.*$")
+
+
+def lizard_command() -> list[str] | None:
+    if shutil.which("lizard"):
+        return ["lizard"]
+    if shutil.which("uvx"):
+        return ["uvx", "--quiet", "lizard"]
+    return None
+
+
+def analyze_lizard(repo: Path, files: list[str], command: list[str]) -> list[Record]:
+    if not files:
+        return []
+    proc = run([*command, "-w", "-C", "0", *files], repo)
+    if proc.returncode not in {0, 1}:
+        raise GateError(f"lizard analysis failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    records: list[Record] = []
+    for line in proc.stdout.splitlines():
+        match = LIZARD_LINE.match(line.removeprefix("./"))
+        if not match:
+            continue
+        rel, lineno, name, nloc, ccn = match.groups()
+        records.append(Record(rel, int(lineno), name, int(ccn), int(nloc)))
+    return records
+
+
+def matches(selector: str, record: Record) -> bool:
+    return fnmatch.fnmatchcase(record.key, selector)
+
+
+def selected_limit(record: Record, config: dict) -> int:
+    if record.key in config["budgets"]:
+        return config["budgets"][record.key]
+    for selector, limit in config["budgets"].items():
+        if matches(selector, record):
+            return limit
+    return config["default"]
+
+
+def skipped(record: Record, config: dict) -> tuple[str, str] | None:
+    for selector, reason in config["skip"].items():
+        if matches(selector, record):
+            return selector, reason
+    return None
+
+
+def emit_record(record: Record) -> None:
+    print(f"{record.file}\t{record.line}\t{record.function}\t{record.ccn}\t{record.nloc}")
+
+
+def read_baseline(path: Path) -> list[Record]:
+    records: list[Record] = []
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as exc:
+        raise GateError(f"cannot read baseline {path}: {exc}") from exc
+    for number, line in enumerate(lines, 1):
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) != 5:
+            raise GateError(f"invalid baseline {path}:{number}: expected 5 TSV fields")
+        try:
+            records.append(Record(fields[0], int(fields[1]), fields[2], int(fields[3]), int(fields[4])))
+        except ValueError as exc:
+            raise GateError(f"invalid baseline {path}:{number}: numeric field required") from exc
+    return records
+
+
+def records_by_key(records: list[Record]) -> dict[str, list[Record]]:
+    grouped: dict[str, list[Record]] = defaultdict(list)
+    for record in records:
+        grouped[record.key].append(record)
+    for values in grouped.values():
+        values.sort(key=lambda record: record.line)
+    return grouped
+
+
+def emit_existing_diffs(
+    before: list[Record], after_by_key: dict[str, list[Record]], config: dict, counts: dict
+) -> None:
+    occurrence: Counter[str] = Counter()
+    for old in sorted(before, key=lambda record: (record.file, record.line, record.function)):
+        candidates = after_by_key.get(old.key, [])
+        index = occurrence[old.key]
+        occurrence[old.key] += 1
+        new = candidates[index] if index < len(candidates) else None
+        if new is None:
+            counts["removed"] += 1
+            print(f"{old.file}\t{old.line}\t{old.function}\t{old.ccn}\t-\t-\tremoved")
+            continue
+        status = "reduced" if new.ccn < old.ccn else "regressed" if new.ccn > old.ccn else "unchanged"
+        counts[status] += 1
+        print(
+            f"{new.file}\t{new.line}\t{new.function}\t{old.ccn}\t{new.ccn}\t"
+            f"{selected_limit(new, config)}\t{status}"
+        )
+
+
+def emit_added_violations(current: list[Record], before_counts: Counter[str], config: dict, counts: dict) -> None:
+    occurrence: Counter[str] = Counter()
+    for record in sorted(current, key=lambda value: (value.file, value.line, value.function)):
+        index = occurrence[record.key]
+        occurrence[record.key] += 1
+        if index >= before_counts[record.key] and record.ccn > selected_limit(record, config):
+            counts["added"] += 1
+            print(
+                f"{record.file}\t{record.line}\t{record.function}\t-\t{record.ccn}\t"
+                f"{selected_limit(record, config)}\tadded"
+            )
+
+
+def emit_diff(before: list[Record], current: list[Record], config: dict, baseline_gate: bool = False) -> int:
+    counts = {"reduced": 0, "unchanged": 0, "regressed": 0, "removed": 0, "added": 0}
+    print("file\tline\tfunction\tbefore\tafter\tbudget\tstatus")
+    emit_existing_diffs(before, records_by_key(current), config, counts)
+    if baseline_gate:
+        emit_added_violations(current, Counter(record.key for record in before), config, counts)
+    diff_fields = ("reduced", "unchanged", "regressed", "removed")
+    fields = (*diff_fields, "added") if baseline_gate else diff_fields
+    print("SUMMARY\t" + "\t".join(f"{key}={counts[key]}" for key in fields))
+    if baseline_gate:
+        return 1 if any(counts[key] for key in ("reduced", "regressed", "removed", "added")) else 0
+    over_budget = any(record.ccn > selected_limit(record, config) for record in current)
+    return 1 if counts["regressed"] or over_budget else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="complexity.sh",
+        description="Cyclomatic complexity gate. TSV: file, line, function, CCN, NLOC.",
+    )
+    parser.add_argument("--all", action="store_true", help="emit every measured function for a baseline")
+    parser.add_argument("--config", help="config path; default <repo>/.ccnrc")
+    parser.add_argument("--diff", metavar="BASELINE_TSV", help="emit before/current regression diff")
+    parser.add_argument(
+        "--check-baseline",
+        metavar="BASELINE_TSV",
+        help="CI ratchet: fail changed or new over-budget functions",
+    )
+    parser.add_argument("--engine", choices=("auto", "eslint", "lizard"))
+    parser.add_argument("--skip", action="append", default=[], metavar="SELECTOR=REASON")
+    parser.add_argument("repo")
+    parser.add_argument("base_ref", nargs="?")
+    return parser.parse_args()
+
+
+def apply_limit_override(config: dict) -> None:
+    if "CCN_MAX" in os.environ:
+        try:
+            env_limit = int(os.environ["CCN_MAX"])
+        except ValueError as exc:
+            raise GateError("CCN_MAX must be a positive integer") from exc
+        if env_limit < 1:
+            raise GateError("CCN_MAX must be a positive integer")
+        config["default"] = env_limit
+
+
+def apply_cli_overrides(config: dict, args: argparse.Namespace) -> None:
+    if args.engine:
+        config["engine"] = args.engine
+    for item in args.skip:
+        if "=" not in item:
+            raise GateError("--skip requires SELECTOR=REASON")
+        selector, reason = item.split("=", 1)
+        if not selector or not reason.strip():
+            raise GateError("--skip requires a non-empty selector and reason")
+        config["skip"][selector] = reason.strip()
+
+
+def collect_records(repo: Path, files: list[str], engine: str) -> list[Record]:
+    js_files = [name for name in files if Path(name).suffix.lower() in JS_EXTS]
+    other_files = [name for name in files if name not in js_files]
+    eslint = eslint_binary(repo)
+    use_eslint = engine != "lizard" and bool(js_files) and bool(eslint) and has_eslint_config(repo)
+    if engine == "eslint" and not use_eslint:
+        raise GateError("eslint engine requested, but an executable and project config were not found")
+
+    records: list[Record] = []
+    if use_eslint:
+        print("complexity engine: eslint AST for JS/TS", file=sys.stderr)
+        records.extend(analyze_eslint(repo, js_files, eslint or "eslint"))
+    else:
+        other_files += js_files
+        if js_files:
+            print(
+                "complexity engine: lizard fallback for JS/TS; object-literal methods are not visible",
+                file=sys.stderr,
+            )
+
+    lizard = lizard_command()
+    if other_files:
+        if not lizard:
+            raise AnalyzerUnavailable("no analyzer: install lizard/uvx, or project ESLint for JS/TS")
+        records.extend(analyze_lizard(repo, other_files, lizard))
+    return records
+
+
+def apply_skips(records: list[Record], config: dict) -> list[Record]:
+    kept: list[Record] = []
+    announced: set[tuple[str, str]] = set()
+    for record in records:
+        skip = skipped(record, config)
+        if not skip:
+            kept.append(record)
+        elif skip not in announced:
+            print(f"complexity skip: {skip[0]} ({skip[1]})", file=sys.stderr)
+            announced.add(skip)
+    return kept
+
+
+def main() -> int:
+    args = parse_args()
+    if args.diff and args.check_baseline:
+        raise GateError("choose --diff or --check-baseline, not both")
+    repo = Path(args.repo).resolve()
+    if not repo.is_dir():
+        raise GateError(f"repo is not a directory: {repo}")
+    config_path = Path(args.config).resolve() if args.config else repo / ".ccnrc"
+    config = load_config(config_path)
+    apply_limit_override(config)
+    apply_cli_overrides(config, args)
+
+    files = targets(repo, args.base_ref)
+    if not files:
+        return 0
+    kept = apply_skips(collect_records(repo, files, config["engine"]), config)
+
+    if args.diff:
+        return emit_diff(read_baseline(Path(args.diff)), kept, config)
+    if args.check_baseline:
+        return emit_diff(read_baseline(Path(args.check_baseline)), kept, config, baseline_gate=True)
+    if args.all:
+        for record in sorted(kept, key=lambda value: (value.file, value.line, value.function)):
+            emit_record(record)
+        return 0
+
+    hotspots = [record for record in kept if record.ccn > selected_limit(record, config)]
+    for record in sorted(hotspots, key=lambda value: (-value.ccn, value.file, value.line)):
+        emit_record(record)
+    return 1 if hotspots else 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AnalyzerUnavailable as exc:
+        print(f"complexity SKIPPED: {exc}", file=sys.stderr)
+        raise SystemExit(3)
+    except GateError as exc:
+        print(f"complexity ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/scripts/complexity.sh
+++ b/scripts/complexity.sh
@@ -1,49 +1,7 @@
 #!/bin/bash
-# complexity.sh <repo-dir> [base-ref]
-#
-# Cyclomatic complexity per function, worst first. The measurement lane behind
-# /kernel:simplify and the review skill's complexity check: a number a tool produced, not a
-# question the model answers about itself.
-#
-# Uses lizard (polyglot: Python, JS/TS, Go, Rust, Swift, Java, C, ...). Runs it from PATH,
-# else via `uvx lizard` (no install). Neither present: prints SKIPPED and exits 3, never a
-# silent pass.
-#
-# Diff mode (base-ref given): only files changed since base-ref are measured.
-# Threshold: $CCN_MAX (default 15). A project linter config with its own complexity
-# threshold outranks this default; the caller passes it through CCN_MAX.
-#
-# Output: TSV to stdout, file<TAB>line<TAB>function<TAB>ccn<TAB>nloc, sorted by ccn desc,
-#         only functions at or above CCN_MAX. Exit 0 if none, 1 if any, 3 if no tool.
+# complexity.sh [options] <repo-dir> [base-ref]
+# AST-aware JS/TS when the project has ESLint; lizard for other supported languages.
 set -u
 
-REPO="${1:?usage: complexity.sh <repo-dir> [base-ref]}"
-BASE="${2:-}"
-CCN_MAX="${CCN_MAX:-15}"
-cd "$REPO" || exit 2
-
-if command -v lizard >/dev/null; then LIZ=(lizard)
-elif command -v uvx >/dev/null; then LIZ=(uvx --quiet lizard)
-else echo "lizard SKIPPED (install: pip install lizard, or have uvx on PATH)" >&2; exit 3; fi
-
-EXCL=(-x '*/node_modules/*' -x '*/dist/*' -x '*/build/*' -x '*/.venv/*' -x '*/venv/*'
-      -x '*/.svelte-kit/*' -x '*/.next/*' -x '*/vendor/*' -x '*/graphify-out/*' -x '*.min.js')
-
-TARGETS=()
-if [ -n "$BASE" ]; then
-  while IFS= read -r f; do [ -n "$f" ] && [ -f "$f" ] && TARGETS+=("$f"); done < <(
-    git diff --name-only --diff-filter=d "$BASE"...HEAD 2>/dev/null || git diff --name-only --diff-filter=d "$BASE"..HEAD)
-  [ "${#TARGETS[@]}" -eq 0 ] && exit 0
-else
-  TARGETS=(.)
-fi
-
-# lizard -w prints one warning per function over the threshold:
-#   path:line: warning: name has N NLOC, M CCN, ...
-OUT="$("${LIZ[@]}" -w -C "$CCN_MAX" "${EXCL[@]}" "${TARGETS[@]}" 2>/dev/null \
-  | sed -E 's#^\./##; s/^([^:]+):([0-9]+): warning: (.+) has ([0-9]+) NLOC, ([0-9]+) CCN.*$/\1\t\2\t\3\t\5\t\4/' \
-  | awk -F'\t' 'NF==5 && $2 ~ /^[0-9]+$/ && $4 ~ /^[0-9]+$/' \
-  | sort -t"$(printf '\t')" -k4,4nr -k1,1)"
-[ -z "$OUT" ] && exit 0
-printf '%s\n' "$OUT"
-exit 1
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec python3 "$ROOT/scripts/complexity.py" "$@"

--- a/scripts/deterministic-review.sh
+++ b/scripts/deterministic-review.sh
@@ -14,11 +14,12 @@
 #
 # Install the lanes (all free; any subset works, missing ones are reported as SKIPPED):
 #   brew install gitleaks semgrep actionlint zizmor osv-scanner shellcheck jq
-#   pip install lizard   (or have uvx on PATH; complexity lane, MED severity, never gates)
+#   project ESLint or lizard/uvx (complexity lane; .ccnrc budgets apply)
 # Licensing: semgrep Community rules are internal-use only (no resale/SaaS on top of them);
 # gitleaks/actionlint/zizmor MIT, osv-scanner Apache-2.0, shellcheck GPL-3.0 (tool-only).
 set -u
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO="${1:?usage: deterministic-review.sh <repo-dir> [base-ref]}"
 BASE="${2:-}"
 cd "$REPO" || exit 2
@@ -87,13 +88,24 @@ if command -v osv-scanner >/dev/null; then
   note osv-scanner RAN
 else note osv-scanner SKIPPED; fi
 
-CX_SH="$(dirname "$0")/complexity.sh"
-if [ -x "$CX_SH" ] && { command -v lizard >/dev/null || command -v uvx >/dev/null; }; then
-  ( "$CX_SH" . ${BASE:+"$BASE"} > "$T/complexity.tsv" 2>/dev/null; true ) &
-  note complexity RAN
+CX_SH="$SCRIPT_DIR/complexity.sh"
+CX_AVAILABLE=0
+if [ -x "$CX_SH" ]; then
+  CX_AVAILABLE=1
+  ( rc=0; "$CX_SH" . ${BASE:+"$BASE"} > "$T/complexity.tsv" 2>"$T/complexity.err" || rc=$?; printf '%s\n' "$rc" > "$T/complexity.rc" ) &
 else note complexity SKIPPED; fi
 
 wait
+
+if [ "$CX_AVAILABLE" -eq 1 ]; then
+  CX_RC="$(cat "$T/complexity.rc" 2>/dev/null || echo 2)"
+  if [ "$CX_RC" -eq 0 ] || [ "$CX_RC" -eq 1 ]; then
+    note complexity RAN
+  else
+    note complexity NOT_CHECKED
+    sed 's/^/complexity: /' "$T/complexity.err" >&2
+  fi
+fi
 
 # --- normalize -------------------------------------------------------------------------
 F="$OUT_DIR/findings.tsv"; : > "$F"
@@ -108,7 +120,7 @@ J "$T/actionlint.json" && jq -r '.[] | [.filepath, (.line|tostring), "actionlint
 J "$T/zizmor.json" && jq -r '.[]? | (.locations[0].symbolic.key.Local.given_path // "workflow") as $f | [$f, "0", "zizmor", (if .determinations.severity=="High" then "HIGH" else "MED" end), .ident] | @tsv' "$T/zizmor.json" >> "$F" 2>/dev/null
 J "$T/osv.json" && jq -r '.results[]?.packages[]? | .package.name as $p | .vulnerabilities[]? | [$p, "0", "osv-scanner", (if ((.database_specific.severity//"")|ascii_downcase)=="critical" or ((.database_specific.severity//"")|ascii_downcase)=="high" then "HIGH" else "MED" end), .id] | @tsv' "$T/osv.json" >> "$F" 2>/dev/null
 
-[ -s "$T/complexity.tsv" ] && awk -F'\t' 'BEGIN{OFS="\t"} {print $1, $2, "complexity", "MED", $3 " CCN " $4 " (>= " CCN_MAX ")"}' CCN_MAX="${CCN_MAX:-15}" "$T/complexity.tsv" >> "$F"
+[ -s "$T/complexity.tsv" ] && awk -F'\t' 'BEGIN{OFS="\t"} {print $1, $2, "complexity", "MED", $3 " CCN " $4 " (over declared budget)"}' "$T/complexity.tsv" >> "$F"
 
 sort -t"$(printf '\t')" -k4,4 -k1,1 -o "$F" "$F"
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -56,7 +56,7 @@ agentdb recall "<feature> <subsystem> <files/symbols> <error/outcome>" --global
 | `/kernel:forge` | Autonomous engine, heat/hammer/quench/anneal | Run overnight. Iterates until antifragile or reports why not. |
 | `/kernel:dream` | Creative exploration, 3 perspectives + stress test | When you need competing approaches before committing. |
 | `/kernel:diagnose` | Systematic debugging + refactor analysis | Bugs, regressions, or before refactoring. Diagnosis before prescription. |
-| `/kernel:simplify` | Cut cyclomatic complexity, measured by lizard, verified by re-measure | Jungle code, god functions, after any AI-written branchy function. A number, not an opinion. |
+| `/kernel:simplify` | Cut cyclomatic complexity with AST-aware budgets, regression diffs, and a project gate | Jungle code, god functions, after any AI-written branchy function. A number, not an opinion. |
 
 ## Quality & Review (kind: validator)
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -95,9 +95,13 @@ detection: grep -r "catch.*{}" (empty catch)
 </check>
 
 <check id="5_complexity">
-- Any function with cyclomatic complexity >= 15? A number, not a guess.
+- Run the configured project verify command first. If complexity is not on that armed path,
+  report the enforcement gap; a manual measurement is not a gate.
+- Any function above its `.ccnrc` budget? A number, not a guess.
+- If a baseline exists, does the diff say `regressed=0`?
+- For JS/TS, did stderr name `eslint AST`? Lizard's fallback does not see object-literal methods.
 - Nested ternaries > 2 levels?
-detection: ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo> <base-ref>  (exit 1 = hotspots listed, exit 3 = no tool, say so)
+detection: ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo> <base-ref>; ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh --diff <baseline.tsv> <repo>
 fix: /kernel:simplify on the listed functions
 </check>
 </big5>
@@ -188,6 +192,11 @@ A finding blocks only with ALL of:
 
 Everything else is filed with its `distance:N` label under the `quarantine` milestone. Recurrence
 is signal, silence is a verdict.
+
+Complexity clears the block bar only when changed code exceeds a declared budget, a regression
+diff names the increase, or the acceptance record requires the project gate and that armed path
+does not run it. A lizard result over JS/TS object-literal methods cannot support APPROVE or FAIL;
+it is `NOT CHECKED` until an AST-aware parser runs.
 </block_bar>
 
 Read the acceptance record before reviewing: claims, declared invariants, and tradeoffs already

--- a/skills/simplify/SKILL.md
+++ b/skills/simplify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simplify
-description: "Lower cyclomatic complexity: lizard measures, a verifier re-measures. Triggers: simplify, refactor, complexity, spaghetti."
+description: "Lower cyclomatic complexity with AST-aware measurement, per-function budgets, regression diffs, and a project gate. Triggers: simplify, refactor, complexity, spaghetti."
 user-invocable: true
 allowed-tools: Agent, Bash, Read, Edit, Grep, Glob
 kernel:
@@ -13,13 +13,12 @@ kernel:
 <skill id="simplify">
 
 <purpose>
-AI-written code works but branches like a jungle. This skill forces one measurement the model
-cannot skip (cyclomatic complexity per function, from a tool) and names the one way it will
-cheat (hiding branches in dense one-liners). Prose about "cleaner code" is not accepted; the
-number is.
+AI-written code works but branches like a jungle. This skill forces a measured per-function
+number, records its movement, and installs the same check in the project's normal verification.
+Prose about "cleaner code" is not accepted.
 
-Adapted from saurabhkumar8112/cyclomatic-complexity-skill (Apache-2.0), with one change:
-the refactoring model never signs its own before/after table. A verifier re-measures.
+Adapted from saurabhkumar8112/cyclomatic-complexity-skill (Apache-2.0). The refactoring model
+never signs its own result; a verifier re-measures and runs the armed project gate.
 </purpose>
 
 <on_start>
@@ -28,16 +27,40 @@ agentdb recall "simplify complexity <files/symbols>" --global
 
 <measure>
 ```bash
-# whole repo, worst first (TSV: file, line, function, ccn, nloc)
+# violations, worst first (TSV: file, line, function, ccn, nloc)
 ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo-dir>
 # only what this branch changed
 ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo-dir> <base-ref>
+# complete snapshot + before/current diff
+${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh --all <repo-dir> > before.tsv
+${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh --diff before.tsv <repo-dir>
+# CI ratchet: baseline contains only current over-budget debt
+${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh --check-baseline .complexity-baseline.tsv <repo-dir>
 ```
-The project's own linter config wins. If eslint `complexity`, radon, sonar, or golangci
-sets a threshold, pass it: `CCN_MAX=<n> scripts/complexity.sh ...`. No config: default 15.
 
-Exit 3 means no lizard and no uvx. Say so and count by hand (decision points + 1:
-`if`, `elif`, `case`, loops, `catch`, ternary, `&&`/`||` in conditions). Never skip silently.
+JS/TS uses the project's installed ESLint and parser, so object-literal methods are real
+functions. Lizard is the fallback for other languages. Its JS/TS fallback is NOT AST-complete:
+it can attribute hundreds of lines to the preceding function and never enter methods inside a
+returned object literal. The command names this fallback on stderr. Never treat it as proof for
+that pattern: install/configure ESLint, or explicitly skip the file with a reason.
+
+Project config is `.ccnrc` JSON:
+
+```json
+{
+  "version": 1,
+  "default": 15,
+  "budgets": { "src/machine.ts:transition": 20 },
+  "skip": { "src/legacy-repo.ts:*": "lizard cannot enter createLegacyRepo's returned methods" }
+}
+```
+
+Selectors are `repo-relative-file:function` globs. `--skip 'selector=reason'` is the one-run
+equivalent. A skip without a reason is invalid. Budgets are declared design constraints, not a
+way to bless today's number: name why the function earns the higher ceiling in the config diff.
+
+Exit 2 means invalid config or analyzer failure. Exit 3 means no analyzer. Either blocks
+verification. Never replace an unavailable parser with an unlabelled hand count.
 
 Ladder (default, project config outranks it):
 - 1 to 5: leave alone
@@ -50,9 +73,17 @@ Ladder (default, project config outranks it):
 1. Measure. Print the table before touching anything. Rank by CCN descending.
 2. Confirm tests exist and pass. None: say so, refactor conservatively, propose one test per
    extracted function.
-3. Refactor worst first, one function at a time, commit each working state.
-4. Re-measure the same command. Print before/after.
-5. Hand off to the verifier (below). Its re-measure is the record, not yours.
+3. Save `--all` output as the before baseline. Refactor worst first, one function at a time.
+4. Re-measure with `--diff before.tsv`. Any `regressed` row is unresolved.
+5. Wire the project-owned gate before handoff:
+   - add a `complexity` script/check using the project's checked-in runner or native analyzer;
+   - seed `.complexity-baseline.tsv` with current over-budget rows only; the CI ratchet
+     grandfathers those exact values, rejects increases/new violations, and requires a refreshed
+     baseline after reductions or removals;
+   - include it in `npm run verify`, Make/just verify, or the existing pre-commit gate;
+   - run that exact parent command red against a seeded over-budget fixture, then green;
+   - never point CI at a developer's plugin-cache path.
+6. Hand off to the verifier. Its fresh diff and armed-gate run are the record.
 </workflow>
 
 <tactics order="preference">
@@ -72,6 +103,9 @@ Ladder (default, project config outranks it):
 - Do not change public APIs or exported signatures without asking.
 - One responsibility per function. If the name needs "and", split again.
 - Small functions with clear names beat few functions with section comments.
+- No optional finish: a manual complexity command without project verify/pre-commit wiring is incomplete.
+- Never introduce the gate red on the existing default branch. Snapshot current debt, declare narrow
+  budgets with reasons, then tighten them as functions improve.
 </hard_rules>
 
 <verify>
@@ -79,10 +113,10 @@ Spawn a verifier that never saw this session's reasoning. It receives: the diff,
 table, the claimed after table, the test command, and this contract:
 
 ```
-ACCEPTANCE: every function in the before table is at or under the after value claimed
-ACCEPT WHEN: complexity.sh re-run matches the claimed after table; tests pass; no exported signature changed
-CHECK: ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh <repo> <base-ref>; <test command>; git diff <base-ref> -- <files> | grep -E '^[-+](def |export |func |pub fn )'
-ESCALATE IF: any function's re-measured CCN exceeds the claim, or a one-liner replaced a branch without a name
+ACCEPTANCE: no measured function regresses; budgets hold; the project's normal verify path runs the gate
+ACCEPT WHEN: fresh --diff says regressed=0; project verify passes; seeded over-budget fixture makes it fail; no exported signature changed
+CHECK: ${CLAUDE_PLUGIN_ROOT}/scripts/complexity.sh --diff <before.tsv> <repo>; <project verify command>; <seeded failure probe>; git diff <base-ref> -- <files> | grep -E '^[-+](def |export |func |pub fn )'
+ESCALATE IF: AST-aware JS/TS parsing is unavailable for object-literal methods, any row regresses, a skip lacks a concrete parser limitation, or a one-liner replaced a branch without a name
 DISCOVERY AXIS: invariant
 ```
 Builder and verifier identities go on the receipt. The builder never fills in "behavior verified".
@@ -92,13 +126,10 @@ Builder and verifier identities go on the receipt. The builder never fills in "b
 End with, and nothing after it:
 ```
 ## Complexity report
-| Function | Before | After |
-|----------|--------|-------|
-| parse_order | 14 | 4 |
-
-Extracted: validate_header, resolve_discount
-Tests: <command> <pass/fail before> -> <pass/fail after>
-Verified by: <verifier identity> (re-measured: match | mismatch)
+Reduced: N · unchanged: N · regressed: 0 · removed: N
+Budgets: <config path>; exceptions: <none | selectors + reasons>
+Gate: <project verify command> (seeded red -> clean green)
+Verified by: <verifier identity>
 ```
 Keep prose minimal. Numbers and diffs do the talking.
 </output>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5481,6 +5481,167 @@ sys.exit(0)
 PY
 }
 
+# === Complexity gate tests ===
+
+make_fake_eslint_complexity_project() {
+  mkdir -p "$TEST_PROJECT/node_modules/.bin"
+  cat > "$TEST_PROJECT/eslint.config.mjs" <<'EOF'
+export default [];
+EOF
+  cat > "$TEST_PROJECT/sample.ts" <<'EOF'
+export const createKnowledgeRepo = () => ({
+  transition(value: number) {
+    if (value > 0) return value;
+    return 0;
+  },
+});
+EOF
+  cat > "$TEST_PROJECT/node_modules/.bin/eslint" <<'EOF'
+#!/bin/bash
+python3 - <<'PY'
+import json, os
+root = os.getcwd()
+if os.environ.get("FAKE_ESLINT_FATAL"):
+    messages = [{"fatal": True, "line": 1, "message": "Parsing error: Unexpected token ;"}]
+elif os.environ.get("FAKE_ESLINT_DUPLICATES"):
+    messages = [
+      {"ruleId": "complexity", "line": 2, "message": "Method 'run' has a complexity of 11. Maximum allowed is 0."},
+      {"ruleId": "complexity", "line": 3, "message": "Method 'run' has a complexity of 1. Maximum allowed is 0."},
+    ]
+else:
+    messages = [
+      {"ruleId": "complexity", "line": 1, "message": "Arrow function has a complexity of 1. Maximum allowed is 0."},
+      {"ruleId": "complexity", "line": 2, "message": "Method 'transition' has a complexity of 18. Maximum allowed is 0."},
+    ]
+print(json.dumps([{"filePath": root + "/sample.ts", "messages": messages}]))
+PY
+exit 1
+EOF
+  chmod +x "$TEST_PROJECT/node_modules/.bin/eslint"
+}
+
+test_complexity_uses_ast_object_methods() {
+  make_fake_eslint_complexity_project
+  local output
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" --all "$TEST_PROJECT" 2>&1) || return 1
+  assert_contains "$output" "complexity engine: eslint AST" || return 1
+  assert_contains "$output" $'sample.ts\t2\ttransition\t18\t0'
+}
+
+test_complexity_respects_function_budget() {
+  make_fake_eslint_complexity_project
+  cat > "$TEST_PROJECT/.ccnrc" <<'EOF'
+{"version":1,"default":15,"budgets":{"sample.ts:transition":20},"skip":{}}
+EOF
+  local output rc=0
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 0 "$rc" "declared 20 budget should admit CCN 18" || return 1
+  if printf '%s\n' "$output" | grep -q $'sample.ts\t2\ttransition'; then
+    echo "  FAIL: budgeted function was reported as a violation"
+    return 1
+  fi
+}
+
+test_complexity_requires_skip_reason() {
+  make_fake_eslint_complexity_project
+  local output rc=0
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" --skip 'sample.ts:transition' "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 2 "$rc" "unreasoned skip must be invalid" || return 1
+  assert_contains "$output" "SELECTOR=REASON"
+}
+
+test_complexity_diff_reports_regressions() {
+  make_fake_eslint_complexity_project
+  cat > "$TEST_PROJECT/before.tsv" <<'EOF'
+sample.ts	1	createKnowledgeRepo	1	0
+sample.ts	2	transition	17	0
+EOF
+  local output rc=0
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" --diff "$TEST_PROJECT/before.tsv" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 1 "$rc" "CCN 17 to 18 must fail the diff" || return 1
+  assert_contains "$output" $'SUMMARY\treduced=0\tunchanged=1\tregressed=1\tremoved=0'
+}
+
+test_complexity_diff_reports_reductions() {
+  make_fake_eslint_complexity_project
+  cat > "$TEST_PROJECT/.ccnrc" <<'EOF'
+{"version":1,"default":20,"budgets":{},"skip":{}}
+EOF
+  cat > "$TEST_PROJECT/before.tsv" <<'EOF'
+sample.ts	1	createKnowledgeRepo	1	0
+sample.ts	2	transition	20	0
+EOF
+  local output rc=0
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" --diff "$TEST_PROJECT/before.tsv" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 0 "$rc" "CCN 20 to 18 should pass the diff" || return 1
+  assert_contains "$output" $'SUMMARY\treduced=1\tunchanged=1\tregressed=0\tremoved=0'
+}
+
+test_complexity_baseline_ratchets_debt() {
+  make_fake_eslint_complexity_project
+  cat > "$TEST_PROJECT/baseline.tsv" <<'EOF'
+sample.ts	2	transition	18	0
+EOF
+  local output rc=0
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" --check-baseline "$TEST_PROJECT/baseline.tsv" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 0 "$rc" "unchanged debt should pass the baseline gate" || return 1
+  assert_contains "$output" $'SUMMARY\treduced=0\tunchanged=1\tregressed=0\tremoved=0\tadded=0' || return 1
+  cat > "$TEST_PROJECT/baseline.tsv" <<'EOF'
+sample.ts	2	transition	17	0
+EOF
+  rc=0
+  output=$("$PLUGIN_ROOT/scripts/complexity.sh" --check-baseline "$TEST_PROJECT/baseline.tsv" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 1 "$rc" "a baseline increase must fail" || return 1
+  assert_contains "$output" "regressed=1"
+}
+
+test_complexity_blocks_eslint_parser_failure() {
+  make_fake_eslint_complexity_project
+  local output rc=0
+  output=$(FAKE_ESLINT_FATAL=1 "$PLUGIN_ROOT/scripts/complexity.sh" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 2 "$rc" "fatal parser error must block" || return 1
+  assert_contains "$output" "eslint could not parse"
+}
+
+test_complexity_diff_keeps_duplicate_functions_distinct() {
+  make_fake_eslint_complexity_project
+  cat > "$TEST_PROJECT/.ccnrc" <<'EOF'
+{"version":1,"default":20,"budgets":{},"skip":{}}
+EOF
+  cat > "$TEST_PROJECT/before.tsv" <<'EOF'
+sample.ts	2	run	10	0
+sample.ts	3	run	1	0
+EOF
+  local output rc=0
+  output=$(FAKE_ESLINT_DUPLICATES=1 "$PLUGIN_ROOT/scripts/complexity.sh" --diff "$TEST_PROJECT/before.tsv" "$TEST_PROJECT" 2>&1) || rc=$?
+  assert_exit_code 1 "$rc" "first same-named function regression must not collide with second" || return 1
+  assert_contains "$output" $'SUMMARY\treduced=0\tunchanged=1\tregressed=1\tremoved=0'
+}
+
+test_complexity_runs_through_npm_verify() {
+  make_fake_eslint_complexity_project
+  cat > "$TEST_PROJECT/baseline.tsv" <<'EOF'
+sample.ts	2	transition	18	0
+EOF
+  cat > "$TEST_PROJECT/package.json" <<EOF
+{"scripts":{"complexity":"python3 $PLUGIN_ROOT/scripts/complexity.py --check-baseline baseline.tsv .","verify":"npm run complexity"}}
+EOF
+  npm run verify >/dev/null 2>&1 || { echo "  FAIL: clean npm verify gate should pass"; return 1; }
+  cat > "$TEST_PROJECT/baseline.tsv" <<'EOF'
+sample.ts	2	transition	17	0
+EOF
+  local rc=0
+  npm run verify >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || { echo "  FAIL: seeded regression passed npm run verify"; return 1; }
+}
+
+test_complexity_skills_require_armed_gate() {
+  grep -q 'npm run verify' "$PLUGIN_ROOT/skills/simplify/SKILL.md" || { echo "  FAIL: simplify does not name npm verify"; return 1; }
+  grep -q 'seeded over-budget fixture' "$PLUGIN_ROOT/skills/simplify/SKILL.md" || { echo "  FAIL: simplify does not seed-test the gate"; return 1; }
+  grep -q 'manual measurement is not a gate' "$PLUGIN_ROOT/skills/review/SKILL.md" || { echo "  FAIL: review accepts manual-only complexity"; return 1; }
+  grep -q 'eslint AST' "$PLUGIN_ROOT/skills/review/SKILL.md" || { echo "  FAIL: review does not require AST-aware JS/TS"; return 1; }
+}
+
 run_test_suite() {
 
   local suite="$1"
@@ -5683,6 +5844,18 @@ run_test_suite() {
       run_test "ingest has research step" test_ingest_command_has_research_step
       run_test "forge has loop control" test_forge_command_has_loop
       run_test "commands use structured format" test_commands_use_structured_format
+      ;;
+    complexity)
+      run_test "complexity sees object-literal methods" test_complexity_uses_ast_object_methods
+      run_test "complexity respects function budgets" test_complexity_respects_function_budget
+      run_test "complexity rejects unreasoned skips" test_complexity_requires_skip_reason
+      run_test "complexity diff reports regressions" test_complexity_diff_reports_regressions
+      run_test "complexity diff reports reductions" test_complexity_diff_reports_reductions
+      run_test "complexity baseline ratchets debt" test_complexity_baseline_ratchets_debt
+      run_test "complexity blocks parser failures" test_complexity_blocks_eslint_parser_failure
+      run_test "complexity keeps duplicate functions distinct" test_complexity_diff_keeps_duplicate_functions_distinct
+      run_test "complexity runs through npm verify" test_complexity_runs_through_npm_verify
+      run_test "complexity skills require armed gate" test_complexity_skills_require_armed_gate
       ;;
     tokens)
       run_test "CLAUDE.md token budget" test_claude_md_token_budget
@@ -6109,6 +6282,7 @@ main() {
     run_test_suite "security"
     run_test_suite "observe"
     run_test_suite "verify"
+    run_test_suite "complexity"
     run_test_suite "tokens"
     run_test_suite "portable"
     run_test_suite "security_hooks"


### PR DESCRIPTION
🔧 ready to review

Complexity gates now see TypeScript object methods, honor explicit budgets, and fail regressions.

| Change | Consequence |
|---|---|
| ESLint AST plus lizard fallback | Returned object methods are measured; blind fallback is disclosed |
| `.ccnrc` budgets and reasoned skips | State machines get honest limits without gaming |
| Baseline diff and verify wiring | Reduced, unchanged, regressed counts become enforceable |

Checks: complexity 10/10; tokens 8/8; kernel9 1/1; independent verifier PASS.

<details><summary>Known unrelated suite red</summary>

Full suite: 506 pass, 1 existing portable-path failure caused by the test writing real `~/Vaults` while `~/Documents/Vaults` already exists.
</details>