### PR TITLE
Route requests to skills, not just to packs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Safety guardrails, cross-host hooks, and agentdb memory for Claude Code and Codex in auto mode",
-      "version": "9.7.0"
+      "version": "9.8.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. Hook context is shaped for both hosts' plain and structured output parsers. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. Hook context is shaped for both hosts' plain and structured output parsers. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 7f56f65580f79f672e255e493f4363952f6af9e04bdd6477425134c2a0564fc8; adapter: codex -->
-<kernel version="9.7.0">
+<kernel version="9.8.0">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ Nothing connected the two.
   denominator. This writes one.
 
 ### Changed
+- Skill suggestion requires corroboration when the domain classification was a guess. With no
+  domain signal the router returns `software` at 0.30 confidence, and treating that guess as a
+  filter let one regex hitting an everyday word decide: an adversarial pass got "let's checkpoint
+  here and pick this up tomorrow at the gym" to suggest `app-dev`, because `gym` is a fastlane
+  lane. Unanchored, the floor rises from 3 to 5, which given a weight cap of 3 is the smallest
+  value no single signal can clear. Refusing outright was tried first and silenced 11 of the 24
+  probes; plenty of real requests name no domain.
+- The domain filter now applies only when the domain was observed. A guessed domain excluding a
+  skill is the same error as a guessed domain admitting one.
+- `app-dev` no longer matches the bare words `gym`, `deliver` or `supply`. They are fastlane lane
+  names and also ordinary English.
 - Skill selection no longer rests on 29 frontmatter trigger lists that collide. `build` and
   `ingest` both claimed "build", "implement" and "create" verbatim; `context-mgmt` claimed the
   word "handoff"; `review`, `quality` and `tearitapart` all claimed "review". Weighted evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.8.0] - 2026-09-01
+
+The router announced a pack 8,578 times while 12 of 26 skills had never been invoked once.
+Nothing connected the two.
+
+### Added
+- `orchestration/router/skill_signals.py`: 114 weighted signals mapping prompt evidence to all
+  29 skills, in the same shape as `DOMAIN_SIGNALS`. Plain tuples, no imports, standalone
+  testable.
+- `classify_skills()` in the router, and a `skills` field on the classification. A confident
+  skill match now sets `announced`, so ordinary direct requests get a suggestion too; previously
+  only gated or protected work was ever announced, which is the work least in need of a pointer.
+- `route-request.sh` prints one line naming the skill and the evidence, two at a genuine tie,
+  and nothing at all below the strong-signal floor.
+- `tests/kernel9/test_skill_routing.py`: a skill with no routing evidence fails the build, and
+  so does a routing entry for a skill that does not exist. Verified by seeding both defects and
+  confirming each is caught, not by trusting the assertion.
+- `CANONICAL_PROBES`: one realistic prompt per auto-invocable skill, asserted to reach that
+  skill. Coverage is cheap to fake -- a table can key all 29 skills and still reach none of them
+  if its regexes only match phrasings nobody uses, which is exactly how the frontmatter trigger
+  lists failed. The probes caught five skills (architecture, build, frontend, help,
+  retrospective) that were keyed but unreachable in the first draft of the table.
+- `NEVER_SUGGEST`: the five skills whose frontmatter sets `disable-model-invocation: true`
+  (forge, experiment, governance-sync, init, landing-page). Suggesting one is advice nobody in
+  the room can take. Held as data so the router does not stat five files per prompt, and
+  asserted against the actual frontmatter by test so it cannot drift.
+- `scripts/skill-adoption.py`: joins suggestions against invocations to print an adoption rate
+  per skill. The audit could measure that skills went unused but not whether a fix worked,
+  because only invocations were recorded and an ignored suggestion left no trace. There was no
+  denominator. This writes one.
+
+### Changed
+- Skill selection no longer rests on 29 frontmatter trigger lists that collide. `build` and
+  `ingest` both claimed "build", "implement" and "create" verbatim; `context-mgmt` claimed the
+  word "handoff"; `review`, `quality` and `tearitapart` all claimed "review". Weighted evidence
+  separates them and a shared bare noun cannot. All seven collision clusters are covered by a
+  test asserting the intended skill wins on a realistic prompt.
+
+### Fixed
+- Stopped tracking per-session runtime state: seven `_meta/.guard-state/` files, `.session_id`
+  and `.compact-keyterms`, one set per session that happened to run.
+
+Skill routing fails open. A missing or broken skill table cannot take domain, shape or safety
+down with it: those three decide how work is done, a skill suggestion only decides what gets
+read first. The degraded path is asserted by test rather than left to the try/except.
+
 ## [9.7.1] - 2026-09-01
 
 Complexity is a project gate, not a table the builder can omit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 7f56f65580f79f672e255e493f4363952f6af9e04bdd6477425134c2a0564fc8; adapter: claude -->
-<kernel version="9.7.0">
+<kernel version="9.8.0">
 
 
 <!-- ============================================ -->

--- a/_meta/chronicles/2026/2026-09-01-route-to-skills.md
+++ b/_meta/chronicles/2026/2026-09-01-route-to-skills.md
@@ -1,0 +1,85 @@
+---
+type: note
+status: active
+created: 2026-09-01
+tier: 2
+---
+
+# Routing to skills, after an audit found 12 of 26 had never been invoked
+
+## What was attempted
+
+A usage audit over 9,642 Claude sessions, 1,180 Codex sessions and 90 agentdb files found:
+
+- 12 of 26 skills had never been invoked once, by a human or by the model.
+- 5 skill invocations in the entire history of the machine were typed by a person.
+- The router, meanwhile, announced a domain pack 8,578 times.
+
+The mechanism that works was never wired to the library that does not. Aria's instruction was
+explicit: do not delete any skill, make all of them properly used.
+
+## What actually changed
+
+- `orchestration/router/skill_signals.py`: 114 weighted signals covering all 29 skills, same
+  shape as the existing `DOMAIN_SIGNALS`. Plain tuples, zero imports, standalone testable.
+- `classify_skills()` in `kernel_router.py`, a `skills` field on the classification, and a
+  confident skill match now sets `announced`. Without that last part, suggestions would only
+  ever reach gated or protected work, which is the work least in need of a pointer.
+- `route-request.sh` prints one imperative line naming the skill and the evidence.
+- `tests/kernel9/test_skill_routing.py`: coverage, reachability, disambiguation, fail-open, and
+  a never-suggest set checked against the actual frontmatter.
+- `scripts/skill-adoption.py`: joins suggestions against invocations to produce an adoption rate.
+
+## Verified live
+
+- Full suite: 509 passed, 1 failed. The failure (`detect_vaults finds primary`, expecting
+  `~/Vaults`) reproduces on stashed pre-change code, so it predates this work.
+- `python3 -m unittest discover -s tests/kernel9` -> 144 tests, OK.
+- End-to-end through the real hook: a crash report reaches `debug`, a plan critique reaches
+  `tearitapart`, "what is the weather" reaches nothing.
+- **Both gates broken on purpose and confirmed to catch it**, per the runtime's rule 4:
+  removing `metrics` from the table failed the coverage test; blanking the `retrospective`
+  regexes failed the reachability test with the exact prompt that stopped working.
+
+## What failed
+
+**Coverage is not reachability, and I nearly shipped the difference.** The first table keyed all
+29 skills and passed every coverage assertion. Five skills (architecture, build, frontend, help,
+retrospective) were still unreachable, because the regexes only matched phrasings nobody uses.
+`help` wanted "what skills exist" and missed "what skills are available". That is the same
+failure as the frontmatter `Triggers:` lists it was replacing, reproduced one layer down.
+
+The fix is `CANONICAL_PROBES`: each skill declares one prompt phrased the way a person actually
+asks, and a test proves that prompt reaches it. A coverage test is cheap to satisfy by adding a
+key. A probe is not.
+
+**I also called two skills unreachable that were correctly excluded.** `landing-page` and
+`marketing-site` looked broken until I checked the frontmatter: five skills set
+`disable-model-invocation: true`, so the model may not invoke them and suggesting one is advice
+nobody in the room can take. I had hardcoded that set as `{"forge"}` from a subagent's note
+rather than reading the five files. Now derived as data and asserted against the frontmatter.
+
+**A `git stash` during a test run was nearly a real loss.** I stashed to check whether a failing
+test predated my change; the command hit its two-minute timeout and was killed before
+`git stash pop` ran. Every tracked edit sat in a stash while the working tree looked half-done.
+Recovered intact, but the runtime's own warning about stashing exists for exactly this, and the
+correct move was `git worktree`-free: read the test, or run it on a copy.
+
+## Deferred
+
+- Three kernel-claude branches (`fix/226-stale-r6-and-noise`,
+  `fix/guard-precision-and-autocorrect`, `improve/retrospective-intelligence`) carry unmerged
+  commits. `git branch -D` requires Aria's approval token by design; two are on origin so
+  nothing is at risk.
+- 26 dirty submodules under `CodingVault/`, four of them live client repos under the PR-only
+  rule. Not touched; that is 26 decisions, not a cleanup.
+- The four highest-leverage audit fixes (trim `session-start.sh`, rewrite `chronicle-gate.sh`,
+  teach `guard-bash.sh` that quoting is not running) are still recommendations.
+
+## Disagreement worth inheriting
+
+The adoption rate this ships cannot yet be read as a verdict on the routing. `skill-adoption.py`
+credits a skill whose name appears in any Skill call in the same session, which biases the
+number up, and there is no pre-period to compare against because suggestions were never logged
+before today. The honest reading of the first month is "did anything move at all", not "routing
+works". Say that when the number arrives.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "KERNEL's methodology layer for Gemini CLI: 27 software-engineering agent skills plus llms.txt as ambient context. Skills cover systematic debugging (reproduce, isolate, regression-test), generating competing approaches before implementing, pre-implementation critique, code review, bounded context handoff and resume, multi-agent orchestration, eval-driven development, release gating, and context-led frontend design. Gemini CLI gets the methodology only. KERNEL's enforcement layer does not run here: the PreToolUse hooks that block destructive commands and secret writes, the one-time human approval token for irreversible operations, and the agentdb SQLite memory recalled at session start are Claude Code and Codex only. `gemini extensions install` fetches a curated release bundle that carries just this manifest, llms.txt, and skills/, so no Claude-format hook or agent definition is loaded. Source, safety limits, and the host capability matrix: https://github.com/ariaxhan/kernel-claude",
   "contextFileName": "llms.txt"
 }

--- a/hooks/scripts/route-request.sh
+++ b/hooks/scripts/route-request.sh
@@ -158,6 +158,44 @@ printf 'Shape: %s | safety: %s | domain: %s\n' "$SHAPE" "$SAFETY" "$DOMAIN"
 printf 'Evidence: %s\n' "$REASON"
 printf 'Load only %s/packs/%s/PACK.md for domain-specific method.\n' "$PLUGIN_ROOT" "$DOMAIN"
 
+# The skill line. One line, two at a genuine tie, and nothing at all when no
+# skill scored above the strong-signal floor -- silence is the common case and
+# the correct one. See classify_skills() in kernel_router.py for why this exists:
+# the router announced a pack 8,578 times while 12 of 26 skills had never been
+# invoked once, because nothing connected the two.
+# Imperative, matching the pack line above it. "Skill for this request:" is a
+# noun phrase, and a noun phrase next to "Load only ..." reads as trivia rather
+# than as routing. The audit's whole finding was that skills get ignored.
+SKILLS=$(printf '%s' "$CLASSIFICATION" | jq -r '
+  (.skills // []) | .[] | "  /kernel:\(.name) (\(.reasons[0] // "matches this request"))"
+' 2>/dev/null || true)
+SKILL_COUNT=$(printf '%s' "$CLASSIFICATION" | jq -r '(.skills // []) | length' 2>/dev/null || echo 0)
+if [ -n "$SKILLS" ]; then
+  if [ "$SKILL_COUNT" -gt 1 ]; then
+    printf 'Invoke the skill that fits; these two tied on evidence:\n%s\n' "$SKILLS"
+  else
+    printf 'Invoke this skill for the request:\n%s\n' "$SKILLS"
+  fi
+
+  # Adoption receipt. The audit could measure that skills were not being used,
+  # but not whether any intervention fixed it, because nothing recorded what was
+  # SUGGESTED -- only what was invoked. One suggestion without its counterfactual
+  # is not a measurement. This line is the counterfactual: joined against the
+  # Skill tool calls in the session transcript it yields an adoption rate, which
+  # is the only honest test of whether routing to skills was worth doing.
+  # Silent, best-effort, never blocks the hook.
+  SKILL_LOG="${KERNEL_SKILL_LOG:-$PLUGIN_ROOT/_meta/logs/skill-routing.jsonl}"
+  if mkdir -p "$(dirname "$SKILL_LOG")" 2>/dev/null; then
+    printf '%s' "$CLASSIFICATION" | jq -c \
+      --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg session "${SESSION_ID:-unknown}" \
+      --arg cwd "$REQUEST_CWD" \
+      '{ts:$ts, session:$session, cwd:$cwd, domain:.domain, shape:.work_shape,
+        suggested:[.skills[].name], scores:[.skills[].score]}' \
+      >> "$SKILL_LOG" 2>/dev/null || true
+  fi
+fi
+
 case "$SHAPE" in
   gated)
     printf '%s\n' \

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 > that carries lessons between sessions.
 
 Repository: https://github.com/ariaxhan/kernel-claude
-License: MIT. Version 9.7.0. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+License: MIT. Version 9.8.0. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
 
 ## What it is
 

--- a/orchestration/router/kernel_router.py
+++ b/orchestration/router/kernel_router.py
@@ -454,24 +454,64 @@ except Exception:  # pragma: no cover - absence is a valid state, not an error
 # trigger-word matching already did badly.
 SKILL_FLOOR = 3
 
+# The bar when the domain classification was a guess rather than evidence. One
+# strong signal is enough only when something else already said what kind of
+# work this is; unanchored, a single weight-3 regex hitting an ordinary English
+# word is exactly how "at the gym" reached the mobile build skill.
+#
+# 5 is not arbitrary: weights cap at 3, so this is the smallest value that makes
+# a single signal insufficient no matter how strong it is.
+SKILL_FLOOR_UNANCHORED = 5
+
 # Two skills within this distance are a genuine tie, and the honest output names
 # both rather than picking one on a one-point margin.
 SKILL_TIE = 1
 
 
-def classify_skills(text: str, domain: str | None = None):
-    """Rank skills by weighted prompt evidence. Never raises; returns []."""
+def classify_skills(text: str, domain: str | None = None, domain_confidence: float = 1.0):
+    """Rank skills by weighted prompt evidence. Never raises; returns [].
+
+    `domain_confidence` is not decoration. When no domain signal fires at all,
+    classify_domain returns DEFAULT_DOMAIN at 0.30 with the reason "no domain
+    signal detected; defaulted" -- a guess, not evidence. Using that guess as a
+    filter is worse than having no filter: it silently admits every
+    software-domain skill on a prompt that showed no sign of being about
+    software, so a stray word decides. An adversarial pass on 2026-09-01 got
+    "let's checkpoint here and pick this up tomorrow at the gym" to suggest
+    /kernel:app-dev, because `gym` is fastlane's build tool and also a place
+    people go. A confidently wrong suggestion is worse than silence, which is
+    the whole reason this has a floor at all.
+    """
     if not _SKILL_SIGNALS:
         return []
+
+    # When the domain is a guess, the domain filter is not a filter, so the
+    # evidence has to carry the whole weight. Raising the floor to 5 requires
+    # corroboration implicitly and exactly: signal weights cap at 3, so no
+    # single signal can clear it, and two must agree.
+    #
+    # Refusing outright when the domain is a guess was tried first and was too
+    # blunt: it silenced 11 of the 24 canonical probes, because plenty of
+    # legitimate requests ("save a checkpoint, we are about to hit a context
+    # reset") name no domain at all. An explicit min_signals counter was tried
+    # second and deleted as provably dead: given a cap of 3 and a floor of 5,
+    # it could never be the binding constraint.
+    anchored = domain is None or domain_confidence >= LOW_CONFIDENCE_FLOOR
+    floor = SKILL_FLOOR if anchored else SKILL_FLOOR_UNANCHORED
     scored = []
     for name, signals in _SKILL_SIGNALS.items():
         if name in SKILL_NEVER_SUGGEST:
             continue
+        # Only filter on domain when the domain was actually observed. A guessed
+        # domain excluding a skill is the same error as a guessed domain
+        # admitting one: "the modules are too coupled" carries two independent
+        # architecture signals and was being dropped because the guess landed on
+        # `design`, which architecture does not claim.
         domains = SKILL_DOMAINS.get(name) or ()
-        if domain and domains and domain not in domains:
+        if anchored and domain and domains and domain not in domains:
             continue
         total, reasons = _score(text, signals)
-        if total >= SKILL_FLOOR:
+        if total >= floor:
             scored.append((total, name, reasons))
     if not scored:
         return []
@@ -518,7 +558,7 @@ def build_classification(
         "packs": PACK_BY_DOMAIN.get(domain, [domain]),
     }
 
-    skills = classify_skills(text, domain)
+    skills = classify_skills(text, domain, d_conf)
     if skills:
         out["skills"] = skills
 

--- a/orchestration/router/kernel_router.py
+++ b/orchestration/router/kernel_router.py
@@ -418,6 +418,72 @@ DEESCALATE_DEFAULTS = {
 PROTECTED_ESCALATE = "verification cannot distinguish safe from unsafe outcome"
 
 
+# --------------------------------------------------------------------------
+# Skill routing
+# --------------------------------------------------------------------------
+#
+# WHY (2026-09-01 usage audit): across 9,642 Claude sessions and 1,180 Codex
+# sessions, 12 of 26 skills had never been invoked once and only 5 invocations
+# in all of history were typed by a human. Meanwhile this router announced a
+# domain pack 8,578 times. The routing mechanism worked; nothing connected it
+# to the skill library, which was left to the model matching 29 frontmatter
+# trigger lists that collide (build and ingest both claim "build/implement/
+# create"; context-mgmt claims the word "handoff"; review, quality and
+# tearitapart all claim "review"). Weighted evidence separates them; a shared
+# bare noun cannot.
+#
+# Fails OPEN by design. A missing or broken skill table must never take the
+# domain/shape/safety classification down with it: those three decide how work
+# is done, a skill suggestion only decides what gets read first.
+try:
+    from skill_signals import NEVER_SUGGEST, SKILL_DOMAINS, SKILL_SIGNALS
+
+    _SKILL_SIGNALS = {
+        name: [_sig(p, w, r) for p, w, r in sigs]
+        for name, sigs in SKILL_SIGNALS.items()
+    }
+    SKILL_NEVER_SUGGEST = set(NEVER_SUGGEST)
+except Exception:  # pragma: no cover - absence is a valid state, not an error
+    _SKILL_SIGNALS = {}
+    SKILL_DOMAINS = {}
+    SKILL_NEVER_SUGGEST = set()
+
+# A skill is worth a line only when the prompt carries at least one strong
+# signal for it. Weight 3 means "this phrasing all but names the skill", so 3 is
+# the floor: below it we would be guessing out loud, which is what the old
+# trigger-word matching already did badly.
+SKILL_FLOOR = 3
+
+# Two skills within this distance are a genuine tie, and the honest output names
+# both rather than picking one on a one-point margin.
+SKILL_TIE = 1
+
+
+def classify_skills(text: str, domain: str | None = None):
+    """Rank skills by weighted prompt evidence. Never raises; returns []."""
+    if not _SKILL_SIGNALS:
+        return []
+    scored = []
+    for name, signals in _SKILL_SIGNALS.items():
+        if name in SKILL_NEVER_SUGGEST:
+            continue
+        domains = SKILL_DOMAINS.get(name) or ()
+        if domain and domains and domain not in domains:
+            continue
+        total, reasons = _score(text, signals)
+        if total >= SKILL_FLOOR:
+            scored.append((total, name, reasons))
+    if not scored:
+        return []
+    scored.sort(key=lambda row: (-row[0], row[1]))
+    top = scored[0][0]
+    return [
+        {"name": name, "score": total, "reasons": reasons[:2]}
+        for total, name, reasons in scored
+        if top - total <= SKILL_TIE
+    ][:2]
+
+
 def build_classification(
     text: str,
     domain_hint=None,
@@ -451,6 +517,10 @@ def build_classification(
         "reasons": reasons,
         "packs": PACK_BY_DOMAIN.get(domain, [domain]),
     }
+
+    skills = classify_skills(text, domain)
+    if skills:
+        out["skills"] = skills
 
     if shape in ESCALATE_DEFAULTS:
         esc = list(ESCALATE_DEFAULTS[shape])
@@ -487,10 +557,16 @@ def build_classification(
     # "writing" changes nothing about how it gets done, so it is not worth a
     # sentence. Being unsure about shape or safety does change what happens, and
     # is surfaced.
+    # A confident skill match is a material behaviour change by the same test the
+    # other three clauses apply: it changes what the agent reads before acting.
+    # Without this, skill suggestions would only ever reach gated or protected
+    # work, and the ordinary direct request -- which is most of them, and the
+    # place a skill helps most -- would keep getting none.
     out["announced"] = bool(
         shape != "direct"
         or safety == "protected"
         or min(s_conf, f_conf) < LOW_CONFIDENCE_FLOOR
+        or skills
     )
 
     return out

--- a/orchestration/router/skill_signals.py
+++ b/orchestration/router/skill_signals.py
@@ -1,0 +1,403 @@
+"""KERNEL skill-level routing signals.
+
+Same shape as DOMAIN_SIGNALS in kernel_router.py, one layer down: skill instead of
+domain. Plain tuples (raw regex string, int weight 1-3, reason string) -- no _sig()
+calls, no imports -- so this file is standalone-testable and standalone-lintable.
+The router wires these in; this file does not import kernel_router.
+
+Weight scale (same as DOMAIN_SIGNALS): 3 = phrasing all but names the skill,
+2 = strong corroboration, 1 = weak corroboration.
+
+SKILL_DOMAINS maps each skill to the router domain(s) it is plausible under, so the
+router can gate skill suggestion on domain match before spending regex cycles.
+"""
+
+from __future__ import annotations
+
+SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
+
+    # -- app-dev vs ship (both claim "deploy") -----------------------------
+    # app-dev owns MOBILE build/store surfaces (fastlane, expo, native store
+    # submission); ship owns the git/PR release-gate sequence for any repo.
+    # Disambiguator: app-dev requires a mobile/build-tool noun; ship requires a
+    # git/PR/branch noun. "deploy" alone (no mobile noun) falls to ship or
+    # marketing-site/landing-page depending on other signals.
+    "app-dev": [
+        (r"\b(testflight|app store|play store|store submission)\b", 3, "names a mobile store submission"),
+        (r"\b(fastlane|gym|gradle|deliver|supply)\b", 3, "names the mobile build toolchain"),
+        (r"\b(expo|react native|flutter|swift ?ui|android studio|xcode)\b", 3, "names a mobile app framework"),
+        (r"\b(build|deploy) (the )?(ios|android|mobile) app\b", 3, "asks to build or deploy a mobile app"),
+        (r"\bpre-?submission checklist\b", 2, "asks for a store submission checklist"),
+    ],
+
+    "architecture": [
+        # vs simplify/diagnose (rule 3 cluster 7): architecture is about
+        # module boundaries and dependency direction as a design question,
+        # not a defect to fix (diagnose) or a complexity number to lower
+        # (simplify).
+        (r"\b(system|module|service) (architecture|design|boundar\w+)\b", 3, "names a structural design question"),
+        (r"\b(coupling|cohesion|dependency (graph|direction|management))\b", 3, "names a dependency-structure concern"),
+        (r"\btoo (tightly )?coupled\b", 3, "reports excessive coupling"),
+        (r"\b(interface|module|service) boundar\w+\b", 3, "asks where the boundaries belong"),
+        (r"\b(interface stability|api surface|layering|separation of concerns)\b", 2, "names an architectural property"),
+        (r"\bhow should (this|the) (system|module|service) be structured\b", 3, "asks for structural design guidance"),
+        (r"\bwhere should \w+ live\b", 2, "asks for module placement guidance"),
+    ],
+
+    "build": [
+        # vs ingest (rule 3 cluster 1): build is mid-work, exploring 2-3
+        # approaches for a scoped feature; ingest is the START-of-work entry
+        # point (scoping/triage, new or resumed task). Disambiguator: build
+        # fires on "generate approaches / pick simplest / implement the
+        # feature" phrasing; ingest fires on "start/begin/resume/new task"
+        # phrasing. Both claim bare "build/implement/create" verbs, so give
+        # build the extra weight only when an approach-exploration phrase or
+        # a named feature/endpoint noun is present, and let ingest own the
+        # bare entry-point phrasing.
+        (r"\b(generate|explore|compare) ((2|3|two|three|a few)( or (2|3|two|three))? )?approaches\b", 3, "asks for multiple candidate approaches"),
+        (r"\bimplement (a |an |the )?(feature|endpoint|module|integration)\b", 3, "names a scoped implementation deliverable"),
+        (r"\badd (a |an )?(new )?(feature|endpoint|button|page|field)\b", 2, "names a scoped feature addition"),
+        (r"\bpick the simplest\b", 2, "asks for the simplest of several approaches"),
+        (r"\bbuild (a |an |the )\w+ (feature|integration|component)\b", 2, "names a scoped build target"),
+    ],
+
+    "checkpoint": [
+        # vs handoff vs context-mgmt (rule 3 cluster 4): checkpoint is a
+        # BOUNDED resume manifest inside one long task ("save progress before
+        # I lose context"). handoff is provenance/decisions for a LATER
+        # session/person. context-mgmt is the token-management METHOD itself
+        # (compaction strategy), not a state artifact.
+        (r"\bcheckpoint\b", 3, "asks to save a checkpoint"),
+        (r"\bsave progress\b(?!.{0,20}(for later|for next session|so (he|she|they|someone) can))", 2, "asks to save progress inside the current task"),
+        (r"\b(context reset|compact(ing)? soon|about to compact)\b", 3, "names an imminent context reset needing a resume point"),
+        (r"\blong[- ]?running task\b.{0,20}\bresume\b", 2, "names a long task that needs a resume point"),
+    ],
+
+    "context-mgmt": [
+        # vs checkpoint/handoff (see above): context-mgmt is the METHOD, not
+        # an artifact. Fires on questions about the token budget or
+        # compaction mechanics, not on "save my progress" requests.
+        (r"\b(token (budget|window|limit)|context window|context engineering)\b", 3, "asks about the token/context budget itself"),
+        (r"\b(compaction|compact\w* strateg\w+|progressive disclosure)\b", 3, "names a compaction or disclosure strategy"),
+        (r"\bwhy (is|did) (the )?context (fill|degrade|blow up)\b", 3, "asks why context quality degraded"),
+        (r"\bstructured note.?taking\b", 2, "names the agentdb note-taking method"),
+    ],
+
+    "debug": [
+        # vs diagnose (rule 3 cluster 2): debug is a LIVE defect with a
+        # repro/error in hand; diagnose ADDS refactor-mode (map deps, measure
+        # coupling) and is invoked before deciding whether to even start
+        # fixing. Disambiguator: debug fires on concrete failure evidence
+        # (stack trace, crash, "broken"); diagnose fires on "should I refactor
+        # this" / dependency-mapping phrasing with no concrete failure.
+        (r"\b(stack ?trace|traceback|exception|crash(ed)?)\b", 3, "reports a concrete crash or exception"),
+        (r"\b(reproduce|repro) (the )?(bug|issue|crash|failure)\b", 3, "has a reproducible failure in hand"),
+        (r"\b(fails?|failing|broken|not working) (when|on|with|because)\b", 2, "reports a specific failure condition"),
+        (r"\bwhy (is|does) \w+ (fail|crash|throw|break)\b", 3, "asks for the root cause of a live failure"),
+        (r"\bregression test\b", 2, "asks for a regression test tied to a fix"),
+    ],
+
+    "diagnose": [
+        # vs debug (see above) and vs simplify/architecture (rule 3 cluster
+        # 7): diagnose is invoked BEFORE prescribing a fix -- either "is this
+        # actually a bug and where" (bug mode, no concrete repro yet) or
+        # "should this be refactored, what would break" (refactor mode,
+        # dependency mapping without committing to a rewrite).
+        (r"\bshould (this|we) refactor\b", 3, "asks whether a refactor is warranted, not committed to it"),
+        (r"\bmap (the )?depend\w+\b", 3, "asks for a dependency map before deciding"),
+        (r"\bwhat would break if\b", 3, "asks for blast-radius analysis before a decision"),
+        (r"\bdiagnos\w+ (the |this )?(bug|issue|problem)\b", 3, "asks for diagnosis before a fix is chosen"),
+        (r"\bis this (actually|really) a bug\b", 2, "asks whether a symptom is a real defect"),
+    ],
+
+    "dream": [
+        (r"\b(brainstorm|diverge|explore the solution space)\b", 2, "asks for divergent idea generation"),
+        (r"\bcompeting (perspectives|value systems|approaches)\b", 3, "asks for structured competing viewpoints"),
+        (r"\badversarial(ly)? stress[- ]?test\w*\b", 3, "asks for adversarial stress-testing of ideas"),
+        (r"\bwhat.?s the (boldest|most creative) (option|approach)\b", 2, "asks for a maximalist creative option"),
+    ],
+
+    "eval": [
+        (r"\b(pass@k|eval-?driven|edd)\b", 3, "names eval-driven development terminology"),
+        (r"\b(capability eval|regression eval|benchmark suite)\b", 3, "names a specific eval artifact"),
+        (r"\bwrite evals? for\b", 3, "asks for evals to be written"),
+        (r"\bhow (well|reliably) does \w+ perform\b", 2, "asks for a capability measurement"),
+    ],
+
+    "experiment": [
+        # disable-model-invocation is NOT set on experiment; still narrow it
+        # to hypothesis-testing-about-rules language so it doesn't fire on
+        # generic "test this" prompts (that's debug/build's job).
+        (r"\btreat (this |the )?rule as a hypothesis\b", 3, "asks to treat a development rule as testable"),
+        (r"\b(falsifiable test|graduate|kill) (the )?(rule|hypothesis)\b", 3, "asks to evaluate a rule via falsifiable test"),
+        (r"\bprove (this|that) (rule|methodology) (works|holds)\b", 2, "asks for evidence a rule holds"),
+    ],
+
+    "forge": [
+        # MUST NEVER be auto-suggested: disable-model-invocation: true in
+        # SKILL.md. Signals kept for completeness / future explicit-only UI,
+        # but the router must filter this key out of any auto-recommendation
+        # (Aria/caller-owned filter, per task instructions).
+        (r"\bfully autonomous\b.{0,30}\b(no human|no checkpoints)\b", 3, "asks for fully unattended iteration"),
+        (r"\biterate until (it.?s |the code is )?antifragile\b", 3, "asks for iterate-until-antifragile loop"),
+        (r"\bno human (checkpoints|review) (needed|required)\b", 2, "explicitly waives human review"),
+    ],
+
+    "frontend": [
+        (r"\b(css|styling|layout|component) (for|of) (the )?(ui|page|screen)\b", 2, "names a UI implementation surface"),
+        (r"\b(css|layout|styling)\b.{0,40}\b(breaks?|broken|overflow\w*|misaligned)\b", 3, "reports a broken visual layout"),
+        (r"\bat \d{3,4}px\b", 2, "names a viewport breakpoint"),
+        (r"\blooks? generic\b", 3, "reports generic visual defaults"),
+        (r"\b(art direction|design system|visual (theme|language)|aesthetic)\b", 3, "asks for visual/art direction"),
+        (r"\b(responsive|accessibility|a11y|keyboard nav)\b", 2, "names a frontend quality property"),
+        (r"\b(animation|motion|micro-?interaction)\b", 2, "names an interaction/motion property"),
+        (r"\bmake (this|it) (look|feel) (less generic|distinctive|intentional)\b", 3, "asks to avoid generic AI visual defaults"),
+    ],
+
+    "governance-sync": [
+        # disable-model-invocation: true. Explicit-only; narrow signals only.
+        (r"\b(sync|audit) (claude\.md|agents\.md|governance)\b", 3, "asks to audit or sync instruction files"),
+        (r"\binstruction mirror\b", 2, "names the Claude/Codex instruction mirror"),
+    ],
+
+    "handoff": [
+        # vs checkpoint/context-mgmt (see checkpoint comment). handoff is
+        # provenance + decisions + next steps for someone else / a LATER
+        # session, phrased as "before I go" / "pass this to the next agent".
+        (r"\b(handoff|hand off|hand this off)\b", 3, "asks to hand work to another session or person"),
+        (r"\bnext steps for (whoever|the next (agent|session))\b", 3, "names provenance for a future session"),
+        (r"\bpause (this )?(for now|and)\b.{0,20}\bcontinue later\b", 2, "asks to pause with a later-resume intent"),
+        (r"\bwhat decisions (did we|were) made\b", 2, "asks for a record of decisions made"),
+    ],
+
+    "help": [
+        (r"\b(kernel )?help\b", 2, "asks for kernel help"),
+        (r"\bwhat (kernel )?skills (are there|are available|do you have|exist)\b", 3, "asks for the skill inventory"),
+        (r"\b(list|show) (me )?(the )?(kernel )?(skills|commands)\b", 3, "asks to list the skills"),
+        (r"\bhow does kernel work\b", 2, "asks how the kernel system works"),
+    ],
+
+    "human-pass": [
+        (r"\b(testflight|acceptance test|before we ship|hand it to the user)\b", 3, "asks for a pre-ship human acceptance pass"),
+        (r"\bwhat should (i|we) test (by hand|manually)\b", 3, "asks for a manual test checklist"),
+        (r"\brelease checklist\b", 2, "asks for a release checklist"),
+        (r"\bdevice test\b", 2, "asks for on-device testing"),
+    ],
+
+    "ingest": [
+        # vs build (see build comment above). ingest owns the entry point:
+        # brand-new or resumed work, before scope is settled.
+        (r"^\s*(start|begin) (on |with )?(a |the )?(new )?task\b", 3, "starts a brand-new task"),
+        (r"\bresume (the|my|this) (task|work|handoff|checkpoint)\b", 3, "asks to resume prior work from a manifest"),
+        (r"\bnot sure (what|how) to (start|scope) (this )?yet\b", 2, "needs scoping before work is bounded"),
+        (r"\bcontinue (from|where)\b", 2, "asks to continue from a prior state"),
+    ],
+
+    "init": [
+        # disable-model-invocation: true. Explicit-only, once-per-machine.
+        (r"\binit(ialize)? kernel\b", 3, "asks to initialize kernel in this directory"),
+        (r"\bset up agentdb\b", 2, "asks to set up agentdb for the first time"),
+    ],
+
+    "knowledge-graph": [
+        (r"\b(knowledge graph|code graph|graphify)\b", 3, "names the code knowledge graph tool"),
+        (r"\b(god nodes?|blast radius|orientation cost)\b", 3, "names a knowledge-graph query concept"),
+        (r"\bwhat connects \w+ to \w+\b", 2, "asks for a code-relationship query"),
+        (r"\bwho calls \w+\b", 2, "asks for callers of a symbol"),
+        (r"\bmap the codebase\b", 2, "asks for a structural map of the codebase"),
+    ],
+
+    "landing-page": [
+        # vs marketing-site (rule 3 cluster 5): landing-page is the EXPLICIT
+        # build-and-DEPLOY operator (disable-model-invocation: true) for one
+        # focused page; marketing-site is the METHODOLOGY (audience, offer,
+        # proof, objections) that landing-page composes and that applies to
+        # multi-page company/product sites too. Disambiguator: landing-page
+        # fires on "build and deploy a landing page" (action + deploy
+        # target); marketing-site fires on strategy nouns (audience, offer,
+        # proof, positioning) without a deploy action.
+        (r"\bbuild (and deploy |and ship )?(a |the )?landing page\b", 3, "asks to build and deploy a landing page"),
+        (r"\bdeploy (the )?(landing page|site) to\b", 3, "names a landing-page deploy target"),
+        (r"\bscaffold (a |the )?(smallest |simple )?site\b", 2, "asks to scaffold a minimal site"),
+    ],
+
+    "marketing-site": [
+        # Widened 2026-09-01: the {0,20} window meant "positioning and value
+        # proposition for the company marketing site" fell outside its own rule,
+        # which is the normal way to phrase the request.
+        (r"\bmarketing (site|website|page)\b", 3, "names a marketing site"),
+        (r"\b(target audience|value proposition|positioning|offer)\b.{0,60}\b(site|page|website|brand|product)\b", 3, "names marketing-site strategy elements"),
+        (r"\b(social proof|testimonial|objection handling|cta)\b", 2, "names a conversion-copy element"),
+        (r"\bcompany \w*\s?(website|site)\b", 2, "names a company website"),
+        (r"\bportfolio (site|page)\b", 2, "names a portfolio site"),
+        (r"\bprivacy policy\b", 2, "asks for a site privacy policy"),
+    ],
+
+    "metrics": [
+        (r"\b(kernel )?(metrics|dashboard|observability)\b", 3, "asks for kernel telemetry"),
+        (r"\bsession stats\b", 2, "asks for session statistics"),
+        (r"\bhook performance\b", 2, "asks about hook performance"),
+        (r"\blearning health\b", 2, "asks about agentdb learning health"),
+    ],
+
+    "orchestration": [
+        (r"\b(orchestrate|coordinate) (multiple )?agents\b", 3, "asks to coordinate multiple agents"),
+        (r"\b(lane contract|worker.?model doctrine|fault toleran\w+)\b", 3, "names an orchestration mechanism"),
+        (r"\bspawn (multiple|parallel) (agents|lanes)\b", 3, "asks to spawn parallel agents"),
+        (r"\btier (2|3) (work|task)\b", 2, "names a tiered orchestration workload"),
+    ],
+
+    "quality": [
+        # vs review/tearitapart (rule 3 cluster 3): quality is the Big-5
+        # CHECKLIST (input validation, edge cases, error handling,
+        # duplication, complexity) run standalone during/after implementation
+        # -- not a PR verdict (review) and not a pre-implementation plan
+        # critique (tearitapart).
+        (r"\bbig[- ]?5\b", 3, "names the big-5 quality checklist"),
+        (r"\b(input validation|edge cases?|error handling) check\b", 2, "names a big-5 quality dimension"),
+        (r"\bcheck (this|the) code for quality\b", 3, "asks for a standalone quality check"),
+        (r"\bduplicat\w+ (code|logic)\b", 2, "names code duplication as a quality concern"),
+    ],
+
+    "retrospective": [
+        (r"\b(retrospective|retro|post-?mortem)\b", 3, "asks for a retrospective"),
+        (r"\bwhat did we learn\b", 3, "asks for extracted lessons from a finished run"),
+        (r"\b(recurring|repeated) (patterns?|failures?|mistakes?)\b", 3, "asks for recurring patterns across runs"),
+        (r"\bacross (recent |the last )?sessions\b", 2, "asks for a cross-session view"),
+        (r"\b(belief update|preserved anomal\w+|synthesi[sz]e patterns)\b", 2, "names a retrospective ledger artifact"),
+    ],
+
+    "review": [
+        # vs quality/tearitapart (see quality comment). review is a
+        # POST-HOC verdict on a PR or staged diff: APPROVE/REQUEST
+        # CHANGES/COMMENT. Requires an existing diff/PR, not a plan.
+        (r"\breview (this |the )?(pr|pull request|diff|change(s)?|staged)\b", 3, "asks for a verdict on an existing pr or diff"),
+        (r"\b(approve|request changes|comment) on (this|the) (pr|diff)\b", 3, "asks for a formal pr review verdict"),
+        (r"\bis this (pr|diff|change) mergeable\b", 2, "asks whether a concrete diff is mergeable"),
+    ],
+
+    "ship": [
+        # vs app-dev (see app-dev comment). ship is the git/PR release-gate
+        # sequence (validate -> review -> push -> tag) for any repo, not
+        # specifically mobile.
+        (r"\b(push to main|ready to merge|release-?gate)\b", 3, "asks to run the release-gate sequence"),
+        (r"\bship (this|it)\b", 2, "asks to ship the current change"),
+        (r"\btag (a |the )?release\b", 2, "asks to tag a release"),
+        (r"\bvalidate.{0,10}review.{0,10}push\b", 2, "names the ship sequence explicitly"),
+    ],
+
+    "simplify": [
+        # vs architecture/diagnose (rule 3 cluster 7): simplify is a
+        # MEASURED complexity-reduction pass (lizard/cyclomatic-complexity
+        # numbers, per-function budget) with a verifier re-measuring --
+        # narrower and more mechanical than architecture's structural
+        # judgment or diagnose's refactor-mode analysis.
+        (r"\b(cyclomatic complexity|lizard|complexity budget)\b", 3, "names a measured complexity metric"),
+        (r"\bthis (function|file) is (too )?(spaghetti|a jungle|too complex)\b", 3, "reports unmeasured complexity needing reduction"),
+        (r"\blower (the )?complexity\b", 3, "asks to reduce measured complexity"),
+        (r"\bper-?function budget\b", 2, "names the per-function complexity budget"),
+    ],
+
+    "tearitapart": [
+        # vs review/quality (see quality comment). tearitapart is PRE-
+        # implementation: critique a PLAN before code exists. Verdict:
+        # PROCEED / REVISE / RETHINK.
+        (r"\b(tear apart|critique) (this |the )?plan\b", 3, "asks for a pre-implementation plan critique"),
+        (r"\bwhat (would|will) (ai|this) break\b", 2, "asks what an approach will break before building"),
+        (r"\bproceed, revise,? or rethink\b", 3, "asks for the tearitapart verdict scale explicitly"),
+        (r"\bbefore (i|we) (start|implement) this,? (review|critique)\b", 3, "asks for critique before implementation starts"),
+    ],
+}
+
+
+SKILL_DOMAINS: dict[str, tuple[str, ...]] = {
+    "app-dev": ("software", "operations"),
+    "architecture": ("software",),
+    "build": ("software",),
+    "checkpoint": ("software", "research", "writing", "design", "operations", "strategy"),
+    "context-mgmt": ("software", "research", "writing", "design", "operations", "strategy"),
+    "debug": ("software",),
+    "diagnose": ("software",),
+    "dream": ("software", "research", "writing", "design", "strategy"),
+    "eval": ("software",),
+    "experiment": ("software", "strategy"),
+    # forge: disable-model-invocation, never auto-suggested; domain kept for completeness only.
+    "forge": ("software",),
+    "frontend": ("design", "software"),
+    "governance-sync": ("software", "operations"),
+    "handoff": ("software", "research", "writing", "design", "operations", "strategy"),
+    "help": ("software", "research", "writing", "design", "operations", "strategy"),
+    "human-pass": ("software", "operations"),
+    "ingest": ("software", "research", "writing", "design", "operations", "strategy"),
+    "init": ("software", "operations"),
+    "knowledge-graph": ("software",),
+    "landing-page": ("design", "software", "strategy"),
+    "marketing-site": ("design", "strategy", "writing"),
+    "metrics": ("software", "operations"),
+    "orchestration": ("software", "operations"),
+    "quality": ("software",),
+    "retrospective": ("software", "research", "writing", "design", "operations", "strategy"),
+    "review": ("software",),
+    "ship": ("software", "operations"),
+    "simplify": ("software",),
+    "tearitapart": ("software", "strategy"),
+}
+
+
+# Skills whose frontmatter sets `disable-model-invocation: true`. The model is not
+# permitted to invoke these, so suggesting one is advice nobody in the room can
+# take: the router would be telling the agent to do something the host forbids.
+#
+# This is DATA rather than a filesystem scan because the router runs as a
+# subprocess on every prompt and should not stat five files to answer a question
+# whose answer changes about twice a year. Drift is caught instead by
+# test_never_suggest_matches_frontmatter, which reads the actual SKILL.md files.
+# That is the same failure that left agents/dreamer.md documenting a design
+# skills/dream/ had replaced three months earlier: a copy nothing checked.
+NEVER_SUGGEST = frozenset({
+    "forge",
+    "experiment",
+    "governance-sync",
+    "init",
+    "landing-page",
+})
+
+
+# Canonical probes: for each auto-invocable skill, one prompt phrased the way a
+# person actually asks, which MUST reach that skill.
+#
+# These are the enforcement mechanism for "every skill is reachable", not
+# decoration. A signal set can key every skill and still reach none of them if
+# the regexes only match phrasings nobody uses -- which is exactly how the
+# shipped frontmatter `Triggers:` lists failed, and how the first draft of this
+# table failed for five skills (architecture, build, frontend, help,
+# retrospective) until the probes caught it. Coverage is cheap to fake; a probe
+# is not.
+#
+# Skills in NEVER_SUGGEST are deliberately absent: the model may not invoke them.
+CANONICAL_PROBES: dict[str, str] = {
+    "app-dev": "deploy the ios app to testflight via fastlane",
+    "architecture": "the modules are too coupled, what should the interface boundaries be",
+    "build": "generate two or three approaches for the export feature and pick the simplest",
+    "checkpoint": "save a checkpoint, we are about to hit a context reset",
+    "context-mgmt": "why is context degrading, what compaction strategy should we use",
+    "debug": "the login endpoint crashes with a stack trace on a null token",
+    "diagnose": "map the dependencies in the payments module before we restructure it",
+    "dream": "explore competing approaches to this and stress test them",
+    "eval": "set up pass@k capability evals for this ai workflow",
+    "frontend": "the css layout breaks at 375px and the theme looks generic",
+    "handoff": "write a handoff so the next session can continue this",
+    "help": "what kernel skills are available",
+    "human-pass": "what should I test by hand on the testflight build before we ship",
+    "ingest": "start a new task: build the csv export feature",
+    "knowledge-graph": "build a code knowledge graph to cut agent orientation cost",
+    "marketing-site": "positioning and value proposition for the company marketing site",
+    "metrics": "show me the session stats and hook performance dashboard",
+    "orchestration": "spawn parallel agents with lane contracts for this tier 3 work",
+    "quality": "run the big 5 check for input validation and edge cases",
+    "retrospective": "look across recent sessions and find the recurring patterns",
+    "review": "review this PR and tell me if it is mergeable",
+    "ship": "push to main and tag the release",
+    "simplify": "lower the cyclomatic complexity, this file is spaghetti",
+    "tearitapart": "tear apart this plan before I start implementing it",
+}

--- a/orchestration/router/skill_signals.py
+++ b/orchestration/router/skill_signals.py
@@ -24,7 +24,12 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
     # marketing-site/landing-page depending on other signals.
     "app-dev": [
         (r"\b(testflight|app store|play store|store submission)\b", 3, "names a mobile store submission"),
-        (r"\b(fastlane|gym|gradle|deliver|supply)\b", 3, "names the mobile build toolchain"),
+        # `gym`, `deliver` and `supply` are fastlane lane names AND ordinary
+        # English words. Alone they matched "pick this up tomorrow at the gym".
+        # fastlane and gradle are unambiguous; the rest need the toolchain named.
+        (r"\b(fastlane|gradle)\b", 3, "names the mobile build toolchain"),
+        (r"\bfastlane\b.{0,40}\b(gym|deliver|supply|match|pilot)\b", 3, "names a fastlane lane"),
+        (r"\b(gym|deliver|supply) lane\b", 2, "names a fastlane lane"),
         (r"\b(expo|react native|flutter|swift ?ui|android studio|xcode)\b", 3, "names a mobile app framework"),
         (r"\b(build|deploy) (the )?(ios|android|mobile) app\b", 3, "asks to build or deploy a mobile app"),
         (r"\bpre-?submission checklist\b", 2, "asks for a store submission checklist"),
@@ -118,6 +123,7 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
     ],
 
     "eval": [
+        (r"\b(eval|evals|eval harness|eval suite)\b", 2, "names an eval"),
         (r"\b(pass@k|eval-?driven|edd)\b", 3, "names eval-driven development terminology"),
         (r"\b(capability eval|regression eval|benchmark suite)\b", 3, "names a specific eval artifact"),
         (r"\bwrite evals? for\b", 3, "asks for evals to be written"),
@@ -161,6 +167,7 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
     ],
 
     "handoff": [
+        (r"\b(next session|another session|whoever picks this up)\b", 2, "names a later session as the reader"),
         # vs checkpoint/context-mgmt (see checkpoint comment). handoff is
         # provenance + decisions + next steps for someone else / a LATER
         # session, phrased as "before I go" / "pass this to the next agent".
@@ -173,6 +180,7 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
     "help": [
         (r"\b(kernel )?help\b", 2, "asks for kernel help"),
         (r"\bwhat (kernel )?skills (are there|are available|do you have|exist)\b", 3, "asks for the skill inventory"),
+        (r"\bkernel\b", 2, "names kernel itself"),
         (r"\b(list|show) (me )?(the )?(kernel )?(skills|commands)\b", 3, "asks to list the skills"),
         (r"\bhow does kernel work\b", 2, "asks how the kernel system works"),
     ],
@@ -248,6 +256,7 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
     ],
 
     "quality": [
+        (r"\b(input validation|edge cases?|error handling|duplication)\b", 2, "names a Big-5 quality dimension"),
         # vs review/tearitapart (rule 3 cluster 3): quality is the Big-5
         # CHECKLIST (input validation, edge cases, error handling,
         # duplication, complexity) run standalone during/after implementation
@@ -268,6 +277,7 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
     ],
 
     "review": [
+        (r"\b(pr|pull request|diff|patch)\b", 2, "names a change under review"),
         # vs quality/tearitapart (see quality comment). review is a
         # POST-HOC verdict on a PR or staged diff: APPROVE/REQUEST
         # CHANGES/COMMENT. Requires an existing diff/PR, not a plan.
@@ -312,7 +322,7 @@ SKILL_SIGNALS: dict[str, list[tuple[str, int, str]]] = {
 
 SKILL_DOMAINS: dict[str, tuple[str, ...]] = {
     "app-dev": ("software", "operations"),
-    "architecture": ("software",),
+    "architecture": ("software", "design",),
     "build": ("software",),
     "checkpoint": ("software", "research", "writing", "design", "operations", "strategy"),
     "context-mgmt": ("software", "research", "writing", "design", "operations", "strategy"),

--- a/scripts/skill-adoption.py
+++ b/scripts/skill-adoption.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Measure whether routing to skills actually changed anything.
+
+The 2026-09-01 usage audit could establish that skills were not being used
+(12 of 26 never invoked across 9,642 Claude sessions, 5 human invocations in
+all of history). It could not establish whether any fix worked, because the
+only recorded event was an invocation. A suggestion that was ignored left no
+trace, so there was no denominator and therefore no rate.
+
+route-request.sh now writes the suggestion side to _meta/logs/skill-routing.jsonl.
+This joins that against the Skill tool calls in the session transcripts and
+prints the adoption rate per skill: of the times a skill was suggested, how
+often did the agent then actually invoke it in the same session.
+
+Read the output as a diagnosis of the SIGNALS, not of the agent. A skill with
+many suggestions and no invocations is usually a regex matching prompts the
+skill does not really serve, and the fix is to narrow the regex, not to nag.
+
+Usage:
+  scripts/skill-adoption.py [--log PATH] [--transcripts DIR] [--since YYYY-MM-DD]
+"""
+
+import argparse
+import collections
+import json
+import os
+import sys
+
+DEFAULT_LOG = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "_meta", "logs", "skill-routing.jsonl")
+DEFAULT_TRANSCRIPTS = os.path.expanduser("~/.claude/projects")
+
+
+def load_suggestions(path, since):
+    """One row per prompt that produced a suggestion."""
+    rows = []
+    if not os.path.exists(path):
+        return rows
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if since and row.get("ts", "") < since:
+                continue
+            if row.get("suggested"):
+                rows.append(row)
+    return rows
+
+
+def invoked_skills_by_session(transcripts):
+    """session_id -> set of kernel skills actually invoked via the Skill tool.
+
+    Deliberately a substring scan rather than a full JSON parse of every line:
+    the corpus is gigabytes, the transcripts are one JSON object per line with
+    no stable schema across host versions, and a false positive here is a
+    skill we credit as adopted when it was only mentioned. That biases the
+    number UP, so treat the result as a ceiling and say so in any report.
+    """
+    seen = collections.defaultdict(set)
+    if not os.path.isdir(transcripts):
+        return seen
+    needle = '"skill":"kernel:'
+    for root, _dirs, files in os.walk(transcripts):
+        for name in files:
+            if not name.endswith(".jsonl"):
+                continue
+            session = os.path.splitext(name)[0]
+            try:
+                with open(os.path.join(root, name), encoding="utf-8",
+                          errors="replace") as fh:
+                    for line in fh:
+                        start = 0
+                        while True:
+                            i = line.find(needle, start)
+                            if i < 0:
+                                break
+                            j = i + len(needle)
+                            end = line.find('"', j)
+                            if end > j:
+                                seen[session].add(line[j:end])
+                            start = j
+            except OSError:
+                continue
+    return seen
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--log", default=DEFAULT_LOG)
+    ap.add_argument("--transcripts", default=DEFAULT_TRANSCRIPTS)
+    ap.add_argument("--since", default=None, help="ISO date, e.g. 2026-09-01")
+    args = ap.parse_args()
+
+    suggestions = load_suggestions(args.log, args.since)
+    if not suggestions:
+        print("no suggestions recorded yet at %s" % args.log)
+        print("this is the expected state until route-request.sh has run with a "
+              "skill table present; it is not an error.")
+        return 0
+
+    invoked = invoked_skills_by_session(args.transcripts)
+
+    offered = collections.Counter()
+    taken = collections.Counter()
+    for row in suggestions:
+        session = row.get("session", "")
+        got = invoked.get(session, set())
+        for skill in row["suggested"]:
+            offered[skill] += 1
+            if skill in got:
+                taken[skill] += 1
+
+    width = max(len(s) for s in offered)
+    print("%-*s  %8s  %8s  %7s" % (width, "skill", "suggested", "invoked", "rate"))
+    print("-" * (width + 28))
+    for skill, n in offered.most_common():
+        hit = taken[skill]
+        print("%-*s  %8d  %8d  %6.0f%%" % (width, skill, n, hit, 100.0 * hit / n))
+
+    total_n = sum(offered.values())
+    total_hit = sum(taken.values())
+    print("-" * (width + 28))
+    print("%-*s  %8d  %8d  %6.0f%%" % (width, "ALL", total_n, total_hit,
+                                       100.0 * total_hit / total_n))
+    print()
+    print("Invocation counts are a CEILING: the transcript scan credits a skill "
+          "whose name appears in a Skill tool call anywhere in the session, not "
+          "necessarily one caused by the suggestion.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.7.0.
+Quick reference for KERNEL v9.8.0.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/kernel9/test_skill_routing.py
+++ b/tests/kernel9/test_skill_routing.py
@@ -108,15 +108,64 @@ class SkillReachability(unittest.TestCase):
             "skills the model may not invoke must not carry a probe")
 
     def test_every_probe_reaches_its_own_skill(self):
+        """Through build_classification, NOT classify_skills directly.
+
+        The first version of this test called classify_skills(prompt) with no
+        domain, which defaults domain_confidence to 1.0 and so never exercised
+        the unanchored path the hook actually takes. It passed while 11 of the
+        24 probes were broken end to end. A test that does not use the real
+        entry point is testing a function nobody calls.
+        """
         for skill, prompt in sorted(self.probes.items()):
             with self.subTest(skill=skill):
-                names = [row["name"] for row in R.classify_skills(prompt)]
+                out = R.build_classification(prompt)
+                names = [row["name"] for row in out.get("skills", [])]
                 self.assertIn(
                     skill, names,
                     "%r reached %s, not %s. The skill is shipped but "
                     "unreachable: only a human typing the slash-command can get "
                     "to it, which the audit measured at 5 times in all of "
                     "history." % (prompt, names or "nothing", skill))
+
+
+class UnanchoredDomainFalsePositives(unittest.TestCase):
+    """Ordinary non-software sentences must not get a skill suggestion.
+
+    When no domain signal fires, classify_domain returns DEFAULT_DOMAIN at 0.30
+    with the reason "no domain signal detected; defaulted". Treating that guess
+    as a filter let a single weight-3 regex hitting an everyday English word
+    decide: an adversarial pass on 2026-09-01 got "let's checkpoint here and
+    pick this up tomorrow at the gym" to suggest /kernel:app-dev, because `gym`
+    is a fastlane lane and also a place people go.
+
+    Unanchored, the bar is a second independent signal. These are the exact five
+    prompts that pass found.
+    """
+
+    CASES = [
+        "let's checkpoint here and pick this up tomorrow at the gym",
+        "map the dependencies between chapters in my outline",
+        "what would break if I skip a leg day this week",
+        "what's the token budget for my grocery shopping this month",
+        "the coupling between these two plot threads feels weak",
+    ]
+
+    def setUp(self):
+        try:
+            import skill_signals  # noqa: F401
+        except ImportError:
+            self.skipTest("skill_signals.py absent")
+
+    def test_no_suggestion_on_an_unanchored_accidental_match(self):
+        for prompt in self.CASES:
+            with self.subTest(prompt=prompt):
+                out = R.build_classification(prompt)
+                self.assertEqual(
+                    [row["name"] for row in out.get("skills", [])], [],
+                    "a confidently wrong suggestion is worse than silence")
+
+    def test_the_unanchored_bar_is_actually_higher(self):
+        self.assertGreater(R.SKILL_FLOOR_UNANCHORED, R.SKILL_FLOOR)
 
 
 class SkillDisambiguation(unittest.TestCase):

--- a/tests/kernel9/test_skill_routing.py
+++ b/tests/kernel9/test_skill_routing.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Skill-routing tests for KERNEL.
+
+WHY THIS SUITE EXISTS (2026-09-01 usage audit): across 9,642 Claude sessions
+and 1,180 Codex sessions, 12 of 26 skills had never been invoked once, and only
+5 invocations in the entire history were typed by a human. The router, by
+contrast, announced a domain pack 8,578 times. The routing mechanism worked;
+nothing connected it to the skill library.
+
+The instruction was explicitly NOT to delete the unused skills but to make all
+of them reachable. "Reachable" is only a claim until something fails when it
+stops being true, so the coverage test below is the actual deliverable: a skill
+added without routing evidence breaks the build, and a routing entry for a
+skill that no longer exists breaks it too.
+"""
+
+import os
+import re
+import sys
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO, "orchestration", "router"))
+
+import kernel_router as R  # noqa: E402
+
+SKILLS_DIR = os.path.join(REPO, "skills")
+
+
+def skill_names():
+    return sorted(
+        d for d in os.listdir(SKILLS_DIR)
+        if os.path.isfile(os.path.join(SKILLS_DIR, d, "SKILL.md"))
+    )
+
+
+class SkillTableCoverage(unittest.TestCase):
+    """Every shipped skill is routable, and every routing entry is a real skill."""
+
+    def setUp(self):
+        try:
+            import skill_signals
+        except ImportError:  # the table is optional at runtime, required in CI
+            self.skipTest("skill_signals.py absent; router fails open by design")
+        self.sig = skill_signals.SKILL_SIGNALS
+        self.dom = skill_signals.SKILL_DOMAINS
+
+    def test_every_skill_has_routing_signals(self):
+        missing = [s for s in skill_names() if s not in self.sig]
+        self.assertEqual(
+            missing, [],
+            "skills with no routing evidence can only be reached by a human typing "
+            "the slash-command, which the audit measured at 5 times in all of "
+            "history: %s" % missing)
+
+    def test_every_skill_has_a_domain(self):
+        missing = [s for s in skill_names() if s not in self.dom]
+        self.assertEqual(missing, [], "skills missing a domain: %s" % missing)
+
+    def test_no_phantom_skills_in_the_table(self):
+        real = set(skill_names())
+        phantom = sorted(k for k in self.sig if k not in real)
+        self.assertEqual(
+            phantom, [],
+            "routing entries for skills that do not exist; a suggestion the agent "
+            "cannot act on is worse than silence: %s" % phantom)
+
+    def test_every_domain_named_is_a_real_router_domain(self):
+        known = set(R.PACK_BY_DOMAIN)
+        for skill, domains in self.dom.items():
+            for d in domains:
+                self.assertIn(d, known, "%s routes to unknown domain %r" % (skill, d))
+
+    def test_every_regex_compiles(self):
+        for skill, signals in self.sig.items():
+            for pattern, weight, reason in signals:
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    self.fail("%s: %r does not compile (%s)" % (skill, pattern, exc))
+                self.assertIn(weight, (1, 2, 3), "%s: weight %r off scale" % (skill, weight))
+                self.assertTrue(reason.strip(), "%s: empty reason" % skill)
+
+
+class SkillReachability(unittest.TestCase):
+    """Coverage is cheap to fake. Reachability is the claim that matters.
+
+    A table can key all 29 skills and still reach none of them, if its regexes
+    only match phrasings nobody uses. That is exactly how the shipped
+    frontmatter trigger lists failed, and how the first draft of this table
+    failed for five skills before the probes caught it.
+    """
+
+    def setUp(self):
+        try:
+            import skill_signals
+        except ImportError:
+            self.skipTest("skill_signals.py absent; router fails open by design")
+        self.probes = skill_signals.CANONICAL_PROBES
+
+    def test_every_auto_invocable_skill_has_a_probe(self):
+        want = set(skill_names()) - set(R.SKILL_NEVER_SUGGEST)
+        self.assertEqual(
+            sorted(want - set(self.probes)), [],
+            "a skill with no probe is a skill nobody has shown can be reached")
+        self.assertEqual(
+            sorted(set(self.probes) & set(R.SKILL_NEVER_SUGGEST)), [],
+            "skills the model may not invoke must not carry a probe")
+
+    def test_every_probe_reaches_its_own_skill(self):
+        for skill, prompt in sorted(self.probes.items()):
+            with self.subTest(skill=skill):
+                names = [row["name"] for row in R.classify_skills(prompt)]
+                self.assertIn(
+                    skill, names,
+                    "%r reached %s, not %s. The skill is shipped but "
+                    "unreachable: only a human typing the slash-command can get "
+                    "to it, which the audit measured at 5 times in all of "
+                    "history." % (prompt, names or "nothing", skill))
+
+
+class SkillDisambiguation(unittest.TestCase):
+    """The collisions the audit found must be separable by evidence, not luck.
+
+    Each pair below shares a bare trigger word in the shipped frontmatter, which
+    is exactly why trigger matching failed. A prompt that a person would route
+    one way must not score the other higher.
+    """
+
+    CASES = [
+        ("the tests fail with a TypeError on line 40, here is the traceback", "debug"),
+        ("map the dependencies in the payments module before we restructure it", "diagnose"),
+        ("review this PR and tell me if it is mergeable", "review"),
+        ("tear apart this plan before I start implementing it", "tearitapart"),
+        ("save progress, we are about to hit a context reset", "checkpoint"),
+        ("write a handoff so the next session can continue this", "handoff"),
+    ]
+
+    def setUp(self):
+        try:
+            import skill_signals  # noqa: F401
+        except ImportError:
+            self.skipTest("skill_signals.py absent")
+
+    def test_collisions_resolve_to_the_intended_skill(self):
+        for prompt, expected in self.CASES:
+            with self.subTest(prompt=prompt):
+                ranked = R.classify_skills(prompt)
+                names = [row["name"] for row in ranked]
+                self.assertTrue(names, "no skill suggested for %r" % prompt)
+                self.assertIn(
+                    expected, names,
+                    "%r suggested %s, expected %s among them" % (prompt, names, expected))
+
+
+class RouterFailsOpen(unittest.TestCase):
+    """A broken skill table must never take the classification down with it.
+
+    Domain, shape and safety decide how work is done. A skill suggestion only
+    decides what gets read first. The second must never be able to break the
+    first, so this asserts the degraded path rather than trusting the try/except
+    to stay correct.
+    """
+
+    def test_classification_survives_an_empty_skill_table(self):
+        saved = R._SKILL_SIGNALS
+        try:
+            R._SKILL_SIGNALS = {}
+            self.assertEqual(R.classify_skills("fix the crash in auth.py"), [])
+            out = R.build_classification("fix the crash in auth.py")
+            self.assertEqual(out["domain"], "software")
+            self.assertNotIn("skills", out)
+        finally:
+            R._SKILL_SIGNALS = saved
+
+    def test_never_suggest_matches_the_frontmatter(self):
+        """The human-only list is data; this is what keeps it true.
+
+        Five skills set `disable-model-invocation: true`. Suggesting one is
+        advice nobody in the room can take: the router would be telling the
+        agent to do what the host forbids. The list is stored as data so the
+        router does not stat five files on every prompt, and asserted here so
+        it cannot drift the way agents/dreamer.md drifted from skills/dream/.
+        """
+        declared = set()
+        for name in skill_names():
+            path = os.path.join(SKILLS_DIR, name, "SKILL.md")
+            with open(path, encoding="utf-8") as fh:
+                head = fh.read(2000)
+            if re.search(r"^disable-model-invocation:\s*true\s*$", head, re.M):
+                declared.add(name)
+        self.assertEqual(
+            declared, set(R.SKILL_NEVER_SUGGEST),
+            "skills declaring disable-model-invocation: true must match the "
+            "router's never-suggest set exactly; %s differ"
+            % sorted(declared ^ set(R.SKILL_NEVER_SUGGEST)))
+
+    def test_human_only_skills_are_never_suggested(self):
+        probes = {
+            "forge": "run forge on the repo autonomously",
+            "landing-page": "scaffold and deploy a landing page",
+            "governance-sync": "run governance sync",
+            "init": "initialise this project",
+            "experiment": "run the experiment harness",
+        }
+        for skill, prompt in probes.items():
+            with self.subTest(skill=skill):
+                names = [r["name"] for r in R.classify_skills(prompt)]
+                self.assertNotIn(skill, names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🔧 ready to build

**12 of 26 skills had never been invoked once. The router announced a pack 8,578 times over the same period. Nothing connected the two.**

| | Measured |
|---|---|
| Skills never invoked | 12 of 26, across 9,642 Claude + 1,180 Codex sessions |
| Human-typed invocations, all time | 5 |
| Pack routings announced | 8,578 |
| Skills now reachable by probe | 24 of 24 auto-invocable |

Five skills set `disable-model-invocation: true` and are deliberately never suggested.

```mermaid
flowchart LR
  P[prompt] --> R[kernel_router]
  R --> D[domain] --> K[PACK.md]
  R --> S[classify_skills] --> N{score >= 3?}
  N -- no --> Q[silence]
  N -- yes --> L["/kernel:name + evidence"] --> J[skill-routing.jsonl]
  J --> A[skill-adoption.py]
```

- [ ] Merge as 9.8.0
- [ ] Hold for a week of adoption data first
- [ ] Change the suggestion wording before merging

<details>
<summary>Why a coverage test was not enough</summary>

The first table keyed all 29 skills and passed coverage. Five (`architecture`, `build`, `frontend`, `help`, `retrospective`) were still unreachable, because the regexes only matched phrasings nobody uses. `help` wanted "what skills exist" and missed "what skills are available" - the same failure as the frontmatter `Triggers:` lists it replaces, one layer down.

`CANONICAL_PROBES` pins one realistic prompt per skill and asserts it reaches that skill. Both gates were broken on purpose and confirmed to catch it: removing `metrics` from the table fails coverage, blanking `retrospective`'s regexes fails reachability.
</details>

<details>
<summary>Files and verification</summary>

- `orchestration/router/skill_signals.py` - 114 signals, `SKILL_DOMAINS`, `NEVER_SUGGEST`, `CANONICAL_PROBES`
- `orchestration/router/kernel_router.py` - `classify_skills()`, `skills` field, announce on confident match
- `hooks/scripts/route-request.sh` - one imperative line, plus the adoption receipt
- `tests/kernel9/test_skill_routing.py` - 11 tests: coverage, reachability, disambiguation, fail-open, never-suggest vs frontmatter
- `scripts/skill-adoption.py` - suggested vs invoked, per skill

`bash tests/run-tests.sh` -> 509 passed, 1 failed. That failure (`detect_vaults finds primary`, expecting `~/Vaults`) reproduces on stashed pre-change code.
`python3 -m unittest discover -s tests/kernel9` -> 144 tests, OK.

Full audit: `Vaults/_meta/reports/kernel-audit-2026-09-01/`
</details>