### PR TITLE
Execute the audit recommendations, and reverse the three that were wrong

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "kernel",
       "source": "./",
       "description": "Safety guardrails, cross-host hooks, and agentdb memory for Claude Code and Codex in auto mode",
-      "version": "9.8.0"
+      "version": "9.8.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. Hook context is shaped for both hosts' plain and structured output parsers. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "KERNEL is a Claude Code and Codex plugin that replaces per-action approval prompts with guardrails enforced by hooks. Hook context is shaped for both hosts' plain and structured output parsers. In auto mode, destructive commands and secret writes are blocked before they run; irreversible operations require a one-time token only a human can open; independent verification agents check finished work without seeing the builder's reasoning; session state persists as schema-validated JSON manifests. agentdb, a local SQLite agent memory, is recalled at session start and written at session end, so a failure recorded once is blocked the next time. Skills invoke as /kernel:<name> on Claude Code and $kernel:<name> on Codex; run /kernel:help first. Agent-readable summary and safety limits: llms.txt.",
   "author": {
     "name": "Aria Han",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 7f56f65580f79f672e255e493f4363952f6af9e04bdd6477425134c2a0564fc8; adapter: codex -->
-<kernel version="9.8.0">
+<kernel version="9.8.1">
 
 
 <!-- ============================================ -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to KERNEL are documented in this file.
 
+## [9.8.1] - 2026-09-01
+
+Executing the audit's recommendations. Two of them turned out to be wrong, and saying so is
+part of the work.
+
+### Changed
+- `session-start.sh` prints the compression preamble only when no loaded `CLAUDE.md` or
+  `AGENTS.md` already carries it. ~798 tokens a session where one does; unchanged for anyone
+  without one. The audit said to cut the block outright: that was WRONG. For any repo that is
+  not kernel-claude, this hook is the only delivery of kernel doctrine, and cutting it would
+  have silently disarmed the plugin everywhere. Only the duplicated preamble is conditional;
+  the operating rules below it appear in no generated file and always print. The split lives in
+  `generate-governance.py`, not in its output, so the next regeneration cannot clobber it.
+- `chronicle-gate.sh` refuses up to three times instead of once, accepts a one-line
+  `<date>-skipped.md` note as satisfaction, and no longer prints its own bypass variable.
+  `KERNEL_CHRONICLE_OK=1` had appeared 402 times across 262 sessions against 3 real refusals:
+  a Stop hook that cannot refuse twice is a reminder wearing a gate's clothes, and one whose
+  refusal text names the variable that silences it is running a tutorial for the thing it
+  exists to prevent. The variable still works for CI.
+- `warn-hardcoded.sh` warns once per file, naming the count and the token file to use, and
+  exempts token-definition files, hairline borders, radii and media queries. It had fired 227
+  times corpus-wide and changed nothing, because `[0-9]+px` matches every stylesheet ever
+  written. A warning that fires on correct code trains the reader to skip the line.
+- `detect-secrets.sh` names the file in its refusal, gives the platform's jq install command,
+  and tells a fixture author to shorten the value rather than assemble it at runtime.
+- `_meta/agentdb/agentdb` derives its vault root from `$HOME` instead of a hardcoded
+  `/Users/ariaxhan/...`, which the vault invariants forbid and which made it fail on every
+  machine but one.
+
+### Fixed
+- `guard-bash.sh`, four narrowings and one widening, all from measured false positives:
+  - A file-then-exec heredoc run by an INTERPRETER is code only if its body can spawn a
+    process. A shell body still always counts. This blocked a Python script three times in one
+    session for quoting a command it was writing into a markdown file, once while writing the
+    audit that reported it and once while writing this fix.
+  - A search pattern is data: `grep` never executes what it looks for.
+  - The interpreter one-liner rule read the rest of the line, and newlines are collapsed to
+    spaces before matching, so an explicit `rm -rf` on a later line was attributed to an earlier
+    `python3 -c "print(1)"`. It now reads the interpreter's quoted argument.
+  - List-form argv is normalised before matching, closing a PRE-EXISTING hole where
+    `subprocess.run(["git","branch","-D","x"])` matched nothing at all.
+
+### Rejected
+- Exempting secrets that "look fake" (containing `example`, `dummy`, `0000`). Written, then
+  reverted: it immediately failed three of this repo's own detection tests, because
+  `AKIAIOSFODNN7EXAMPLE` is the canonical AWS example key. The strings that announce themselves
+  as fake are exactly what a real leak looks like to a regex. Weakening a secret scanner so a
+  fixture reads more nicely is a bad trade.
+- Deleting `warn-hardcoded.sh`. The audit ranked it CUT on evidence, but the test suite uses it
+  as the canonical content-consuming advisory hook, so removing it would have gutted coverage of
+  the shared multi-file payload parser. Fixed its precision instead.
+
 ## [9.8.0] - 2026-09-01
 
 The router announced a pack 8,578 times while 12 of 26 skills had never been invoked once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!-- GENERATED FILE. Edit governance/kernel.md.tmpl, then run scripts/generate-governance.py.
      source-sha256: 7f56f65580f79f672e255e493f4363952f6af9e04bdd6477425134c2a0564fc8; adapter: claude -->
-<kernel version="9.8.0">
+<kernel version="9.8.1">
 
 
 <!-- ============================================ -->

--- a/_meta/chronicles/2026/2026-09-01-audit-recommendations.md
+++ b/_meta/chronicles/2026/2026-09-01-audit-recommendations.md
@@ -1,0 +1,80 @@
+---
+type: note
+status: active
+created: 2026-09-01
+tier: 2
+---
+
+# Executing the audit recommendations, including the two that were wrong
+
+## What was attempted
+
+Aria: "execute all of the recommendations please", against the ranked audit in
+`Vaults/_meta/reports/kernel-audit-2026-09-01/`.
+
+## What actually changed
+
+Shipped as 9.8.1, full suite 509 passed / 1 failed (the pre-existing `detect_vaults` test that
+expects `~/Vaults`, reproducible on main):
+
+- **Doctrine dedupe.** The compression block loaded six times in one session. The two globals
+  keep it; the four project files that always load alongside a global now carry one line. ~972
+  tokens a session.
+- **session-start.** The preamble prints only when no loaded CLAUDE.md/AGENTS.md carries it.
+  ~798 tokens a session here. The split lives in the generator, not its output.
+- **chronicle-gate.** Refuses three times instead of once, accepts a one-line skipped note, and
+  no longer prints its own bypass.
+- **guard-bash.** Four narrowings, one widening. The widening closed a pre-existing hole where
+  list-form argv matched nothing at all.
+- **warn-hardcoded.** Precise instead of deleted.
+- **detect-secrets.** Better refusal, no weakening.
+- **kernel-install-current.** Updates every marketplace clone, not just the default account.
+- **agentdb script.** Vault root from `$HOME` instead of a hardcoded `/Users/ariaxhan/...`.
+
+## Verified live
+
+- `bash tests/run-tests.sh` -> 509/1, matching main baseline.
+- Guard changes tested in BOTH directions, 11 cases: a quoted command allowed, a shell body
+  blocked, a Python body that shells out blocked, a bare force-delete blocked, a grep allowed.
+- chronicle-gate driven through all four states in a throwaway repo.
+- All four marketplace clones converged on 9.8.0 from four different commits.
+- session-start verified with and without a CLAUDE.md present.
+
+## What failed
+
+**Two of the recommendations were wrong, and I wrote both of them.**
+
+1. *"Cut session-start output by 60%."* The block is not accidentally duplicating CLAUDE.md;
+   it is the same source rendered twice, and for any repo that is not kernel-claude the hook is
+   the ONLY delivery of kernel doctrine. Executing it literally would have silently disarmed the
+   plugin everywhere. The audit reasoned from token counts without asking what the tokens were
+   for. Implemented as a conditional instead.
+
+2. *"detect-secrets needs a fixtures exemption."* Written, then reverted within minutes: it
+   failed three of this repo own detection tests, because `AKIAIOSFODNN7EXAMPLE` is the
+   canonical AWS example key and contains the word EXAMPLE. The values that announce themselves
+   as fake are exactly what a real leak looks like to a regex. The nuisance was real; the hole
+   would have been worse.
+
+A third, *"delete warn-hardcoded"*, was correct about the evidence (227 fires, zero behaviour
+changes) and wrong about the remedy: the test suite uses it as the canonical content-consuming
+advisory hook, so deleting it would have gutted coverage of the shared payload parser. Fixed its
+precision instead.
+
+**The guard blocked me from writing its own fix.** `guard-bash` refused the patch three times
+because the patch comment quoted the command it was teaching the guard to ignore. That is the
+cleanest possible demonstration of the false positive, and it cost three rewrites to land.
+
+## Deferred
+
+- The 90 separate `agent.db` files remain unshared: a lesson learned in one project is invisible
+  in another unless written `--global`. Changing that is a data-migration decision, not a fix.
+- Three kernel-claude branches still need Aria approval token to force-delete.
+
+## Disagreement worth inheriting
+
+An audit that ranks by measured cost will recommend cutting things that are cheap to measure and
+expensive to lose. Two of five recommendations here were of exactly that shape. The token count
+was right in both cases; the conclusion was wrong in both cases. Rank by cost, but before
+executing a CUT, ask what breaks if it is gone, and check by removing it in a throwaway copy
+rather than by reasoning.

--- a/_meta/chronicles/2026/2026-09-01-audit-recommendations.md
+++ b/_meta/chronicles/2026/2026-09-01-audit-recommendations.md
@@ -111,3 +111,47 @@ byte-identical to main; all four guard hash pins match the shipped files; and th
 
 Its one quarantined finding (a CLAUDE.md that shows the header inside a code fence would
 suppress the real preamble) was cheap enough to just fix rather than accept.
+
+## Three rounds on one exemption, and what settled it
+
+The search-pattern exemption took three adversarial rounds:
+
+1. Stripped the pattern unconditionally. A grep-then-eval walked through.
+2. Enumerated re-execution verbs (eval, source, xargs, bare dot, `-c` with a variable).
+   Eight more routes walked through: backticks, `$()` in command position, a here-string,
+   `printf | bash`, `zsh -s`, process substitution, and writing the match to a file and running
+   it by path, which involves no "re-execution verb" at all.
+3. Inverted to an allowlist. The exemption applies only when the whole command is recognisably
+   inert; anything unrecognised keeps the literal visible.
+
+The verifier confirmed round three holds and could not route captured grep output to an executor
+without also failing the inert test. Its own summary of why: "an allowlist of recognized-inert
+forms with unrecognized = stay visible as the fail-safe default is the right shape for this
+problem."
+
+Two shell bugs had been quietly defeating rounds one and two, and both are worth remembering
+independently of this feature:
+
+- **BSD sed does not expand `\n` in a replacement.** `sed -E 's/[;|]/\n/g'` produced a literal
+  `n`, not a newline, so splitting a command into segments yielded ONE segment on macOS and
+  every pipeline looked like its first command. This pattern appears elsewhere in the guard and
+  predates this change.
+- **`read` returns non-zero on a final line with no trailing newline**, so the LAST segment of a
+  split was silently dropped. `grep ... | zsh -s` survived two rounds on that alone: the loop
+  examined `grep`, called it inert, and never saw `zsh`.
+
+Both are the same class as the audit's own findings: a check that looks like it runs, reports
+success, and is examining nothing.
+
+**A second near-miss with the same cause as the earlier stash.** A seeded-defect run put the
+pre-fix guard into the working tree, and the command timed out before its restore line. The
+broken guard sat in the tree until the next check caught it. Twice in one session a timeout has
+stranded a file mid-experiment. The fix both times was the same and should have been the first
+move: run the experiment on a copy, never on the tree.
+
+## Deferred, filed separately
+
+The verifier found a pre-existing GTFOBins-class gap present identically on main and this
+branch: `sort --compress-program=` executes an arbitrary program, and `tail -f` hangs
+indefinitely, and neither is blocked standalone. Unrelated to this exemption, and not a reason
+to hold the merge.

--- a/_meta/chronicles/2026/2026-09-01-audit-recommendations.md
+++ b/_meta/chronicles/2026/2026-09-01-audit-recommendations.md
@@ -78,3 +78,36 @@ expensive to lose. Two of five recommendations here were of exactly that shape. 
 was right in both cases; the conclusion was wrong in both cases. Rank by cost, but before
 executing a CUT, ask what breaks if it is gone, and check by removing it in a throwaway copy
 rather than by reasoning.
+
+## The verifier found a real regression, and it was in the fix for a false positive
+
+An independent adversary, given the acceptance record but not the reasoning, reported
+DO NOT MERGE on 9.8.1 with one blocking finding:
+
+```
+X=$(grep -o "<destructive literal>" file.txt); eval "$X"
+```
+
+main blocked it. My branch allowed it. The cause was change 3(b), "a search pattern is data":
+I replaced the quoted grep pattern with a placeholder before keyword matching, on the reasoning
+that grep never executes what it looks for. That reasoning is correct about grep and incomplete
+about the command line, because a later segment can run what the grep returned.
+
+This is worth stating plainly: the regression was introduced by a fix for a false positive that
+had blocked me three times in one session. Irritation is a bad reason to loosen a safety gate,
+and it produced exactly the failure the gate exists to prevent. The narrowing was still right;
+it just needed the other half.
+
+The exemption is now withdrawn whenever the command also holds `eval`, `source`, a bare `.`,
+`xargs`, or an interpreter `-c` reading a variable. Differential against main across six cases:
+grep-then-eval, grep-then-source and grep-then-xargs block on both sides again, the bare
+destructive command blocks on both, and the original false positive is still allowed.
+
+The verifier also confirmed, with numbers I had not produced: the compression conditional
+suppresses the preamble for 100% of projects under the vault and is correct in every case
+because the Claude global genuinely carries the rule; detect-secrets' `PATTERNS` array is
+byte-identical to main; all four guard hash pins match the shipped files; and the
+`detect_vaults` failure reproduces on main.
+
+Its one quarantined finding (a CLAUDE.md that shows the header inside a code fence would
+suppress the real preamble) was cheap enough to just fix rather than accept.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "KERNEL's methodology layer for Gemini CLI: 27 software-engineering agent skills plus llms.txt as ambient context. Skills cover systematic debugging (reproduce, isolate, regression-test), generating competing approaches before implementing, pre-implementation critique, code review, bounded context handoff and resume, multi-agent orchestration, eval-driven development, release gating, and context-led frontend design. Gemini CLI gets the methodology only. KERNEL's enforcement layer does not run here: the PreToolUse hooks that block destructive commands and secret writes, the one-time human approval token for irreversible operations, and the agentdb SQLite memory recalled at session start are Claude Code and Codex only. `gemini extensions install` fetches a curated release bundle that carries just this manifest, llms.txt, and skills/, so no Claude-format hook or agent definition is loaded. Source, safety limits, and the host capability matrix: https://github.com/ariaxhan/kernel-claude",
   "contextFileName": "llms.txt"
 }

--- a/hooks/scripts/chronicle-gate.sh
+++ b/hooks/scripts/chronicle-gate.sh
@@ -17,9 +17,27 @@ export GIT_OPTIONAL_LOCKS=0
 # Prose asking for a chronicle does not produce chronicles; roughly 40% of prose
 # rules are skipped under load. Hence a gate (I0.15).
 #
-# It is a gate, not a trap. It refuses ONCE per session, tells you exactly what to
-# write and where, and always names an escape hatch. A gate you cannot satisfy is
-# worse than no gate: people learn to disable the whole hook chain.
+# It is a gate, not a trap: it tells you exactly what to write and where, accepts a
+# one-line "nothing was owed" note as satisfaction, and yields after three refusals
+# so it can never strand a session. A gate you cannot satisfy is worse than no gate.
+#
+# REVISED 2026-09-01 after a usage audit measured what it was actually doing:
+# KERNEL_CHRONICLE_OK=1 appeared 402 times across 262 sessions against 3 real
+# first-refusals. Two design choices made it decorative, and both are fixed here.
+#
+#   1. It refused ONCE PER SESSION and then yielded forever. A Stop hook that
+#      cannot refuse twice is a reminder wearing a gate's clothes. It now refuses
+#      up to three times, escalating, and says on the last one that it is done.
+#   2. Its own refusal text ended with "Skip deliberately with KERNEL_CHRONICLE_OK=1",
+#      which taught every agent that read it how to never see the gate again. The
+#      variable still works, for automation that legitimately needs it, but the
+#      gate no longer advertises it. A guard that hands out its own bypass is
+#      running a tutorial for the thing it exists to prevent.
+#
+# The cheap compliant path matters more than either. Agents overrode because
+# overriding was cheaper than complying. A one-line file saying WHY nothing was
+# owed is cheaper than setting an env var, and unlike the env var it leaves a
+# record the next session can read.
 #
 # Degraded mode: fail-open-loud. If jq or git is missing we cannot tell whether
 # source changed, and blocking the end of a session on a missing parser would trap
@@ -82,26 +100,38 @@ fi
 YEAR=$(date +%Y)
 TODAY=$(date +%Y-%m-%d)
 CHRONICLE_DIR="$ROOT/_meta/chronicles/$YEAR"
+# Either a real chronicle or an explicit "nothing was owed" note satisfies this.
+# The second is the cheap path: the gate was being bypassed because bypassing cost
+# one environment variable and complying cost a document. A single honest line is
+# cheaper than the bypass and, unlike the bypass, the next session can read it.
 if [ -d "$CHRONICLE_DIR" ] && ls "$CHRONICLE_DIR"/"$TODAY"*.md >/dev/null 2>&1; then
   rm -f "$SEEN_MARKER" 2>/dev/null
   exit 0
 fi
 
+# Still honoured, for CI and automation that genuinely cannot write a file. Not
+# advertised in the refusal below: see the 402-to-3 note at the top of this file.
 if [ "${KERNEL_CHRONICLE_OK:-0}" = "1" ]; then
   echo "chronicle-gate: source changed with no chronicle; proceeding because KERNEL_CHRONICLE_OK=1." >&2
   exit 0
 fi
 
-# Refuse once. A second Stop proceeds, so this can never trap a session.
-if [ -f "$SEEN_MARKER" ]; then
-  echo "chronicle-gate: still no chronicle. Proceeding -- this gate refuses once, never twice." >&2
+# Refuse up to three times, then yield. Never traps a session; also never lets one
+# walk past on the first shrug, which is what "refuses once, never twice" allowed.
+MAX_REFUSALS=3
+ASKED=$(cat "$SEEN_MARKER" 2>/dev/null || echo 0)
+case "$ASKED" in ''|*[!0-9]*) ASKED=0 ;; esac
+if [ "$ASKED" -ge "$MAX_REFUSALS" ]; then
+  echo "chronicle-gate: $ASKED refusals, still no chronicle. Proceeding, and this is the last time it asks." >&2
+  echo "  What happened in this session is now unrecoverable for whoever picks it up next." >&2
   rm -f "$SEEN_MARKER" 2>/dev/null
   exit 0
 fi
-touch "$SEEN_MARKER" 2>/dev/null
+ASKED=$((ASKED + 1))
+echo "$ASKED" > "$SEEN_MARKER" 2>/dev/null
 
 cat >&2 <<EOF
-This session changed source and has no chronicle.
+This session changed source and has no chronicle. (Asked $ASKED of $MAX_REFUSALS.)
 
 Write one small file at _meta/chronicles/$YEAR/$TODAY-<slug>.md covering:
   - what was attempted, and what actually changed
@@ -111,6 +141,11 @@ Write one small file at _meta/chronicles/$YEAR/$TODAY-<slug>.md covering:
 One file per session, rewritten rather than accumulated. Honest beats complete:
 the failures are the part the next session cannot reconstruct on its own.
 
-Skip deliberately with KERNEL_CHRONICLE_OK=1.
+If this session genuinely owed nothing, say so in one line and that also satisfies
+this gate:
+
+  echo 'Nothing owed: <why>' > _meta/chronicles/$YEAR/$TODAY-skipped.md
+
+Size the record to the consequence. A write-up longer than the work is a defect too.
 EOF
 exit 2

--- a/hooks/scripts/detect-secrets.sh
+++ b/hooks/scripts/detect-secrets.sh
@@ -11,7 +11,13 @@
 INPUT=$(cat)
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "BLOCKED: secret scanner cannot run (jq not found). Install jq, or set the secret via an environment variable instead of writing it." >&2
+  echo "BLOCKED: secret scanner cannot run (jq not found), so no write can be checked." >&2
+  if [ "$(uname -s)" = "Darwin" ]; then
+    echo "  Install it:  brew install jq" >&2
+  else
+    echo "  Install it:  apt install jq   (or the equivalent for this distro)" >&2
+  fi
+  echo "  Then retry. Do not work around this by writing the secret elsewhere." >&2
   exit 2
 fi
 
@@ -43,6 +49,10 @@ CONTENT=$(echo "$INPUT" | jq -r '
 
 [ -z "$CONTENT" ] && exit 0
 
+# Named only so the refusal can say WHICH file. Never used for policy: see the
+# note on _looks_deliberately_fake about why path-based exemptions do not work.
+FILE_HINT=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
 # Secret patterns to detect
 PATTERNS=(
   'sk-[a-zA-Z0-9_-]{20,}'                  # OpenAI / Anthropic keys (incl. sk-ant-api03-, sk-proj-; hyphen/underscore allowed)
@@ -62,12 +72,30 @@ PATTERNS=(
   'AccountKey=[a-zA-Z0-9+/=]{40,}'         # Azure storage account keys
 )
 
+# CONSIDERED AND REJECTED 2026-09-01: exempting values that "look fake"
+# (containing example, dummy, 0000...). A usage audit found this gate blocking a
+# test file whose `sk-` fixtures were obviously invented, and the agent worked
+# around it by assembling the string at runtime, leaving a permanently uglier
+# test. The exemption was written, and it immediately failed three of this
+# repo own detection tests: `AKIAIOSFODNN7EXAMPLE` is the canonical AWS example
+# key and contains the word EXAMPLE, `ghp_` fixtures run on 1234567, and so on.
+# The strings that announce themselves as fake are exactly the strings a scanner
+# must still catch, because they are what a real leak looks like to a regex.
+#
+# Weakening a secret scanner so a fixture reads more nicely is a bad trade. The
+# nuisance is real but small; the hole would not be. The message below tells the
+# author what to do instead, which is the part that was actually missing.
 for pattern in "${PATTERNS[@]}"; do
-  if echo "$CONTENT" | grep -qE -- "$pattern"; then
-    echo "BLOCKED: Potential secret detected (pattern: $pattern)" >&2
-    echo "Remove the secret before writing. Use environment variables instead." >&2
-    exit 2
+  if ! printf '%s' "$CONTENT" | grep -qE -- "$pattern"; then
+    continue
   fi
+  echo "BLOCKED: potential secret in ${FILE_HINT:-this write} (pattern: $pattern)" >&2
+  echo "  Remove it and read the value from the environment or the keychain instead." >&2
+  echo "  If it is a TEST FIXTURE: keep it out of the shape a real key has. Shorten it" >&2
+  echo "  below the pattern length, or drop the vendor prefix entirely. Do NOT assemble" >&2
+  echo "  the string at runtime to get past this check: that leaves a worse test and a" >&2
+  echo "  scanner nobody trusts." >&2
+  exit 2
 done
 
 exit 0

--- a/hooks/scripts/guard-bash.sh
+++ b/hooks/scripts/guard-bash.sh
@@ -141,7 +141,7 @@ fi
 # `git commit -m`, `gh issue comment -b`, or `agentdb learn` is data. An argument to
 # `bash -c` or `python3 -c` is code, and those are matched in full, above and below.
 _strip_text_arguments() {
-  printf '%s' "$1" | awk '
+  printf '%s' "$1" | awk -v strip_patterns="${_strip_search_patterns:-1}" '
     {
       line = $0
       # Drop the quoted payload that follows a text-consuming flag, keeping the command
@@ -154,11 +154,32 @@ _strip_text_arguments() {
       # force-delete it was searching for, while writing the report about it.
       # \047 is an apostrophe: this awk program lives inside a single-quoted
       # shell string, so a literal one would end the string.
-      gsub(/(grep|egrep|fgrep|rg|ag|ack)([[:space:]]+-[^[:space:]]+)*[[:space:]]+"[^"]*"/, " <pattern> ", line)
-      gsub(/(grep|egrep|fgrep|rg|ag|ack)([[:space:]]+-[^[:space:]]+)*[[:space:]]+\047[^\047]*\047/, " <pattern> ", line)
+      if (strip_patterns == "1") {
+        gsub(/(grep|egrep|fgrep|rg|ag|ack)([[:space:]]+-[^[:space:]]+)*[[:space:]]+"[^"]*"/, " <pattern> ", line)
+        gsub(/(grep|egrep|fgrep|rg|ag|ack)([[:space:]]+-[^[:space:]]+)*[[:space:]]+\047[^\047]*\047/, " <pattern> ", line)
+      }
       print line
     }'
 }
+# A search pattern is data ONLY while nothing re-executes what the search returns.
+# A command can capture a destructive literal out of a file with `grep -o` and then
+# hand it to eval, and stripping the pattern first left that eval segment with
+# nothing to match. An adversarial pass on 2026-09-01 confirmed main blocked such a
+# command and this branch allowed it: a real regression, caught before merge.
+#
+# So the exemption is withdrawn the moment the command line also contains a
+# primitive that can run captured output. Conservative on purpose: the cost of not
+# stripping is one false positive on an unusual command, and the cost of stripping
+# wrongly is a destructive command running.
+_reexecutes_captured_output() {
+  printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];|&(){}`])(eval|source|xargs)([[:space:]]|$)' && return 0
+  printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];|&(){}])\.[[:space:]]' && return 0
+  printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[[:space:]]+-[ce][[:space:]]*"?\$' && return 0
+  return 1
+}
+_strip_search_patterns=1
+_reexecutes_captured_output && _strip_search_patterns=0
+
 if printf '%s' "$COMMAND" | grep -qE '(git[[:space:]]+(commit|tag)|gh[[:space:]]+[a-z-]+|agentdb[[:space:]]+(learn|contract|verdict|write-end)|(grep|egrep|fgrep|rg|ag|ack)[[:space:]])'; then
   if ! printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[[:space:]]+-[ce]'; then
     COMMAND_CODE=$(_strip_text_arguments "$COMMAND_CODE")

--- a/hooks/scripts/guard-bash.sh
+++ b/hooks/scripts/guard-bash.sh
@@ -161,24 +161,48 @@ _strip_text_arguments() {
       print line
     }'
 }
-# A search pattern is data ONLY while nothing re-executes what the search returns.
-# A command can capture a destructive literal out of a file with `grep -o` and then
-# hand it to eval, and stripping the pattern first left that eval segment with
-# nothing to match. An adversarial pass on 2026-09-01 confirmed main blocked such a
-# command and this branch allowed it: a real regression, caught before merge.
+# A search pattern is data ONLY while the command as a whole cannot carry it
+# anywhere that runs. Two rounds of adversarial review taught the shape of this:
+# the first pass stripped the pattern unconditionally and a grep-then-eval walked
+# through; the second pass enumerated re-execution verbs (eval, source, xargs, a
+# bare dot, -c reading a variable) and EIGHT more routes walked through, among
+# them backticks, $(...) in command position, a here-string, a pipe into `zsh -s`,
+# process substitution, and simply writing the match to a file and running the
+# file by path -- which is not a "re-execution verb" at all, just an ordinary
+# interpreter call on a path nothing can connect back to the grep.
 #
-# So the exemption is withdrawn the moment the command line also contains a
-# primitive that can run captured output. Conservative on purpose: the cost of not
-# stripping is one false positive on an unusual command, and the cost of stripping
-# wrongly is a destructive command running.
-_reexecutes_captured_output() {
-  printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];|&(){}`])(eval|source|xargs)([[:space:]]|$)' && return 0
-  printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];|&(){}])\.[[:space:]]' && return 0
-  printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[[:space:]]+-[ce][[:space:]]*"?\$' && return 0
-  return 1
+# Enumerating dangerous verbs cannot win against shell grammar. So this is
+# inverted: the exemption applies only to a command whose every part is
+# recognisably INERT. Anything unrecognised keeps the literal visible, which is
+# the safe direction. The cost is a false positive on an exotic-but-harmless
+# pipeline; the cost of the other default is a destructive command running.
+#
+# Inert means: no substitution of any kind that could put the match in command
+# position, no redirection that could park it in a file, and every pipeline
+# segment a known read-only consumer.
+_search_output_is_inert() {
+  # Any substitution can place captured text where a command is expected.
+  case "$COMMAND" in
+    *'`'*|*'$('*|*'<('*|*'>'*|*'<<'*) return 1 ;;
+  esac
+  # Every segment must be a search or a known-inert reader. An unrecognised
+  # command word is treated as capable of executing, because it might be.
+  # tr, not sed: BSD sed does not expand \n in a replacement, so `sed 's/[;|]/\n/'`
+  # silently produced ONE segment on macOS and every pipeline looked like its first
+  # command. That is how `grep ... | zsh -s` survived the first version of this
+  # check. tr replaces character-for-character and needs no escape handling.
+  # `|| [ -n "$seg" ]` because the LAST segment has no trailing newline, so a plain
+  # `read` returns non-zero and drops it. That is how `grep ... | zsh -s` survived
+  # a second time: the loop examined `grep`, found it inert, and never saw `zsh`.
+  printf '%s' "$COMMAND" | tr ';|&' '\n\n\n' | while IFS= read -r seg || [ -n "$seg" ]; do
+    seg=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]+//')
+    [ -z "$seg" ] && continue
+    printf '%s' "$seg" | grep -qE '^(grep|egrep|fgrep|rg|ag|ack|head|tail|wc|sort|uniq|cut|nl|column|cat|less|more|tr|comm)([[:space:]]|$)' \
+      || exit 1
+  done
 }
 _strip_search_patterns=1
-_reexecutes_captured_output && _strip_search_patterns=0
+_search_output_is_inert || _strip_search_patterns=0
 
 if printf '%s' "$COMMAND" | grep -qE '(git[[:space:]]+(commit|tag)|gh[[:space:]]+[a-z-]+|agentdb[[:space:]]+(learn|contract|verdict|write-end)|(grep|egrep|fgrep|rg|ag|ack)[[:space:]])'; then
   if ! printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[[:space:]]+-[ce]'; then

--- a/hooks/scripts/guard-bash.sh
+++ b/hooks/scripts/guard-bash.sh
@@ -107,6 +107,23 @@ LOW=$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' 
 # needs case sensitivity and a rule that does not cannot disagree about what is code.
 COMMAND_CODE="$COMMAND"
 
+# (9.8.1) Normalise list-form argv so the keyword matcher can see it. A script that
+# calls subprocess.run(["git","branch","-D","x"]) or execFile("rm",["-rf","/"]) runs
+# exactly the command this guard exists to stop, but the shell string never appears,
+# so every pattern below missed it. Pre-existing hole, found while testing the
+# heredoc fix on 2026-09-01: the body was correctly KEPT as code and then matched
+# against nothing.
+#
+# Only bracketed runs of quoted words are touched, and only in COMMAND_CODE (the
+# matching copy), never in COMMAND itself, which stays exact for hashing and for the
+# approval token.
+if printf '%s' "$COMMAND_CODE" | grep -q '\['; then
+  COMMAND_CODE=$(printf '%s' "$COMMAND_CODE" | sed -E \
+    -e 's/\[[[:space:]]*("[^"]*"|'"'"'[^'"'"']*'"'"')([[:space:]]*,[[:space:]]*("[^"]*"|'"'"'[^'"'"']*'"'"'))*[[:space:]]*\]/ & /g' \
+    -e 's/["'"'"',]/ /g')
+  LOW=$(printf '%s' "$COMMAND_CODE" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
+fi
+
 # Heredoc bodies that are DATA, not code, are dropped before keyword matching. Writing a
 # chronicle that mentions a rewrite tool, or filing an issue that quotes a destructive
 # command, tripped this guard on prose describing the very rules it enforces.
@@ -130,10 +147,19 @@ _strip_text_arguments() {
       # Drop the quoted payload that follows a text-consuming flag, keeping the command
       # itself visible so the guard still sees what is being RUN.
       gsub(/(git[[:space:]]+(commit|tag)[^|;&]*-[a-zA-Z]*m|gh[[:space:]]+[a-z-]+[^|;&]*-[a-zA-Z]*(b|body)|agentdb[[:space:]]+(learn|contract|verdict|write-end)([[:space:]]+[a-z-]+)*)[[:space:]]+"[^"]*"([[:space:]]+"[^"]*")*/, " <text> ", line)
+      # (9.8.1) A SEARCH PATTERN IS DATA. grep and friends never execute their
+      # pattern, so a command that looks for a dangerous string is not a command
+      # that runs one. Confirmed live on 2026-09-01: a grep whose pattern quoted
+      # this hook OWN refusal message was blocked as though it were the
+      # force-delete it was searching for, while writing the report about it.
+      # \047 is an apostrophe: this awk program lives inside a single-quoted
+      # shell string, so a literal one would end the string.
+      gsub(/(grep|egrep|fgrep|rg|ag|ack)([[:space:]]+-[^[:space:]]+)*[[:space:]]+"[^"]*"/, " <pattern> ", line)
+      gsub(/(grep|egrep|fgrep|rg|ag|ack)([[:space:]]+-[^[:space:]]+)*[[:space:]]+\047[^\047]*\047/, " <pattern> ", line)
       print line
     }'
 }
-if printf '%s' "$COMMAND" | grep -qE '(git[[:space:]]+(commit|tag)|gh[[:space:]]+[a-z-]+|agentdb[[:space:]]+(learn|contract|verdict|write-end))'; then
+if printf '%s' "$COMMAND" | grep -qE '(git[[:space:]]+(commit|tag)|gh[[:space:]]+[a-z-]+|agentdb[[:space:]]+(learn|contract|verdict|write-end)|(grep|egrep|fgrep|rg|ag|ack)[[:space:]])'; then
   if ! printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node)[[:space:]]+-[ce]'; then
     COMMAND_CODE=$(_strip_text_arguments "$COMMAND_CODE")
     LOW=$(printf '%s' "$COMMAND_CODE" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
@@ -152,9 +178,29 @@ _heredoc_feeds_executor() {
   # A heredoc body written to a pipe or a file, then executed later in the SAME
   # command by an executor segment (split on |, ;, &&), also feeds an executor.
   # e.g. `cat <<EOF | bash` or `cat <<EOF > s.sh; bash s.sh`.
+  #
+  # (9.8.1) Split by executor KIND, the same distinction the direct-feed branch
+  # above already makes. A shell body is executable by definition: every line is a
+  # command, so a dangerous string in it is a dangerous command. An interpreter
+  # body is not. Python holding a force-delete in a string literal cannot run git
+  # unless it also reaches for subprocess, os.system, or a backtick.
+  #
+  # Without this split the guard blocked `cat > x.py <<'EOF' ... EOF; python3 x.py`
+  # on a script whose only crime was quoting a command it was writing into a
+  # markdown file. That happened three times in one session on 2026-09-01: once
+  # while writing the audit that reported the false positive, and once while
+  # writing THIS fix, whose comment quoted the pattern it was teaching the guard
+  # to ignore. Six earlier instances of the same class are in the 9.5.2 note above.
   if printf '%s' "$COMMAND" | grep -q '<<'; then
-    printf '%s' "$COMMAND" | sed -E 's/\|\||&&|[;|]/\n/g' \
-      | grep -qE '^[[:space:]]*(bash|sh|zsh|ksh|dash|python[0-9.]*|perl|ruby|node|xargs|eval|source|\.)([[:space:]]|$)' && return 0
+    _segments=$(printf '%s' "$COMMAND" | sed -E 's/\|\||&&|[;|]/\n/g')
+    # A shell (or eval/source/xargs) executor: always treat the body as code.
+    printf '%s' "$_segments" \
+      | grep -qE '^[[:space:]]*(bash|sh|zsh|ksh|dash|xargs|eval|source|\.)([[:space:]]|$)' && return 0
+    # An interpreter executor: code only if the body can spawn a process.
+    if printf '%s' "$_segments" \
+      | grep -qE '^[[:space:]]*(python[0-9.]*|perl|ruby|node)([[:space:]]|$)'; then
+      printf '%s' "$COMMAND" | grep -qE 'subprocess|os\.system|os\.popen|os\.exec|shutil\.rmtree|child_process|execSync|spawnSync|spawn\(|exec\(|system\(|Open3|IO\.popen|`[^`]*(rm|git|curl)' && return 0
+    fi
   fi
   return 1
 }
@@ -347,8 +393,26 @@ printf '%s' "$COMMAND" | grep -qE 'mv[[:space:]]+("?/([[:space:]]|$)|~([[:space:
 # in one string meant `rm -rf build && python3 -c "print(1)"` was refused as an indirect
 # recursive delete: two unrelated commands, one of them already explicit and reviewable,
 # which is precisely what this rule exists to prefer.
+# (9.8.1) Take the interpreter ARGUMENT, not the rest of the line. $LOW has had
+# newlines collapsed to spaces, so "everything after the interpreter" swallowed
+# every later command too: `python3 -c "print(1)"` followed on the NEXT LINE by an
+# explicit `rm -rf "$T"` was refused as an indirect recursive delete, which is the
+# exact case the comment above says this rule must not catch. The segment fix was
+# there; it just could not see segments any more once the newlines were gone.
+#
+# The quoted string after -c/-e is the code the interpreter actually runs. If the
+# body is unquoted (rare), fall back to the old tail-of-line read rather than
+# letting something through.
 _after_interpreter=$(printf '%s' "$LOW" | awk '
-  { if (match($0, /(python[0-9.]*|perl|ruby|node)[[:space:]]+(-e|-c)/)) print substr($0, RSTART) }')
+  {
+    if (match($0, /(python[0-9.]*|perl|ruby|node)[[:space:]]+(-e|-c)[[:space:]]*"[^"]*"/)) {
+      print substr($0, RSTART, RLENGTH); next
+    }
+    if (match($0, /(python[0-9.]*|perl|ruby|node)[[:space:]]+(-e|-c)[[:space:]]*\047[^\047]*\047/)) {
+      print substr($0, RSTART, RLENGTH); next
+    }
+    if (match($0, /(python[0-9.]*|perl|ruby|node)[[:space:]]+(-e|-c)/)) print substr($0, RSTART)
+  }')
 if [ -n "$_after_interpreter" ]; then
   printf '%s' "$_after_interpreter" | grep -qE 'rmtree|removedirs|rimraf|rmsync|rmdirsync|fs\.rm|rm[[:space:]]+-[a-z]*r[a-z]*f' \
     && block "interpreter one-liner performing recursive/tree deletion." "Refusing indirect recursive rm via python/perl/node/ruby; do it explicitly so it's reviewable."

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -159,7 +159,7 @@ _compression_already_loaded() {
 _compression_already_loaded() {
   for f in "${CLAUDE_PROJECT_DIR:-$PWD}/CLAUDE.md" "${CLAUDE_PROJECT_DIR:-$PWD}/AGENTS.md" \
            "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" "$HOME/.claude/CLAUDE.md"; do
-    [ -f "$f" ] && grep -q '^## compression' "$f" 2>/dev/null && return 0
+    [ -f "$f" ] && awk '/^```/{f=!f;next} !f && /^## compression/{found=1} END{exit !found}' "$f" 2>/dev/null && return 0
   done
   return 1
 }

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -137,8 +137,34 @@ if [ -n "$HEALTH_WARNINGS" ]; then
   echo ""
 fi
 
+# The compression protocol is ALSO the opening of the CLAUDE.md/AGENTS.md this
+# plugin generates, because both come from one source (governance/kernel.md.tmpl).
+# Where the host already loaded such a file, printing it again is a second copy of
+# a rule the model is holding: a 2026-09-01 audit counted SEVEN copies reaching one
+# session, six from CLAUDE.md files and one from here.
+#
+# So: print it only when nothing else will. A user with no CLAUDE.md still gets the
+# whole thing, which is why the block cannot simply be deleted -- for any repo that
+# is not kernel-claude itself, this hook is the ONLY delivery of kernel doctrine.
+# The audit's own first recommendation was to cut it outright; that would have
+# silently disarmed the plugin everywhere.
+_compression_already_loaded() {
+  for f in "${CLAUDE_PROJECT_DIR:-$PWD}/CLAUDE.md" "${CLAUDE_PROJECT_DIR:-$PWD}/AGENTS.md" \
+           "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" "$HOME/.claude/CLAUDE.md"; do
+    [ -f "$f" ] && grep -q '^## compression' "$f" 2>/dev/null && return 0
+  done
+  return 1
+}
 # BEGIN GENERATED KERNEL AMBIENT
-cat << 'KERNEL_CONTEXT'
+_compression_already_loaded() {
+  for f in "${CLAUDE_PROJECT_DIR:-$PWD}/CLAUDE.md" "${CLAUDE_PROJECT_DIR:-$PWD}/AGENTS.md" \
+           "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" "$HOME/.claude/CLAUDE.md"; do
+    [ -f "$f" ] && grep -q '^## compression' "$f" 2>/dev/null && return 0
+  done
+  return 1
+}
+if ! _compression_already_loaded; then
+cat << 'KERNEL_COMPRESSION'
 ## compression — mandatory
 
 minimum text. zero meaningful loss.
@@ -165,6 +191,9 @@ do not emit while removable text remains.
 verbosity is a defect.
 omission is also a defect.
 
+KERNEL_COMPRESSION
+fi
+cat << 'KERNEL_CONTEXT'
 ## KERNEL quick reference
 
 ```

--- a/hooks/scripts/warn-hardcoded.sh
+++ b/hooks/scripts/warn-hardcoded.sh
@@ -1,6 +1,25 @@
 #!/bin/bash
-# KERNEL: Warn on hardcoded values in component/style files
-# PreToolUse hook — runs before Write/Edit on component files
+# KERNEL: warn when a component bypasses the project's design tokens.
+# PreToolUse hook, advisory only, on Write/Edit of component and style files.
+#
+# REVISED 2026-09-01 after a usage audit: this fired 227 times across the whole
+# transcript corpus (92 hex, 135 px) and not one of them changed what the agent
+# did next. That is the definition of noise, and noise is not free: it trains a
+# reader to skip the line, which is how a real warning gets missed later.
+#
+# The cause was that it matched things every stylesheet legitimately contains.
+# `[0-9]+px` hits a 1px border, a media query breakpoint, a token file DEFINING
+# the spacing scale. A warning that fires on correct code is a warning about
+# nothing. Three changes, all narrowing:
+#
+#   1. Token-definition files are exempt. A file whose job is to declare
+#      `--space-4: 16px` is not bypassing the scale, it IS the scale.
+#   2. px is flagged only on the properties a scale actually governs (padding,
+#      margin, gap, font-size). Borders, outlines, radii, media queries and
+#      1-2px hairlines are left alone: those are where literal px is correct.
+#   3. One line per file, naming the count and the token file to use, instead of
+#      one line per category. A warning with no address is advice nobody can act
+#      on, which is the other half of why the old one changed nothing.
 
 source "$(dirname "$0")/common.sh"
 
@@ -8,18 +27,42 @@ INPUT=$(cat)
 while IFS= read -r RECORD; do
 FILE_PATH=$(printf '%s' "$RECORD" | jq -r '.path // empty' 2>/dev/null)
 CONTENT=$(printf '%s' "$RECORD" | jq -r '.content // empty' 2>/dev/null)
+[ -z "$FILE_PATH" ] && continue
+
 case "$FILE_PATH" in
-  *.tsx|*.jsx|*.svelte|*.vue|*.css)
-    # Check for hardcoded hex colors
-    if echo "$CONTENT" | grep -qE '#[0-9a-fA-F]{3,8}[^-]' 2>/dev/null; then
-      echo "WARN: Hardcoded hex color in $FILE_PATH — use theme tokens instead"
-    fi
-    # Check for hardcoded pixel values (common anti-pattern)
-    if echo "$CONTENT" | grep -qE '[0-9]+px' 2>/dev/null; then
-      echo "WARN: Hardcoded px value in $FILE_PATH — consider using spacing tokens"
-    fi
-    ;;
+  *.tsx|*.jsx|*.svelte|*.vue|*.css) ;;
+  *) continue ;;
 esac
+
+# A file that declares custom properties is the token source, not a consumer.
+case "$FILE_PATH" in
+  *token*|*theme*|*variable*|*global*|*reset*|*.config.*) continue ;;
+esac
+# A DECLARATION is `--name:`; a USE is `var(--name)`. Only the former exempts.
+# Not anchored to line start: `:root { --gap: 8px; }` is one line and still a
+# declaration.
+if printf '%s' "$CONTENT" | grep -qE '(^|[[:space:]{;])--[a-zA-Z0-9-]+[[:space:]]*:' 2>/dev/null; then
+  continue
+fi
+
+HEX=$(printf '%s' "$CONTENT" | grep -oE '#[0-9a-fA-F]{3,8}\b' 2>/dev/null | grep -cv '^$' || true)
+# Only the properties a spacing scale governs. Hairlines (1-2px) are exempt
+# everywhere: a scale does not have a 1px step and should not pretend to.
+PX=$(printf '%s' "$CONTENT" \
+  | grep -oE '(padding|margin|gap|font-size)[a-z-]*:[^;]*[0-9]+px' 2>/dev/null \
+  | grep -vE '\b[12]px' | grep -cv '^$' || true)
+
+[ "${HEX:-0}" -eq 0 ] && [ "${PX:-0}" -eq 0 ] && continue
+
+TOKENS=""
+for candidate in tokens.css theme.css variables.css styles/tokens.css app/styles/tokens.css; do
+  [ -f "${CLAUDE_PROJECT_DIR:-.}/$candidate" ] && { TOKENS="$candidate"; break; }
+done
+
+WHERE="use the project's design tokens"
+[ -n "$TOKENS" ] && WHERE="use the tokens in $TOKENS"
+
+echo "WARN: $FILE_PATH bypasses the scale (${HEX:-0} raw colors, ${PX:-0} spacing px) — $WHERE"
 done < <(kernel_hook_file_records "$INPUT")
 
 exit 0

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@
 > that carries lessons between sessions.
 
 Repository: https://github.com/ariaxhan/kernel-claude
-License: MIT. Version 9.8.0. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
+License: MIT. Version 9.8.1. Requires `git`, `sqlite3`, `jq`, `python3`, `bash`.
 
 ## What it is
 

--- a/scripts/generate-governance.py
+++ b/scripts/generate-governance.py
@@ -152,7 +152,7 @@ def load(root):
     if len(ambient) != 1:
         fail("canonical source must contain exactly one ambient source block")
     ambient_text = ambient[0].rstrip() + "\n"
-    unsafe_lines = {"KERNEL_CONTEXT", SHELL_BEGIN, SHELL_END}
+    unsafe_lines = {"KERNEL_CONTEXT", "KERNEL_COMPRESSION", SHELL_BEGIN, SHELL_END}
     if "\x00" in ambient_text or "\r" in ambient_text or any(
             line in unsafe_lines for line in ambient_text.splitlines()):
         fail("ambient source contains an unsafe heredoc terminator or marker line")
@@ -193,7 +193,44 @@ def render_outputs(root):
     )
     if len(pattern.findall(shell_text)) != 1:
         fail("session-start.sh must contain exactly one generated ambient region")
-    block = f"{SHELL_BEGIN}\ncat << 'KERNEL_CONTEXT'\n{ambient}KERNEL_CONTEXT\n{SHELL_END}"
+    # The compression preamble is ALSO the opening of the generated CLAUDE.md and
+    # AGENTS.md, because both are rendered from this same source. Where the host
+    # already loaded one of those files, printing it again at session start is a
+    # second copy of a rule the model is already holding: a 2026-09-01 usage audit
+    # counted seven copies reaching one session, six from CLAUDE.md files and one
+    # from the hook.
+    #
+    # So the preamble is emitted conditionally and everything after it
+    # unconditionally. The split is not cosmetic: for any repo that is not
+    # kernel-claude itself, this hook is the ONLY delivery of kernel doctrine, and
+    # the operating rules below the preamble appear in no generated file at all.
+    # The audit's first recommendation was to cut the whole block; doing that would
+    # have silently disarmed the plugin everywhere it is installed.
+    marker = "## KERNEL quick reference"
+    if marker in ambient:
+        preamble, rest = ambient.split(marker, 1)
+        rest = marker + rest
+        block = (
+            f"{SHELL_BEGIN}\n"
+            "_compression_already_loaded() {\n"
+            '  for f in "${CLAUDE_PROJECT_DIR:-$PWD}/CLAUDE.md" "${CLAUDE_PROJECT_DIR:-$PWD}/AGENTS.md" \\\n'
+            '           "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" "$HOME/.claude/CLAUDE.md"; do\n'
+            "    [ -f \"$f\" ] && grep -q '^## compression' \"$f\" 2>/dev/null && return 0\n"
+            "  done\n"
+            "  return 1\n"
+            "}\n"
+            "if ! _compression_already_loaded; then\n"
+            "cat << 'KERNEL_COMPRESSION'\n"
+            f"{preamble}"
+            "KERNEL_COMPRESSION\n"
+            "fi\n"
+            "cat << 'KERNEL_CONTEXT'\n"
+            f"{rest}"
+            "KERNEL_CONTEXT\n"
+            f"{SHELL_END}"
+        )
+    else:
+        block = f"{SHELL_BEGIN}\ncat << 'KERNEL_CONTEXT'\n{ambient}KERNEL_CONTEXT\n{SHELL_END}"
     rendered[shell] = pattern.sub(lambda _match: block, shell_text)
     return source_path, rendered
 

--- a/scripts/generate-governance.py
+++ b/scripts/generate-governance.py
@@ -215,7 +215,11 @@ def render_outputs(root):
             "_compression_already_loaded() {\n"
             '  for f in "${CLAUDE_PROJECT_DIR:-$PWD}/CLAUDE.md" "${CLAUDE_PROJECT_DIR:-$PWD}/AGENTS.md" \\\n'
             '           "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" "$HOME/.claude/CLAUDE.md"; do\n'
-            "    [ -f \"$f\" ] && grep -q '^## compression' \"$f\" 2>/dev/null && return 0\n"
+            # A heading inside a fenced block is documentation ABOUT the rule, not
+            # the rule. awk tracks fence state so a file that merely shows the
+            # format does not suppress the real preamble. Flagged by an
+            # adversarial pass 2026-09-01 and cheap enough to just fix.
+            "    [ -f \"$f\" ] && awk '/^```/{f=!f;next} !f && /^## compression/{found=1} END{exit !found}' \"$f\" 2>/dev/null && return 0\n"
             "  done\n"
             "  return 1\n"
             "}\n"

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -13,7 +13,7 @@ kernel:
 <skill id="help">
 
 <purpose>
-Quick reference for KERNEL v9.8.0.
+Quick reference for KERNEL v9.8.1.
 One primitive: skills (methodology, workflows, state transitions, validators,
 operators). Agents, manifests, philosophy, and current plugin status.
 </purpose>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1450,6 +1450,41 @@ test_guard_bash_allows_keychain_password_grant() {
   _gb 'P=$(security find-generic-password -s supabase-password -w) && curl -X POST -H \"apikey: $SUPABASE_ANON_KEY\" -H \"Content-Type: application/json\" --data \"{email:user@example.com,password:$P}\" \"https://project.supabase.co/auth/v1/token?grant_type=password\"'
   assert_exit_code 0 "$?" "keychain password in a Supabase password-grant body must pass"
 }
+# --- 2026-09-01: the search-pattern exemption, and the eleven ways around it ---
+# The exemption exists because guard-bash blocked greps that merely QUOTED a
+# dangerous command, three times in one session. Two rounds of adversarial review
+# then found eleven ways to extract a dangerous literal through a grep pattern and
+# re-execute it. Enumerating re-execution verbs lost twice; the exemption now
+# applies only when the WHOLE command is recognisably inert. These lock that in.
+# The literals are assembled at runtime so this file is not its own tripwire.
+_gb_danger() { printf 'r%s -%sf %s' 'm' 'r' '~'; }
+_gb_forcedel() { printf 'git branch -%s main' 'D'; }
+test_guard_bash_search_exemption_has_no_execution_route() {
+  local d g
+  # single quotes in the probe: _gb embeds "$1" in JSON without escaping, so a
+  # double quote here silently truncates the payload and the guard sees nothing.
+  d=$(_gb_danger); g="grep -o '$d' file.txt"
+  # \140 is a backtick: writing one inside double quotes would make THIS shell
+  # run the substitution while building the test string.
+  _gb "$(printf '\140%s\140' "$g")";               assert_exit_code 2 "$?" "backtick command position" || return 1
+  _gb "\$($g)";                                     assert_exit_code 2 "$?" "command substitution in command position" || return 1
+  _gb "X=\$($g); eval '\$X'";                       assert_exit_code 2 "$?" "grep then eval" || return 1
+  _gb "X=\$($g); sh <<< '\$X'";                     assert_exit_code 2 "$?" "here-string into sh" || return 1
+  _gb "printf '%s' '\$($g)' | bash";               assert_exit_code 2 "$?" "printf piped to bash" || return 1
+  _gb "$g | zsh -s";                               assert_exit_code 2 "$?" "pipe into zsh -s" || return 1
+  _gb "$g | xargs -I{} sh -c '{}'";                assert_exit_code 2 "$?" "grep then xargs" || return 1
+  _gb "$g > /tmp/e.sh; bash /tmp/e.sh";            assert_exit_code 2 "$?" "write then run by path" || return 1
+  _gb "$g > /tmp/e.sh; chmod +x /tmp/e.sh; /tmp/e.sh"; assert_exit_code 2 "$?" "write, chmod, run by path" || return 1
+  _gb "bash <($g)";                                assert_exit_code 2 "$?" "process substitution" || return 1
+  _gb "$g > /tmp/x; source /tmp/x";                assert_exit_code 2 "$?" "grep then source" || return 1
+}
+test_guard_bash_search_exemption_still_allows_plain_search() {
+  _gb "grep -rn '$(_gb_forcedel)' ."
+  assert_exit_code 0 "$?" "a grep whose PATTERN quotes a force-delete is data" || return 1
+  _gb 'grep -rn "TODO" .';               assert_exit_code 0 "$?" "ordinary grep" || return 1
+  _gb 'grep -rn "TODO" . | head -20';    assert_exit_code 0 "$?" "grep piped to an inert reader" || return 1
+  _gb 'grep -c "error" app.log | wc -l'; assert_exit_code 0 "$?" "grep piped to wc" || return 1
+}
 test_guard_bash_allows_string_literal_in_analysis_heredoc() {
   _gb "python3 - <<'PY'\nBD = 'git branch ' + '-D x'\nprint(BD)\nPY"
   assert_exit_code 0 "$?" "a guarded phrase inside a python string literal with no executor is data"
@@ -2237,6 +2272,14 @@ test_critical_guard_scripts_unchanged_for_820() {
   # command could grep a destructive literal out of a file and eval it, and
   # stripping the pattern first left that segment with nothing to match. Main
   # blocked it, the branch allowed it, and the pin moved again to fix it.
+  # A sixth move, and the last of that argument: enumerating re-execution verbs
+  # lost a second time, to eight more routes (backticks, $() in command position,
+  # a here-string, printf into bash, `zsh -s`, write-then-run-by-path with and
+  # without an interpreter word, process substitution). The exemption is now
+  # INVERTED: it applies only when the whole command is recognisably inert -- no
+  # substitution, no redirection, and every pipeline segment a known read-only
+  # reader. All eleven routes and the four legitimate shapes are asserted by
+  # test_guard_bash_search_exemption_*.
   # The detect-secrets pin moved 2026-09-01 for MESSAGING only: the refusal now
   # names the file, says how to install jq when the scanner cannot run, and tells
   # a fixture author to shorten the value rather than assemble it at runtime.
@@ -2249,7 +2292,7 @@ test_critical_guard_scripts_unchanged_for_820() {
     actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
-c3f7b7429864b5fe4221e88413416110574f2b17d39b2b79caf76a26f9a11c0e guard-bash.sh
+350aa13715a3e1faedc8b07ce341a8ad12e3bfd7af33dd73821619b0437d177e guard-bash.sh
 ce20904682f9e53593328cc957c3039e99b7afe5eb9dc9cbea2f6dacbf650191 guard-config.sh
 4860767389e605346ceec60a250493e8fe417cf3ecf4acf10ebd42a33c0ccbfe detect-secrets.sh
 e1c4940def589dce982695d7e79f22e11cb767f6260608a738801f6c4167afbc guard-context.sh
@@ -5928,6 +5971,8 @@ run_test_suite() {
       run_test "guard-bash 9.5.2 still blocks -D on unknown branch" test_guard_bash_still_blocks_D_on_unknown_branch
       run_test "guard-bash 9.5.2 allows keychain auth header" test_guard_bash_allows_keychain_auth_header
       run_test "guard-bash allows Supabase password grant" test_guard_bash_allows_keychain_password_grant
+      run_test "guard-bash search exemption has no execution route" test_guard_bash_search_exemption_has_no_execution_route
+      run_test "guard-bash search exemption still allows plain search" test_guard_bash_search_exemption_still_allows_plain_search
       run_test "guard-bash 9.5.2 allows string literal in analysis heredoc" test_guard_bash_allows_string_literal_in_analysis_heredoc
       run_test "guard-bash 9.5.2 blocks heredoc with subprocess" test_guard_bash_blocks_heredoc_with_subprocess
       run_test "guard-bash blocks unspaced shell heredoc" test_guard_bash_blocks_unspaced_shell_heredoc

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2219,14 +2219,33 @@ test_critical_guard_scripts_unchanged_for_820() {
   # The guard-bash pin moved again 2026-09-01: piped/file-then-exec heredoc
   # bodies (`cat <<EOF | bash`, write-then-exec) are now caught, and quoted
   # heredoc delimiters are treated as data uniformly with unquoted ones.
+  # It moved a second time the same day, after a usage audit found the guard
+  # blocking correct work three times in one session. Two narrowings and one
+  # widening, all reviewed: a file-then-exec heredoc run by an INTERPRETER is
+  # code only if its body can spawn a process (a shell body still always counts);
+  # a search pattern is data, because grep never executes what it looks for; and
+  # list-form argv is normalised before matching, closing a pre-existing hole
+  # where subprocess.run(["git","branch","-D","x"]) matched nothing at all.
+  # A fourth narrowing the same day: the interpreter one-liner rule read the whole
+  # rest of the line, and $LOW has newlines collapsed to spaces, so an explicit
+  # `rm -rf` on a LATER line was attributed to a `python3 -c "print(1)"` earlier in
+  # the command. It now reads the interpreter's quoted argument, which is the code
+  # the interpreter actually runs.
+  # The detect-secrets pin moved 2026-09-01 for MESSAGING only: the refusal now
+  # names the file, says how to install jq when the scanner cannot run, and tells
+  # a fixture author to shorten the value rather than assemble it at runtime.
+  # A "looks deliberately fake" exemption was written and then rejected: it broke
+  # the three detection tests below, because AKIAIOSFODNN7EXAMPLE is the canonical
+  # AWS example key. The strings that announce themselves as fake are exactly the
+  # ones a scanner must still catch.
   local expected actual file
   while read -r expected file; do
     actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
-280d2702a3907a09e04f9a560d71e1b0b676a1b068764e14525ef696aa9ce514 guard-bash.sh
+a3f0b5ae72ed38f9843311de107e4d19bc0de2c6d0b632efcf38cb20034b400c guard-bash.sh
 ce20904682f9e53593328cc957c3039e99b7afe5eb9dc9cbea2f6dacbf650191 guard-config.sh
-c0afdb26d6794934e4e0758cdcd5e03aeb8abbd44a03daf781a7410fbb2e5ea9 detect-secrets.sh
+4860767389e605346ceec60a250493e8fe417cf3ecf4acf10ebd42a33c0ccbfe detect-secrets.sh
 e1c4940def589dce982695d7e79f22e11cb767f6260608a738801f6c4167afbc guard-context.sh
 EOF
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2231,6 +2231,12 @@ test_critical_guard_scripts_unchanged_for_820() {
   # `rm -rf` on a LATER line was attributed to a `python3 -c "print(1)"` earlier in
   # the command. It now reads the interpreter's quoted argument, which is the code
   # the interpreter actually runs.
+  # A fifth move, same day, reversing part of the third: the search-pattern
+  # exemption is withdrawn whenever the command line also holds eval, source,
+  # xargs or an interpreter -c reading a variable. An adversarial pass showed a
+  # command could grep a destructive literal out of a file and eval it, and
+  # stripping the pattern first left that segment with nothing to match. Main
+  # blocked it, the branch allowed it, and the pin moved again to fix it.
   # The detect-secrets pin moved 2026-09-01 for MESSAGING only: the refusal now
   # names the file, says how to install jq when the scanner cannot run, and tells
   # a fixture author to shorten the value rather than assemble it at runtime.
@@ -2243,7 +2249,7 @@ test_critical_guard_scripts_unchanged_for_820() {
     actual=$(shasum -a 256 "$PLUGIN_ROOT/hooks/scripts/$file" | awk '{print $1}')
     assert_equals "$expected" "$actual" "$file must remain unchanged" || return 1
   done <<'EOF'
-a3f0b5ae72ed38f9843311de107e4d19bc0de2c6d0b632efcf38cb20034b400c guard-bash.sh
+c3f7b7429864b5fe4221e88413416110574f2b17d39b2b79caf76a26f9a11c0e guard-bash.sh
 ce20904682f9e53593328cc957c3039e99b7afe5eb9dc9cbea2f6dacbf650191 guard-config.sh
 4860767389e605346ceec60a250493e8fe417cf3ecf4acf10ebd42a33c0ccbfe detect-secrets.sh
 e1c4940def589dce982695d7e79f22e11cb767f6260608a738801f6c4167afbc guard-context.sh


### PR DESCRIPTION
✅ verified · **9.8.1. Every audit recommendation executed. Three were wrong and are reversed here, with the evidence.**

| | |
|---|---|
| Independent verifier | FIXED, merge recommended, after 3 rounds |
| Bypasses found and closed | 11 |
| Full suite | 511 passed, 1 failed (pre-existing, reproduces on main) |
| Tokens saved per session | ~798 (session-start) + ~972 (doctrine dedupe) |

<details>
<summary>The three recommendations that were wrong</summary>

- **"Cut session-start by 60%."** That block is not accidentally duplicating CLAUDE.md; it is the same source rendered twice, and for any repo that is not kernel-claude the hook is the *only* delivery of kernel doctrine. Cutting it would have silently disarmed the plugin everywhere. Implemented as a conditional on the duplicated preamble alone, in the generator rather than its output.
- **"detect-secrets needs a fixtures exemption."** Written, then reverted: it failed three of this repo's own detection tests, because `AKIAIOSFODNN7EXAMPLE` is the canonical AWS example key. The values that announce themselves as fake are exactly what a real leak looks like to a regex.
- **"Delete warn-hardcoded."** Right about the evidence (227 fires, zero behaviour changes), wrong about the remedy: the suite uses it as its canonical content-consuming advisory hook. Made precise instead.
</details>

<details>
<summary>guard-bash: three rounds on one exemption</summary>

The exemption exists because the guard blocked greps that merely *quoted* a dangerous command, three times in one session.

1. Stripped the pattern unconditionally, and a grep-then-`eval` walked through.
2. Enumerated re-execution verbs, and eight more routes walked through: backticks, `$()` in command position, a here-string, `printf | bash`, `zsh -s`, process substitution, write-then-run-by-path.
3. **Inverted to an allowlist**: strip only when the whole command is recognisably inert. Unrecognised means the literal stays visible.

Two shell bugs had been defeating rounds 1 and 2. BSD `sed` does not expand `\n` in a replacement, so the segment split produced one segment on macOS. And `read` drops a final line with no trailing newline, so the last segment was never examined. `grep ... | zsh -s` survived twice on those alone.

All eleven routes plus four legitimate shapes are asserted in the suite, proven to bite by running them against the pre-fix guard in a throwaway copy: 10 of 11 routes it allowed are now blocked.
</details>

<details>
<summary>Also landed</summary>

- `chronicle-gate` refuses 3 times instead of once, accepts a one-line "nothing owed" note, and no longer prints its own bypass. `KERNEL_CHRONICLE_OK=1` had appeared 402 times against 3 real refusals.
- `guard-bash` argv normalisation closes a **pre-existing** hole where a list-form `subprocess.run` matched nothing at all.
- `detect-secrets` names the file and gives the platform's jq command. Detection byte-identical to main, verified.
- `warn-hardcoded` warns once per file; token files, hairlines, radii and media queries exempt.
- `_meta/agentdb/agentdb` derives its root from `$HOME` instead of a hardcoded account path.

Audit: `Vaults/_meta/reports/kernel-audit-2026-09-01/`
</details>
