### PR TITLE
fix: install released Claude runtime

### DIFF
--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Refresh Claude Code's installed KERNEL and prove a fresh process loads it.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+[[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+  echo "Usage: scripts/install-release.sh X.Y.Z" >&2
+  exit 2
+}
+
+command -v claude >/dev/null 2>&1 || { echo "claude CLI not found" >&2; exit 1; }
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CACHE="$CONFIG_DIR/plugins/cache/kernel-marketplace/kernel"
+RUNTIME="$CACHE/$VERSION"
+
+claude plugin marketplace update kernel-marketplace
+claude plugin update kernel@kernel-marketplace --yes
+
+[ -d "$RUNTIME" ] || {
+  echo "Claude cache lacks KERNEL $VERSION: $RUNTIME" >&2
+  exit 1
+}
+KERNEL_CACHE_DIR="$CACHE" "$RUNTIME/scripts/select-runtime.sh" "$RUNTIME"
+
+INSTALLED=$(claude plugin list --json | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+items = data if isinstance(data, list) else data.get("plugins", [])
+for item in items:
+    if item.get("id") == "kernel@kernel-marketplace" or item.get("name") == "kernel":
+        print(item.get("version", ""))
+        break
+')
+[ "$INSTALLED" = "$VERSION" ] || {
+  echo "Claude reports KERNEL ${INSTALLED:-missing}; expected $VERSION" >&2
+  exit 1
+}
+
+DEBUG_LOG=$(mktemp)
+trap 'rm -f "$DEBUG_LOG"' EXIT
+claude --print --max-turns 1 --debug-file "$DEBUG_LOG" "Reply ok" >/dev/null 2>&1 || true
+grep -F "Attempting to load skills from plugin kernel default skillsPath: $RUNTIME/skills" \
+  "$DEBUG_LOG" >/dev/null || {
+  echo "Fresh Claude process did not load KERNEL $VERSION" >&2
+  exit 1
+}
+
+echo "Claude KERNEL $VERSION installed and selected: $RUNTIME"
+echo "Fresh Claude process loaded: $RUNTIME/skills"

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -64,6 +64,11 @@ kernel:
      session exits 127 until it restarts. Name the live sessions in the handoff and say
      they need a restart; never report "upgraded" as if it covered them
      (docs/upgrading.md, 2026-08-27).
+   - After publishing the GitHub release, install it into Claude's own cache and verify a
+     fresh headless Claude process: `scripts/install-release.sh X.Y.Z`. The script updates
+     only Claude's marketplace/cache, atomically advances Claude's `current` selector, and
+     fails unless both the installed manifest and the fresh process report `X.Y.Z`. Codex
+     installation remains a separate operation.
 
 6. **Human pass** *(any user-facing release: app build, deploy, anything a person will touch)*
    - Load `skills/human-pass/SKILL.md` and write the guide for THIS build: literal


### PR DESCRIPTION
Closes #243

Assumptions:
- Release installation targets Claude user scope and leaves every Codex cache unchanged.
- Claude debug initialization is the deterministic fresh-process proof; it identifies the loaded 9.10.1 skill path before any model response.

Verification:
- scripts/install-release.sh 9.10.1 selected ~/.claude/plugins/cache/kernel-marketplace/kernel/9.10.1.
- Claude loaded the 9.10.1 skills from a new headless process.
- Codex plugin inventory SHA remained ebbe3511cc45f5e35dd5e18aecb8eef91f51056477bbdb92767bfaded99dc3bc.
- Existing check: 273 passed, 148 failed. Failures reproduce main-line deletions from 9.10.0, including hook scripts and AgentDB schema assets; this patch changes neither area.