### PR TITLE
fix: persist session identity outside checkouts

### DIFF
--- a/hooks/scripts/common.sh
+++ b/hooks/scripts/common.sh
@@ -202,6 +202,13 @@ kernel_init_agentdb() {
 # Backward-compatible internal name used by existing checks.
 update_current_symlink() { kernel_update_current; }
 
+# Session identity belongs to KERNEL's durable state, not the target checkout.
+kernel_session_id_file() {
+  local vaults="$1" project_root="$2" project_key
+  project_key=$(printf '%s' "$project_root" | shasum -a 256 | awk '{print $1}') || return 1
+  printf '%s\n' "$vaults/_meta/agents/by-project/$project_key/session-id"
+}
+
 # Detect Vaults location - env var takes priority, then checks filesystem
 detect_vaults() {
   # Explicit override always wins (for testing + custom setups)
@@ -344,11 +351,13 @@ _kernel_hook_end() {
   vaults=$(detect_vaults)
   local agentdb
   agentdb=$(get_agentdb "$vaults")
-  # Read session_id from persisted file (written by session-start.sh)
+  # Read session_id from durable KERNEL state (written by session-start.sh).
   local session_id
   local project_root
   project_root=$(get_project_root)
-  session_id=$(cat "$project_root/_meta/.session_id" 2>/dev/null || echo "")
+  local session_id_file
+  session_id_file=$(kernel_session_id_file "$vaults" "$project_root") || session_id_file=""
+  session_id=$(cat "$session_id_file" 2>/dev/null || echo "")
   # Fire-and-forget: never block hook on telemetry
   "$agentdb" emit hook "$hook_name" "$duration_ms" "{\"exit_code\":$exit_code}" "" "$session_id" 2>/dev/null &
 }

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -26,9 +26,12 @@ if [ ! -f "$MEMORY_DIR/MEMORY.md" ]; then
   [ ! -f "$MEMORY_DIR/MEMORY.md" ] && echo "# Memory Index" > "$MEMORY_DIR/MEMORY.md" 2>/dev/null || true
 fi
 
-# Generate session ID and persist for other hooks
+# Generate session ID and persist for other hooks outside the target checkout.
 KERNEL_SESSION_ID="sess-$(date +%Y%m%d%H%M%S)-$$"
-echo "$KERNEL_SESSION_ID" > "$PROJECT_ROOT/_meta/.session_id" 2>/dev/null || true
+AGENTS_DIR="$VAULTS/_meta/agents"
+SESSION_ID_FILE=$(kernel_session_id_file "$VAULTS" "$PROJECT_ROOT")
+mkdir -p "$(dirname "$SESSION_ID_FILE")"
+printf '%s\n' "$KERNEL_SESSION_ID" > "$SESSION_ID_FILE"
 export KERNEL_SESSION_ID
 
 # Generate agent name and persist for other hooks.
@@ -36,7 +39,6 @@ export KERNEL_SESSION_ID
 # race under concurrent sessions, any parallel SessionStart overwrites it and any
 # SessionEnd deletes it, which is how ~43% of commits ended up tagged "unknown-*".
 AGENT_NAME="main-$$"
-AGENTS_DIR="$VAULTS/_meta/agents"
 mkdir -p "$AGENTS_DIR/by-session"
 if [ ! -t 0 ]; then
     CLAUDE_SESSION_ID=$(cat 2>/dev/null | jq -r '.session_id // empty' 2>/dev/null || true)

--- a/hooks/scripts/session-start.sh
+++ b/hooks/scripts/session-start.sh
@@ -91,15 +91,6 @@ cd "$PROJECT_ROOT" 2>/dev/null || true
 if git rev-parse --git-dir >/dev/null 2>&1; then
   BRANCH=$(git branch --show-current 2>/dev/null)
   echo "**Branch:** $BRANCH"
-  # Where this session started, so session-end can post a receipt naming exactly
-  # what landed against which issue. Without this the receipt call is unreachable.
-  _KERNEL_RUNTIME_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}/_meta/.runtime"
-  # `|| true` is load-bearing: a repo with no commits has no HEAD, and under
-  # `set -eo pipefail` this line's failure killed the entire SessionStart hook
-  # with exit 128. A fresh repo got no context injection at all, which is
-  # exactly the session that needs it most.
-  mkdir -p "$_KERNEL_RUNTIME_DIR" 2>/dev/null && \
-    { git rev-parse HEAD > "$_KERNEL_RUNTIME_DIR/session-start-sha" 2>/dev/null || true; }
   CHANGES=$(git status --porcelain --ignore-submodules=dirty 2>/dev/null | wc -l | tr -d ' ')
   if [ "$CHANGES" -gt 0 ]; then
     echo "**Uncommitted:** $CHANGES file(s) on branch $BRANCH"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -505,6 +505,21 @@ test_session_start_outputs_kernel() {
   assert_contains "$output" "agentdb"
 }
 
+test_session_start_keeps_identity_outside_target() {
+  local target="$TEST_DIR/disposable" vaults="$TEST_DIR/vaults" stderr_file="$TEST_DIR/stderr" rc=0 session_file
+  mkdir -p "$target" "$vaults"
+
+  (cd "$target" && CLAUDE_PROJECT_DIR="$target" KERNEL_VAULTS="$vaults" \
+    "$PLUGIN_ROOT/hooks/scripts/session-start.sh" </dev/null >/dev/null 2>"$stderr_file") || rc=$?
+
+  assert_equals "0" "$rc" "session-start exit" || return 1
+  assert_equals "" "$(cat "$stderr_file")" "session-start stderr" || return 1
+  [ ! -e "$target/_meta" ] || { echo "  FAIL: target checkout received runtime state"; return 1; }
+  source "$PLUGIN_ROOT/hooks/scripts/common.sh"
+  session_file=$(kernel_session_id_file "$vaults" "$target") || return 1
+  assert_file_exists "$session_file" "session identity should live in durable KERNEL state"
+}
+
 test_session_start_creates_agent_file() {
   # Hook writes to VAULTS/_meta/agents (detected via common.sh)
   # In test env, we set KERNEL_VAULTS to test project
@@ -5412,6 +5427,7 @@ run_test_suite() {
     hooks)
       run_test "lifecycle hooks survive a repo with no commits" test_lifecycle_hooks_survive_a_repo_with_no_commits
       run_test "session-start outputs KERNEL" test_session_start_outputs_kernel
+      run_test "session-start keeps identity outside target" test_session_start_keeps_identity_outside_target
       run_test "session-start creates agent file" test_session_start_creates_agent_file
       run_test "detect-secrets clean file" test_detect_secrets_clean
       run_test "hooks.json has SessionStart" test_hooks_json_has_session_start

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -508,6 +508,7 @@ test_session_start_outputs_kernel() {
 test_session_start_keeps_identity_outside_target() {
   local target="$TEST_DIR/disposable" vaults="$TEST_DIR/vaults" stderr_file="$TEST_DIR/stderr" rc=0 session_file
   mkdir -p "$target" "$vaults"
+  git -C "$target" init -q
 
   (cd "$target" && CLAUDE_PROJECT_DIR="$target" KERNEL_VAULTS="$vaults" \
     "$PLUGIN_ROOT/hooks/scripts/session-start.sh" </dev/null >/dev/null 2>"$stderr_file") || rc=$?


### PR DESCRIPTION
Closes #242

Session identity now lives under shared KERNEL state, keyed by a SHA-256 of the target path. SessionStart no longer creates runtime state in target repositories.

Verification:
- Regression passes: SessionStart exits zero, emits no stderr, persists identity externally, and leaves a disposable git repository without `_meta/`.
- Existing full check: 269 passed, 153 failed. Failures are outside this diff and trace to retired files plus the local sqlite `.read` incompatibility.